### PR TITLE
First run through of documentation to deploy

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -17,12 +17,10 @@ for more information on getting set up correctly) and you will need your CLI to 
 * [Maven](https://maven.apache.org/): Tested with 3.8.6.
 * [NodeJS / NPM](https://github.com/nvm-sh/nvm#installing-and-updating)
 
-First run (note this command cannot be run from the `sleeper` directory directly as the Java CDK classes are not yet compiled into the JAR named in `cdk.json`):
-
-```sh
-mkdir tmp
-pushd tmp && cdk bootstrap aws://ACCOUNT-NUMBER/REGION && popd
-```
+If CDK has not previously been bootstrapped in this account, then it needs bootstrapping. The `cdk bootstrap ...` command
+cannot be run from the `sleeper` directory directly as the Java CDK classes are not yet compiled into the JAR named in 
+`cdk.json`.  See [this link](https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html) for guidance on how to 
+bootstrap CDK in your account.
 
 To run the system test, set the environment variable ID to be a globally unique string. This is the instance id. It will
 be used as part of the name of various AWS resources, such as an S3 bucket, lambdas, etc., and therefore should conform to

--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -6,14 +6,23 @@ a Sleeper instance with a simple schema, and writes some random data into a tabl
 scripts to see how much data is in the system, run some example queries, and view logs to help understand what the system is
 doing. It is best to do this from an EC2 instance as a significant amount of code needs to be uploaded to AWS.
 
-Before running this demo functionality, you will need the following intalled (see the [deployment guide](02-deployment-guide)
+Before running this demo functionality, you will need the following intalled (see the [deployment guide](02-deployment-guide.md)
 for more information on getting set up correctly) and you will need your CLI to be logged into your AWS account:
 
-- Maven
-- The AWS CLI
-- CDK
-- Docker
-- Java
+* [AWS CDK](https://docs.aws.amazon.com/cdk/latest/guide/cli.html)
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html): v2
+* [Bash](https://www.gnu.org/software/bash/): At least version 4: use `bash --version`.  The default version on a Mac is 3.2, which is too old.
+* [Docker](https://docs.docker.com/get-docker/)
+* [Java 8](https://openjdk.java.net/install/)
+* [Maven](https://maven.apache.org/): Tested with 3.8.6.
+* [NodeJS / NPM](https://github.com/nvm-sh/nvm#installing-and-updating)
+
+First run (note this command cannot be run from the `sleeper` directory directly as the Java CDK classes are not yet compiled into the JAR named in `cdk.json`):
+
+```sh
+mkdir tmp
+pushd tmp && cdk bootstrap aws://ACCOUNT-NUMBER/REGION && popd
+```
 
 To run the system test, set the environment variable ID to be a globally unique string. This is the instance id. It will
 be used as part of the name of various AWS resources, such as an S3 bucket, lambdas, etc., and therefore should conform to
@@ -23,7 +32,12 @@ deployed within each service (go to the service in the AWS console and type the 
 
 Create an environment variable called VPC which is the id of the VPC you want to deploy Sleeper to, and create an
 environment variable called SUBNET with the id of the subnet you wish to deploy Sleeper to (note that this is only relevant
-to the ephemeral parts of Sleeper - all of the main components use services which naturally span availability zones). Then run:
+to the ephemeral parts of Sleeper - all of the main components use services which naturally span availability zones). 
+
+The VPC _must_ have an S3 Gateway endpoint associated with it otherwise the `cdk deploy` step will fail.
+
+Then run:
+
 ```bash
 ./scripts/test/buildDeployTest.sh ${ID} ${VPC} ${SUBNET}
 ```

--- a/docs/02-deployment-guide.md
+++ b/docs/02-deployment-guide.md
@@ -165,7 +165,7 @@ docker push ${REPO_PREFIX}/bulk-import-runner:${VERSION}
 cd ..
 ```
 
-#### Upload the bars to a bucket
+#### Upload the jars to a bucket
 We need to upload jars to a S3 bucket so that they can be used by various resources. The code
 below assumes you start in the project root directory.
 

--- a/scripts/deploy/buildAndDeploy.sh
+++ b/scripts/deploy/buildAndDeploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy/pre-deployment.sh
+++ b/scripts/deploy/pre-deployment.sh
@@ -106,7 +106,7 @@ sed \
 	-e "s|^sleeper.subnet=.*|sleeper.subnet=${SUBNET}|" \
 	-e "s|^sleeper.tags.file=.*|sleeper.tags.file=${TAGS}|" \
 	-e "s|^sleeper.table.properties=.*|sleeper.table.properties=${TABLE_PROPERTIES}|" \
-	-i'.bu' ${INSTANCE_PROPERTIES}
+	-i "" ${INSTANCE_PROPERTIES}
 
 ###################################
 # Build and publish Docker images #

--- a/scripts/deploy/pre-deployment.sh
+++ b/scripts/deploy/pre-deployment.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,7 +106,7 @@ sed \
 	-e "s|^sleeper.subnet=.*|sleeper.subnet=${SUBNET}|" \
 	-e "s|^sleeper.tags.file=.*|sleeper.tags.file=${TAGS}|" \
 	-e "s|^sleeper.table.properties=.*|sleeper.table.properties=${TABLE_PROPERTIES}|" \
-	-i ${INSTANCE_PROPERTIES}
+	-i'.bu' ${INSTANCE_PROPERTIES}
 
 ###################################
 # Build and publish Docker images #

--- a/scripts/deploy/removeUploads.sh
+++ b/scripts/deploy/removeUploads.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy/tearDown.sh
+++ b/scripts/deploy/tearDown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy/uploadDockerImages.sh
+++ b/scripts/deploy/uploadDockerImages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/deploy/uploadJars.sh
+++ b/scripts/deploy/uploadJars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/test/buildDeployTest.sh
+++ b/scripts/test/buildDeployTest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 Crown Copyright
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,13 +51,12 @@ INSTANCE_PROPERTIES=${GENERATED_DIR}/instance.properties
 mkdir -p ${GENERATED_DIR}
 
 echo "Creating System Test Specific Instance Properties Template"
-cp ${THIS_DIR}/system-test-instance.properties ${INSTANCE_PROPERTIES}
 sed \
   -e "s|^sleeper.systemtest.repo=.*|sleeper.systemtest.repo=${INSTANCE_ID}/system-test|" \
   -e "s|^sleeper.optional.stacks=.*|sleeper.optional.stacks=CompactionStack,GarbageCollectorStack,PartitionSplittingStack,QueryStack,SystemTestStack,IngestStack,EmrBulkImportStack|" \
   -e "s|^sleeper.retain.infra.after.destroy=.*|sleeper.retain.infra.after.destroy=false|" \
   -e "s|^sleeper.bulk.import.emr.bucket.create=.*|sleeper.bulk.import.emr.bucket.create=false|" \
-	-i ${GENERATED_DIR}/instance.properties
+  ${THIS_DIR}/system-test-instance.properties > ${INSTANCE_PROPERTIES}
 
 echo "THIS_DIR: ${THIS_DIR}"
 echo "PROJECT_ROOT: ${PROJECT_ROOT}"


### PR DESCRIPTION
First run through of code and small documentation tweaks.

## General

* Small fixes (`/usr/bin/env`, avoid use of `sed -i` where possible or give temp file extension and document versions of tools required) to run on MacOS

## 01-getting-started

* Fix broken link to 02-deployment-guide
* Add note on bash version (MacOS comes with v3 and `declare -A` needs v4
* Add note on `cdk bootstrap`.  Although instructions are in 02-deployment-guide, I hadn't read that yet
* Add note on needed S3 VPC - stopped `cdk deploy` from working on my first attempt.

## 02-deployment-guide

* Fix typo
