### PR TITLE
Issue 153 - Enforce AssertJ usage in tests

### DIFF
--- a/code-style/checkstyle.xml
+++ b/code-style/checkstyle.xml
@@ -182,6 +182,9 @@
         <module name="UpperEll">
             <property name="id" value="upperEll"/>
         </module>
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.junit.Assert"/>
+        </module>
     </module>
     <module name="UniqueProperties">
         <property name="id" value="uniqueProperties"/>

--- a/java/athena/src/test/java/sleeper/athena/metadata/IteratorApplyingMetadataHandlerIT.java
+++ b/java/athena/src/test/java/sleeper/athena/metadata/IteratorApplyingMetadataHandlerIT.java
@@ -59,7 +59,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static sleeper.athena.metadata.IteratorApplyingMetadataHandler.MAX_ROW_KEY_PREFIX;
 import static sleeper.athena.metadata.IteratorApplyingMetadataHandler.MIN_ROW_KEY_PREFIX;

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/ExecutorFactoryIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/ExecutorFactoryIT.java
@@ -32,7 +32,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static sleeper.configuration.properties.SystemDefinedInstanceProperty.CONFIG_BUCKET;
 
@@ -121,10 +121,10 @@ public class ExecutorFactoryIT {
         setEnvironmentVariable("BULK_IMPORT_PLATFORM", "ZZZ");
 
         // When then
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThatThrownBy(() -> {
             ExecutorFactory executorFactory = new ExecutorFactory(s3Client, mock(AmazonElasticMapReduceClient.class), mock(AWSStepFunctionsClient.class));
             executorFactory.createExecutor();
-        });
+        }).isInstanceOf(IllegalArgumentException.class);
 
         s3Client.shutdown();
     }

--- a/java/clients/src/test/java/sleeper/status/update/ReinitialiseTableIT.java
+++ b/java/clients/src/test/java/sleeper/status/update/ReinitialiseTableIT.java
@@ -74,7 +74,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.configuration.properties.SystemDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.UserDefinedInstanceProperty.ACCOUNT;
 import static sleeper.configuration.properties.UserDefinedInstanceProperty.FILE_SYSTEM;
@@ -152,16 +152,18 @@ public class ReinitialiseTableIT {
         String tableName = UUID.randomUUID().toString();
 
         // When
-        assertThrows(IllegalArgumentException.class, () -> new ReinitialiseTable(s3Client,
+        assertThatThrownBy(() -> new ReinitialiseTable(s3Client,
                 dynamoDBClient, "", tableName, false,
-                null, false));
+                null, false))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void shouldThrowExceptionIfTableIsEmpty() {
-        assertThrows(IllegalArgumentException.class, () -> new ReinitialiseTable(s3Client,
+        assertThatThrownBy(() -> new ReinitialiseTable(s3Client,
                 dynamoDBClient, CONFIG_BUCKET_NAME, "", false,
-                null, false));
+                null, false))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/java/tables/src/test/java/sleeper/table/job/TableInitialiserIT.java
+++ b/java/tables/src/test/java/sleeper/table/job/TableInitialiserIT.java
@@ -49,7 +49,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static sleeper.configuration.properties.SystemDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.UserDefinedInstanceProperty.ID;
 import static sleeper.configuration.properties.table.TableProperty.SPLIT_POINTS_BASE64_ENCODED;


### PR DESCRIPTION
Blocks usage of `org.junit.Assert` in tests in the checkstyle

Resolves #153 