### PR TITLE
Remove declare -A from bash scripts

### DIFF
--- a/scripts/deploy/removeUploads.sh
+++ b/scripts/deploy/removeUploads.sh
@@ -32,16 +32,17 @@ STACKS=`grep sleeper.optional.stacks ${PROPERTIES} | cut -d'=' -f2`
 STACKS=$(echo ${STACKS//,/ })
 echo "Stacks:${STACKS}"
 
-declare -A LOOKUP
-LOOKUP=( \
-["CompactionStack"]="sleeper.compaction.repo=" \
-["IngestStack"]="sleeper.ingest.repo=" \
-["SystemTestStack"]="sleeper.systemtest.repo=" \
-["EksBulkImportStack"]="sleeper.bulk.import.eks.repo=")
+Properties_CompactionStack="sleeper.compaction.repo="
+Properties_IngestStack="sleeper.ingest.repo="
+Properties_SystemTestStack="sleeper.systemtest.repo="
+Properties_EksBulkImportStack="sleeper.bulk.import.eks.repo="
 
 echo "Removing ECR images"
 for stack in ${STACKS}; do
-    PROPERTY=${LOOKUP[${stack}]}
+
+    Key=Properties_${stack}
+    PROPERTY=${!Key}
+
     if [[ ! -z "${PROPERTY}" ]]; then
       REPO="$(grep "${PROPERTY}" ${PROPERTIES} | sed -e "s/\(.*=\)\(.*\)/\2/")"
       echo ${REPO}

--- a/scripts/deploy/uploadDockerImages.sh
+++ b/scripts/deploy/uploadDockerImages.sh
@@ -43,12 +43,10 @@ echo "BASE_DOCKERFILE_DIR: ${BASE_DOCKERFILE_DIR}"
 echo "REPO_PREFIX: ${REPO_PREFIX}"
 echo "VERSION: ${VERSION}"
 
-declare -A LOOKUP
-LOOKUP=( \
-["CompactionStack"]="compaction-job-execution" \
-["IngestStack"]="ingest" \
-["SystemTestStack"]="system-test" \
-["EksBulkImportStack"]="bulk-import-runner")
+Stacks_CompactionStack="compaction-job-execution"
+Stacks_IngestStack="ingest"
+Stacks_SystemTestStack="system-test"
+Stacks_EksBulkImportStack="bulk-import-runner"
 
 echo "Beginning docker build and push of images for the following stacks: ${STACKS}"
 
@@ -56,7 +54,9 @@ aws ecr get-login-password --region ${REGION} | docker login --username AWS --pa
 
 for stack in ${STACKS}; do
 
-    DIR=${LOOKUP[${stack}]}
+    Key=Stacks_${stack}
+    DIR=${!Key}
+    
     if [[ ! -z "${DIR}" ]]; then
   	  echo "Building Stack: $stack"
   	  pushd ${BASE_DOCKERFILE_DIR}/${DIR}


### PR DESCRIPTION
Removing `declare -A` which requires bash v4 or later, as per #36.

Instead this potential solution uses an "array" (a shared common prefix on a number of variables).  e.g.

```bash
Stacks_CompactionStack="compaction-job-execution"
Stacks_IngestStack="ingest"
Stacks_SystemTestStack="system-test"
Stacks_EksBulkImportStack="bulk-import-runner"
```

Tested on MacOS with GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin21).