### PR TITLE
Issue 107 - Use JsonUnit for AssertJ-style JSON assertions

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -81,6 +81,10 @@ AssertJ (org.assertj:assertj-core:3.23.1):
 
 - Apache License, Version 2.0
 
+JsonUnit (net.javacrumbs.json-unit:json-unit-assertj:2.22.1):
+
+- Apache License, Version 2.0
+
 SLF4J (org.slf4j:slf4j-api:1.7.36, org.slf4j:slf4j-reload4j:1.7.36):
 
 - MIT License

--- a/java/bulk-import/bulk-import-common/pom.xml
+++ b/java/bulk-import/bulk-import-common/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>bulk-import</artifactId>
         <groupId>sleeper</groupId>
@@ -30,6 +31,11 @@
             <groupId>sleeper</groupId>
             <artifactId>configuration</artifactId>
             <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/java/bulk-import/bulk-import-common/src/test/java/sleeper/bulkimport/job/BulkImportJobSerDeTest.java
+++ b/java/bulk-import/bulk-import-common/src/test/java/sleeper/bulkimport/job/BulkImportJobSerDeTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BulkImportJobSerDeTest {
@@ -49,15 +50,15 @@ public class BulkImportJobSerDeTest {
                 .build();
 
         // When
-        BulkImportJob bulkImportJob = new BulkImportJobSerDe().fromJson(
+        BulkImportJob bulkImportJob = new BulkImportJobSerDe().fromJson("" +
                 "{" +
-                        "   \"id\": \"myJob\"," +
-                        "   \"className\": \"com.example.MyClass\"," +
-                        "   \"files\": [ \"a/b/c.parquet\" ]," +
-                        "   \"sparkConf\": {" +
-                        "       \"key\": \"value\"" +
-                        "   }" +
-                        "}");
+                "   \"id\": \"myJob\"," +
+                "   \"className\": \"com.example.MyClass\"," +
+                "   \"files\": [ \"a/b/c.parquet\" ]," +
+                "   \"sparkConf\": {" +
+                "       \"key\": \"value\"" +
+                "   }" +
+                "}");
 
         // Then
         assertThat(bulkImportJob).isEqualTo(expected);
@@ -91,16 +92,15 @@ public class BulkImportJobSerDeTest {
         String serialised = new BulkImportJobSerDe().toJson(fullJob);
 
         // Then
-        String expected =
+        assertThatJson(serialised).isEqualTo("" +
                 "{" +
-                        "\"className\":\"com.example.MyClass\"," +
-                        "\"files\":[\"a/b/c.parquet\"]," +
-                        "\"id\":\"myJob\"," +
-                        "\"sparkConf\":{" +
-                        "\"key\":\"value\"" +
-                        "}" +
-                        "}";
-        assertThat(serialised).isEqualTo(expected);
+                "    \"className\":\"com.example.MyClass\"," +
+                "    \"files\":[\"a/b/c.parquet\"]," +
+                "    \"id\":\"myJob\"," +
+                "    \"sparkConf\":{" +
+                "        \"key\":\"value\"" +
+                "    }" +
+                "}");
     }
 
     @Test

--- a/java/bulk-import/bulk-import-starter/pom.xml
+++ b/java/bulk-import/bulk-import-starter/pom.xml
@@ -14,7 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>sleeper</groupId>
         <artifactId>bulk-import</artifactId>
@@ -72,6 +73,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -80,6 +80,7 @@
         <testcontainers.version>1.16.2</testcontainers.version>
         <wiremock.version>2.32.0</wiremock.version>
         <assertj.version>3.23.1</assertj.version>
+        <jsonunit.version>2.22.1</jsonunit.version>
         <!-- Maven plugins -->
         <release.plugin.version>3.0.0-M4</release.plugin.version>
         <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
@@ -120,7 +121,7 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
-            <!-- GSON -->
+            <!-- JSON -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
@@ -173,6 +174,12 @@
                 <version>${assertj.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>net.javacrumbs.json-unit</groupId>
+                <artifactId>json-unit-assertj</artifactId>
+                <version>${jsonunit.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -184,6 +191,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -121,7 +121,7 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
             </dependency>
-            <!-- JSON -->
+            <!-- GSON -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>


### PR DESCRIPTION
**Note that this PR is stacked on top of #120, please merge that one first**

JsonUnit is a library for AssertJ-style assertions on JSON. It parses the JSON, does detailed comparison, and outputs a diff when assertions fail. It lets you use whitespace in exact comparisons even if the actual value doesn't have whitespace.

This adds this as a dependency and migrates existing assertions on JSON to use the library.