### PR TITLE
Issue 264 - Fix compaction job queries with multiple runs

### DIFF
--- a/java/compaction-core/src/main/java/sleeper/compaction/job/status/CompactionJobRun.java
+++ b/java/compaction-core/src/main/java/sleeper/compaction/job/status/CompactionJobRun.java
@@ -89,6 +89,14 @@ public class CompactionJobRun {
         }
     }
 
+    public Instant getLatestUpdateTime() {
+        if (isFinished()) {
+            return getFinishedStatus().getUpdateTime();
+        } else {
+            return getStartUpdateTime();
+        }
+    }
+
     public CompactionJobSummary getFinishedSummary() {
         if (isFinished()) {
             return getFinishedStatus().getSummary();

--- a/java/compaction-core/src/main/java/sleeper/compaction/job/status/CompactionJobStatus.java
+++ b/java/compaction-core/src/main/java/sleeper/compaction/job/status/CompactionJobStatus.java
@@ -84,11 +84,8 @@ public class CompactionJobStatus {
         return jobId;
     }
 
-    public String getTaskId() {
-        if (isStarted()) {
-            return getLatestJobRun().getTaskId();
-        }
-        return null;
+    public boolean isTaskIdAssigned(String taskId) {
+        return jobRunList.stream().anyMatch(run -> run.getTaskId().equals(taskId));
     }
 
     public boolean isInPeriod(Instant startTime, Instant endTime) {

--- a/java/compaction-core/src/main/java/sleeper/compaction/job/status/CompactionJobStatus.java
+++ b/java/compaction-core/src/main/java/sleeper/compaction/job/status/CompactionJobStatus.java
@@ -101,28 +101,10 @@ public class CompactionJobStatus {
     }
 
     private Instant lastTime() {
-        if (isFinished()) {
-            return getLatestFinishedStatus().getUpdateTime();
-        } else if (isStarted()) {
-            return getLatestStartedStatus().getUpdateTime();
-        } else {
+        if (jobRunList.isEmpty()) {
             return createdStatus.getUpdateTime();
         }
-    }
-
-    private CompactionJobStartedStatus getLatestStartedStatus() {
-        return jobRunList.stream()
-                .map(CompactionJobRun::getStartedStatus)
-                .findFirst()
-                .orElse(null);
-    }
-
-    private CompactionJobFinishedStatus getLatestFinishedStatus() {
-        return jobRunList.stream()
-                .filter(CompactionJobRun::isFinished)
-                .map(CompactionJobRun::getFinishedStatus)
-                .findFirst()
-                .orElse(null);
+        return getLatestJobRun().getLatestUpdateTime();
     }
 
     private CompactionJobRun getLatestJobRun() {

--- a/java/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusTaskIdAssignedTest.java
+++ b/java/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusTaskIdAssignedTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.compaction.job;
+
+import org.junit.Test;
+import sleeper.compaction.job.status.CompactionJobCreatedStatus;
+import sleeper.compaction.job.status.CompactionJobRun;
+import sleeper.compaction.job.status.CompactionJobStartedStatus;
+import sleeper.compaction.job.status.CompactionJobStatus;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CompactionJobStatusTaskIdAssignedTest {
+
+    private final CompactionJob job = new CompactionJobTestDataHelper().singleFileCompaction();
+
+    @Test
+    public void shouldHaveTaskWhenOneRunHasTask() {
+        // Given
+        CompactionJobStatus status = statusBuilder()
+                .jobRunsLatestFirst(runsWithTaskIds(
+                        "task-id-1", "test-task-id", "task-id-3"))
+                .build();
+
+        // When / Then
+        assertThat(status.isTaskIdAssigned("test-task-id")).isTrue();
+    }
+
+    @Test
+    public void shouldNotHaveTaskWhenNoRunHasTask() {
+        // Given
+        CompactionJobStatus status = statusBuilder()
+                .jobRunsLatestFirst(runsWithTaskIds(
+                        "task-id-1", "task-id-1", "task-id-3"))
+                .build();
+
+        // When / Then
+        assertThat(status.isTaskIdAssigned("test-task-id")).isFalse();
+    }
+
+    @Test
+    public void shouldNotHaveTaskWhenNoRunsSet() {
+        // Given
+        CompactionJobStatus status = statusBuilder()
+                .jobRunsLatestFirst(Collections.emptyList())
+                .build();
+
+        // When / Then
+        assertThat(status.isTaskIdAssigned("test-task-id")).isFalse();
+    }
+
+    private CompactionJobStatus.Builder statusBuilder() {
+        return CompactionJobStatus.builder().jobId(job.getId())
+                .createdStatus(CompactionJobCreatedStatus.from(job,
+                        Instant.parse("2022-10-12T11:29:00.000Z")));
+    }
+
+    private static List<CompactionJobRun> runsWithTaskIds(String... taskIds) {
+        return Stream.of(taskIds)
+                .map(CompactionJobStatusTaskIdAssignedTest::runWithTaskId)
+                .collect(Collectors.toList());
+    }
+
+    private static CompactionJobRun runWithTaskId(String taskId) {
+        return CompactionJobRun.started(taskId,
+                CompactionJobStartedStatus.updateAndStartTime(Instant.now(), Instant.now()));
+    }
+}

--- a/java/compaction-status-store/src/main/java/sleeper/compaction/status/job/DynamoDBCompactionJobStatusStore.java
+++ b/java/compaction-status-store/src/main/java/sleeper/compaction/status/job/DynamoDBCompactionJobStatusStore.java
@@ -133,7 +133,7 @@ public class DynamoDBCompactionJobStatusStore implements CompactionJobStatusStor
     public List<CompactionJobStatus> getJobsByTaskId(String tableName, String taskId) {
         ScanResult result = dynamoDB.scan(createScanRequestByTable(tableName));
         return DynamoDBCompactionJobStatusFormat.streamJobStatuses(result.getItems())
-                .filter(job -> job.getTaskId().equals(taskId))
+                .filter(job -> job.isTaskIdAssigned(taskId))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
The issue with unfinished jobs was resolved by the reporting PR, since we also wanted to report the status of the job correctly: #265

Resolves #264