### PR TITLE
whitespace breaks sed command

### DIFF
--- a/scripts/deploy/pre-deployment.sh
+++ b/scripts/deploy/pre-deployment.sh
@@ -106,7 +106,7 @@ sed \
 	-e "s|^sleeper.subnet=.*|sleeper.subnet=${SUBNET}|" \
 	-e "s|^sleeper.tags.file=.*|sleeper.tags.file=${TAGS}|" \
 	-e "s|^sleeper.table.properties=.*|sleeper.table.properties=${TABLE_PROPERTIES}|" \
-	-i "" ${INSTANCE_PROPERTIES}
+	-i"" ${INSTANCE_PROPERTIES}
 
 ###################################
 # Build and publish Docker images #

--- a/scripts/dev/updateVersionNumber.sh
+++ b/scripts/dev/updateVersionNumber.sh
@@ -33,16 +33,16 @@ popd
 
 # Update the version number in the Python module
 sed \
-  -i "" \
+  -i"" \
   -e "s|^    version=.*|    version='${NEW_VERSION}',|" \
   python/setup.py
 
 # Update the version numbers in the example property files
 sed \
-  -i "" \
+  -i"" \
   -e "s|^sleeper.version=.*|sleeper.version=${NEW_VERSION}|"\
   example/basic/instance.properties
 sed \
-  -i "" \
+  -i"" \
   -e "s|^sleeper.version=.*|sleeper.version=${NEW_VERSION}|"\
   example/full/instance.properties


### PR DESCRIPTION
Apologies, the whitespace in the sed command `-i ""` broke the pre-deploy.sh script.  The pull request fixes that issue.

```
JAR_DIR:/home/ec2-user/environment/sleeper/scripts/jars
VERSION:0.11.1-SNAPSHOT
Generating properties
sed: can't read : No such file or directory
```