### PR TITLE
Issue 326 - Use Instant.parse() in tests to avoid issues with later java versions

### DIFF
--- a/java/dynamodb-tools/src/test/java/sleeper/dynamodb/tools/DynamoDBAttributesTest.java
+++ b/java/dynamodb-tools/src/test/java/sleeper/dynamodb/tools/DynamoDBAttributesTest.java
@@ -64,7 +64,7 @@ public class DynamoDBAttributesTest {
     @Test
     public void shouldCreateNumberAttributeWithInstant() {
         // Given we have a long attribute based on an Instant
-        Instant time = Instant.now();
+        Instant time = Instant.parse("2022-11-07T16:00:00.001Z");
         AttributeValue value = DynamoDBAttributes.createNumberAttribute(time.toEpochMilli());
         // When we construct a record with a key for the attribute value
         Map<String, AttributeValue> item = new HashMap<>();


### PR DESCRIPTION
Fix test failures in #326 