### PR TITLE
Issue 431 - Report records read during ingest

### DIFF
--- a/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesEmptyOutputTest.java
+++ b/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesEmptyOutputTest.java
@@ -37,9 +37,9 @@ import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestDa
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestData.readDataFile;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.assertReadyForGC;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createCompactSortedFiles;
-import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createInitStateStore;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createSchemaWithTypesForKeyAndTwoValues;
-import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createStateStore;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedPartitions;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 public class CompactSortedFilesEmptyOutputTest extends CompactSortedFilesTestBase {
 
@@ -47,7 +47,7 @@ public class CompactSortedFilesEmptyOutputTest extends CompactSortedFilesTestBas
     public void filesShouldMergeCorrectlyWhenSomeAreEmpty() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new LongType(), new LongType(), new LongType());
-        StateStore stateStore = createInitStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
         CompactSortedFilesTestDataHelper dataHelper = new CompactSortedFilesTestDataHelper(schema, stateStore);
 
         List<Record> data = keyAndTwoValuesSortedEvenLongs();
@@ -81,7 +81,7 @@ public class CompactSortedFilesEmptyOutputTest extends CompactSortedFilesTestBas
     public void filesShouldMergeCorrectlyWhenAllAreEmpty() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new LongType(), new LongType(), new LongType());
-        StateStore stateStore = createInitStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
         CompactSortedFilesTestDataHelper dataHelper = new CompactSortedFilesTestDataHelper(schema, stateStore);
 
         dataHelper.writeLeafFile(folderName + "/file1.parquet", Collections.emptyList(), null, null);
@@ -114,8 +114,7 @@ public class CompactSortedFilesEmptyOutputTest extends CompactSortedFilesTestBas
     public void filesShouldMergeAndSplitCorrectlyWhenOneChildFileIsEmpty() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new LongType(), new LongType(), new LongType());
-        StateStore stateStore = createStateStore(schema);
-        stateStore.initialise(new PartitionsBuilder(schema)
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(new PartitionsBuilder(schema)
                 .leavesWithSplits(Arrays.asList("A", "B"), Collections.singletonList(200L))
                 .parentJoining("C", "A", "B")
                 .buildList());

--- a/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIteratorTest.java
+++ b/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIteratorTest.java
@@ -37,8 +37,8 @@ import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestDa
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestData.specifiedFromOdds;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.assertReadyForGC;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createCompactSortedFiles;
-import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createInitStateStore;
-import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createStateStore;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedPartitions;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 public class CompactSortedFilesIteratorTest extends CompactSortedFilesTestBase {
 
@@ -46,7 +46,7 @@ public class CompactSortedFilesIteratorTest extends CompactSortedFilesTestBase {
     public void filesShouldMergeAndApplyIteratorCorrectlyLongKey() throws Exception {
         // Given
         Schema schema = CompactSortedFilesTestUtils.createSchemaWithKeyTimestampValue();
-        StateStore stateStore = createInitStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
         CompactSortedFilesTestDataHelper dataHelper = new CompactSortedFilesTestDataHelper(schema, stateStore);
 
         List<Record> data1 = specifiedFromEvens((even, record) -> {
@@ -91,8 +91,7 @@ public class CompactSortedFilesIteratorTest extends CompactSortedFilesTestBase {
     public void filesShouldMergeAndSplitAndApplyIteratorCorrectlyLongKey() throws Exception {
         // Given
         Schema schema = CompactSortedFilesTestUtils.createSchemaWithKeyTimestampValue();
-        StateStore stateStore = createStateStore(schema);
-        stateStore.initialise(new PartitionsBuilder(schema)
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(new PartitionsBuilder(schema)
                 .leavesWithSplits(Arrays.asList("A", "B"), Collections.singletonList(100L))
                 .parentJoining("C", "A", "B")
                 .buildList());

--- a/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesReportingTest.java
+++ b/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesReportingTest.java
@@ -38,8 +38,8 @@ import static org.mockito.Mockito.mock;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestData.keyAndTwoValuesSortedEvenLongs;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestData.keyAndTwoValuesSortedOddLongs;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createCompactSortedFiles;
-import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createInitStateStore;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createSchemaWithTypesForKeyAndTwoValues;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 public class CompactSortedFilesReportingTest extends CompactSortedFilesTestBase {
 
@@ -49,7 +49,7 @@ public class CompactSortedFilesReportingTest extends CompactSortedFilesTestBase 
     public void shouldReportJobStatusUpdatesWhenCompacting() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new LongType(), new LongType(), new LongType());
-        StateStore stateStore = createInitStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
         CompactSortedFilesTestDataHelper dataHelper = new CompactSortedFilesTestDataHelper(schema, stateStore);
 
         List<Record> data1 = keyAndTwoValuesSortedEvenLongs();

--- a/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingTest.java
+++ b/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingTest.java
@@ -43,7 +43,7 @@ import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUt
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createCompactSortedFiles;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createSchemaWithTwoTypedValuesAndKeyFields;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createSchemaWithTypesForKeyAndTwoValues;
-import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createStateStore;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedPartitions;
 
 public class CompactSortedFilesSplittingTest extends CompactSortedFilesTestBase {
 
@@ -51,8 +51,7 @@ public class CompactSortedFilesSplittingTest extends CompactSortedFilesTestBase 
     public void filesShouldMergeAndSplitCorrectlyAndStateStoreUpdated() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new LongType(), new LongType(), new LongType());
-        StateStore stateStore = createStateStore(schema);
-        stateStore.initialise(new PartitionsBuilder(schema)
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(new PartitionsBuilder(schema)
                 .leavesWithSplits(Arrays.asList("A", "B"), Collections.singletonList(100L))
                 .parentJoining("C", "A", "B")
                 .buildList());
@@ -96,8 +95,7 @@ public class CompactSortedFilesSplittingTest extends CompactSortedFilesTestBase 
         Field field1 = new Field("key1", new LongType());
         Field field2 = new Field("key2", new StringType());
         Schema schema = createSchemaWithTwoTypedValuesAndKeyFields(new LongType(), new LongType(), field1, field2);
-        StateStore stateStore = createStateStore(schema);
-        stateStore.initialise(new PartitionsBuilder(schema)
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(new PartitionsBuilder(schema)
                 .leavesWithSplits(Arrays.asList("A", "B"), Collections.singletonList(100L))
                 .parentJoining("C", "A", "B")
                 .buildList());
@@ -147,8 +145,7 @@ public class CompactSortedFilesSplittingTest extends CompactSortedFilesTestBase 
         Field field1 = new Field("key1", new LongType());
         Field field2 = new Field("key2", new StringType());
         Schema schema = createSchemaWithTwoTypedValuesAndKeyFields(new LongType(), new LongType(), field1, field2);
-        StateStore stateStore = createStateStore(schema);
-        stateStore.initialise(new PartitionsBuilder(schema)
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(new PartitionsBuilder(schema)
                 .leavesWithSplitsOnDimension(1, Arrays.asList("A", "B"), Collections.singletonList("A2"))
                 .parentJoining("C", "A", "B")
                 .buildList());

--- a/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesTest.java
+++ b/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesTest.java
@@ -41,8 +41,8 @@ import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestDa
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestData.readDataFile;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.assertReadyForGC;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createCompactSortedFiles;
-import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createInitStateStore;
 import static sleeper.compaction.jobexecution.testutils.CompactSortedFilesTestUtils.createSchemaWithTypesForKeyAndTwoValues;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 public class CompactSortedFilesTest extends CompactSortedFilesTestBase {
 
@@ -50,7 +50,7 @@ public class CompactSortedFilesTest extends CompactSortedFilesTestBase {
     public void filesShouldMergeCorrectlyAndStateStoreUpdatedLongKey() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new LongType(), new LongType(), new LongType());
-        StateStore stateStore = createInitStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
         CompactSortedFilesTestDataHelper dataHelper = new CompactSortedFilesTestDataHelper(schema, stateStore);
 
         List<Record> data1 = keyAndTwoValuesSortedEvenLongs();
@@ -103,7 +103,7 @@ public class CompactSortedFilesTest extends CompactSortedFilesTestBase {
     public void filesShouldMergeCorrectlyAndStateStoreUpdatedStringKey() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new StringType(), new StringType(), new LongType());
-        StateStore stateStore = createInitStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
         CompactSortedFilesTestDataHelper dataHelper = new CompactSortedFilesTestDataHelper(schema, stateStore);
 
         List<Record> data1 = keyAndTwoValuesSortedEvenStrings();
@@ -161,7 +161,7 @@ public class CompactSortedFilesTest extends CompactSortedFilesTestBase {
     public void filesShouldMergeCorrectlyAndStateStoreUpdatedByteArrayKey() throws Exception {
         // Given
         Schema schema = createSchemaWithTypesForKeyAndTwoValues(new ByteArrayType(), new ByteArrayType(), new LongType());
-        StateStore stateStore = createInitStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
         CompactSortedFilesTestDataHelper dataHelper = new CompactSortedFilesTestDataHelper(schema, stateStore);
 
         List<Record> data1 = keyAndTwoValuesSortedEvenByteArrays();

--- a/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/CompactSortedFilesTestUtils.java
+++ b/java/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/CompactSortedFilesTestUtils.java
@@ -29,13 +29,10 @@ import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.PrimitiveType;
 import sleeper.core.schema.type.Type;
 import sleeper.io.parquet.record.SchemaConverter;
-import sleeper.statestore.DelegatingStateStore;
 import sleeper.statestore.FileInfo;
 import sleeper.statestore.StateStore;
 import sleeper.statestore.StateStoreException;
 import sleeper.statestore.dynamodb.DynamoDBStateStoreCreator;
-import sleeper.statestore.inmemory.FixedPartitionStore;
-import sleeper.statestore.inmemory.InMemoryFileInfoStore;
 
 import java.util.Arrays;
 import java.util.List;
@@ -69,16 +66,6 @@ public class CompactSortedFilesTestUtils {
                 .rowKeyFields(key)
                 .valueFields(new Field("timestamp", new LongType()), new Field("value", new LongType()))
                 .build();
-    }
-
-    public static StateStore createInitStateStore(Schema schema) throws StateStoreException {
-        StateStore stateStore = createStateStore(schema);
-        stateStore.initialise();
-        return stateStore;
-    }
-
-    public static StateStore createStateStore(Schema schema) {
-        return new DelegatingStateStore(new InMemoryFileInfoStore(), new FixedPartitionStore(schema));
     }
 
     public static StateStore createInitStateStore(String tablenameStub, Schema schema, AmazonDynamoDB dynamoDBClient) throws StateStoreException {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
@@ -19,9 +19,11 @@ package sleeper.ingest;
 import sleeper.core.record.process.RecordsProcessed;
 import sleeper.statestore.FileInfo;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 public class IngestResult {
     private final List<FileInfo> fileInfoList;
@@ -38,6 +40,12 @@ public class IngestResult {
 
     public static IngestResult from(List<FileInfo> fileInfoList) {
         return new IngestResult(fileInfoList);
+    }
+
+    public static IngestResult from(Stream<IngestResult> results) {
+        List<FileInfo> fileInfoList = new ArrayList<>();
+        results.forEach(result -> fileInfoList.addAll(result.fileInfoList));
+        return from(fileInfoList);
     }
 
     public static IngestResult noFiles() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
@@ -19,11 +19,9 @@ package sleeper.ingest;
 import sleeper.core.record.process.RecordsProcessed;
 import sleeper.statestore.FileInfo;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 public class IngestResult {
     private final List<FileInfo> fileInfoList;
@@ -36,19 +34,17 @@ public class IngestResult {
         this.recordsWritten = recordsWritten;
     }
 
-    public static IngestResult from(List<FileInfo> fileInfoList) {
+    public static IngestResult allReadWereWritten(List<FileInfo> fileInfoList) {
         long recordsWritten = recordsWritten(fileInfoList);
         return new IngestResult(fileInfoList, recordsWritten, recordsWritten);
     }
 
-    public static IngestResult from(long recordsRead, Stream<List<FileInfo>> results) {
-        List<FileInfo> fileInfoList = new ArrayList<>();
-        results.forEach(fileInfoList::addAll);
+    public static IngestResult fromReadAndWritten(long recordsRead, List<FileInfo> fileInfoList) {
         return new IngestResult(fileInfoList, recordsRead, recordsWritten(fileInfoList));
     }
 
     public static IngestResult noFiles() {
-        return from(Collections.emptyList());
+        return new IngestResult(Collections.emptyList(), 0, 0);
     }
 
     public long getRecordsWritten() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
@@ -30,22 +30,21 @@ public class IngestResult {
     private final long recordsRead;
     private final long recordsWritten;
 
-    private IngestResult(List<FileInfo> fileInfoList) {
+    private IngestResult(List<FileInfo> fileInfoList, long recordsRead, long recordsWritten) {
         this.fileInfoList = fileInfoList;
-        this.recordsWritten = fileInfoList.stream()
-                .mapToLong(FileInfo::getNumberOfRecords)
-                .sum();
-        this.recordsRead = recordsWritten;
+        this.recordsRead = recordsRead;
+        this.recordsWritten = recordsWritten;
     }
 
     public static IngestResult from(List<FileInfo> fileInfoList) {
-        return new IngestResult(fileInfoList);
+        long recordsWritten = recordsWritten(fileInfoList);
+        return new IngestResult(fileInfoList, recordsWritten, recordsWritten);
     }
 
-    public static IngestResult from(Stream<IngestResult> results) {
+    public static IngestResult from(long recordsRead, Stream<List<FileInfo>> results) {
         List<FileInfo> fileInfoList = new ArrayList<>();
-        results.forEach(result -> fileInfoList.addAll(result.fileInfoList));
-        return from(fileInfoList);
+        results.forEach(fileInfoList::addAll);
+        return new IngestResult(fileInfoList, recordsRead, recordsWritten(fileInfoList));
     }
 
     public static IngestResult noFiles() {
@@ -87,5 +86,11 @@ public class IngestResult {
                 "recordsWritten=" + recordsWritten +
                 ",fileInfoList=" + fileInfoList +
                 '}';
+    }
+
+    private static long recordsWritten(List<FileInfo> fileInfoList) {
+        return fileInfoList.stream()
+                .mapToLong(FileInfo::getNumberOfRecords)
+                .sum();
     }
 }

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/IngestResult.java
@@ -25,13 +25,15 @@ import java.util.Objects;
 
 public class IngestResult {
     private final List<FileInfo> fileInfoList;
-    private final long numberOfRecords;
+    private final long recordsRead;
+    private final long recordsWritten;
 
     private IngestResult(List<FileInfo> fileInfoList) {
         this.fileInfoList = fileInfoList;
-        this.numberOfRecords = fileInfoList.stream()
+        this.recordsWritten = fileInfoList.stream()
                 .mapToLong(FileInfo::getNumberOfRecords)
                 .sum();
+        this.recordsRead = recordsWritten;
     }
 
     public static IngestResult from(List<FileInfo> fileInfoList) {
@@ -42,8 +44,8 @@ public class IngestResult {
         return from(Collections.emptyList());
     }
 
-    public long getNumberOfRecords() {
-        return numberOfRecords;
+    public long getRecordsWritten() {
+        return recordsWritten;
     }
 
     public List<FileInfo> getFileInfoList() {
@@ -51,7 +53,7 @@ public class IngestResult {
     }
 
     public RecordsProcessed asRecordsProcessed() {
-        return new RecordsProcessed(numberOfRecords, numberOfRecords);
+        return new RecordsProcessed(recordsRead, recordsWritten);
     }
 
     @Override
@@ -74,7 +76,8 @@ public class IngestResult {
     @Override
     public String toString() {
         return "IngestResult{" +
-                "fileInfoList=" + fileInfoList +
+                "recordsWritten=" + recordsWritten +
+                ",fileInfoList=" + fileInfoList +
                 '}';
     }
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/IngestResultTestData.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/IngestResultTestData.java
@@ -25,7 +25,7 @@ public class IngestResultTestData {
     }
 
     public static IngestResult defaultFileIngestResult(String filename) {
-        return IngestResult.from(Collections.singletonList(
+        return IngestResult.allReadWereWritten(Collections.singletonList(
                 FileInfoTestData.defaultFileOnRootPartition(filename)));
     }
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/IngestResultTestData.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/IngestResultTestData.java
@@ -28,4 +28,10 @@ public class IngestResultTestData {
         return IngestResult.allReadWereWritten(Collections.singletonList(
                 FileInfoTestData.defaultFileOnRootPartition(filename)));
     }
+
+    public static IngestResult defaultFileIngestResultReadAndWritten(
+            String filename, long recordsRead, long recordsWritten) {
+        return IngestResult.fromReadAndWritten(recordsRead, Collections.singletonList(
+                FileInfoTestData.defaultFileOnRootPartitionWithRecords(filename, recordsWritten)));
+    }
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/FixedIngestJobHandler.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/FixedIngestJobHandler.java
@@ -26,7 +26,7 @@ public class FixedIngestJobHandler {
     }
 
     public static IngestJobHandler makingDefaultFiles() {
-        return job -> IngestResult.from(job.getFiles().stream()
+        return job -> IngestResult.allReadWereWritten(job.getFiles().stream()
                 .map(FileInfoTestData::defaultFileOnRootPartition)
                 .collect(Collectors.toList()));
     }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/FixedIngestJobHandler.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/FixedIngestJobHandler.java
@@ -18,6 +18,8 @@ package sleeper.ingest.job;
 import sleeper.ingest.IngestResult;
 import sleeper.statestore.FileInfoTestData;
 
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.stream.Collectors;
 
 public class FixedIngestJobHandler {
@@ -29,5 +31,10 @@ public class FixedIngestJobHandler {
         return job -> IngestResult.allReadWereWritten(job.getFiles().stream()
                 .map(FileInfoTestData::defaultFileOnRootPartition)
                 .collect(Collectors.toList()));
+    }
+
+    public static IngestJobHandler withResults(IngestResult... results) {
+        Iterator<IngestResult> iterator = Arrays.asList(results).iterator();
+        return job -> iterator.next();
     }
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskStatusTestData.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskStatusTestData.java
@@ -20,8 +20,6 @@ import sleeper.core.record.process.RecordsProcessedSummary;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summary;
@@ -73,30 +71,20 @@ public class IngestTaskStatusTestData {
 
     public static IngestTaskStatus finishedMultipleJobs(String taskId, Instant startTaskTime, Instant finishTaskTime,
                                                         Duration duration, Instant... startJobTimes) {
-        return finishedMultipleJobs(taskId, startTaskTime, finishTaskTime, duration,
-                DEFAULT_NUMBER_OF_RECORDS, DEFAULT_NUMBER_OF_RECORDS, Arrays.asList(startJobTimes));
-
-    }
-
-    public static IngestTaskStatus finishedMultipleJobs(String taskId, Instant startTaskTime, Instant finishTaskTime,
-                                                        Duration duration, long linesRead, long linesWritten,
-                                                        Instant... startJobTimes) {
-        return finishedMultipleJobs(taskId, startTaskTime, finishTaskTime, duration,
-                linesRead, linesWritten, Arrays.asList(startJobTimes));
-    }
-
-    public static IngestTaskStatus finishedMultipleJobs(String taskId, Instant startTaskTime, Instant finishTaskTime,
-                                                        Duration duration, long linesRead, long linesWritten,
-                                                        List<Instant> startJobTimes) {
-        return IngestTaskStatus.builder().taskId(taskId).startTime(startTaskTime)
-                .finished(finishTaskTime, startJobTimes.stream().map(startTime -> summary(startTime, duration, linesRead, linesWritten)))
-                .build();
+        return finishedMultipleJobs(taskId, startTaskTime, finishTaskTime,
+                Stream.of(startJobTimes).map(startJobTime ->
+                        summary(startJobTime, duration, DEFAULT_NUMBER_OF_RECORDS, DEFAULT_NUMBER_OF_RECORDS)));
     }
 
     public static IngestTaskStatus finishedMultipleJobs(String taskId, Instant startTaskTime, Instant finishTaskTime,
                                                         RecordsProcessedSummary... summaries) {
+        return finishedMultipleJobs(taskId, startTaskTime, finishTaskTime, Stream.of(summaries));
+    }
+
+    private static IngestTaskStatus finishedMultipleJobs(String taskId, Instant startTaskTime, Instant finishTaskTime,
+                                                         Stream<RecordsProcessedSummary> summaries) {
         return IngestTaskStatus.builder().taskId(taskId).startTime(startTaskTime)
-                .finished(finishTaskTime, Stream.of(summaries))
+                .finished(finishTaskTime, summaries)
                 .build();
     }
 

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/IngestRecords.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/IngestRecords.java
@@ -44,6 +44,6 @@ public class IngestRecords {
     }
 
     public IngestResult close() throws StateStoreException, IteratorException, IOException {
-        return IngestResult.from(ingestCoordinator.closeReturningFileInfoList());
+        return ingestCoordinator.closeReturningResult();
     }
 }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
@@ -280,9 +280,9 @@ public class IngestCoordinator<INCOMINGDATATYPE> implements AutoCloseable {
         return CompletableFuture.allOf(ingestFutures.toArray(new CompletableFuture[0]))
                 .whenComplete((msg, ex) -> internalClose())
                 .thenApply(dummy -> {
-                    IngestResult result = IngestResult.fromReadAndWritten(recordsRead,
-                            ingestFutures.stream().map(CompletableFuture::join)
-                                    .flatMap(List::stream).collect(Collectors.toList()));
+                    List<FileInfo> filesWritten = ingestFutures.stream().map(CompletableFuture::join)
+                            .flatMap(List::stream).collect(Collectors.toList());
+                    IngestResult result = IngestResult.fromReadAndWritten(recordsRead, filesWritten);
                     long noOfRecordsWritten = result.getRecordsWritten();
                     double elapsedSeconds = (System.currentTimeMillis() - ingestCoordinatorCreationTime) / 1000.0;
                     METRICS_LOGGER.info(String.format("Wrote %d records to S3 in %.1f seconds at %.1f per second",

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
@@ -173,7 +173,7 @@ public class IngestCoordinator<INCOMINGDATATYPE> implements AutoCloseable {
             // Apply the Sleeper iterator to the record batch, within a try-with-resources block. This will ensure that
             // the iterators are closed in both success and failure
             try (CloseableIterator<Record> orderedRecordIteratorFromBatch = currentRecordBatch.createOrderedRecordIterator();
-                 RecordIteratorWithSleeperIteratorApplied recordIteratorWithSleeperIteratorApplied =
+                 CloseableIterator<Record> recordIteratorWithSleeperIteratorApplied =
                          new RecordIteratorWithSleeperIteratorApplied(
                                  objectFactory,
                                  sleeperSchema,

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
@@ -172,7 +172,7 @@ public class IngestCoordinator<INCOMINGDATATYPE> implements AutoCloseable {
             // Apply the Sleeper iterator to the record batch, within a try-with-resources block. This will ensure that
             // the iterators are closed in both success and failure
             try (CloseableIterator<Record> orderedRecordIteratorFromBatch = currentRecordBatch.createOrderedRecordIterator();
-                 CloseableIterator<Record> recordIteratorWithSleeperIteratorApplied =
+                 RecordIteratorWithSleeperIteratorApplied recordIteratorWithSleeperIteratorApplied =
                          new RecordIteratorWithSleeperIteratorApplied(
                                  objectFactory,
                                  sleeperSchema,

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
@@ -86,7 +86,7 @@ public class IngestCoordinator<INCOMINGDATATYPE> implements AutoCloseable {
     private PartitionTree partitionTree;
     private boolean isClosed;
 
-    private IngestCoordinator(Builder builder, RecordBatchFactory<INCOMINGDATATYPE> recordBatchFactory) {
+    private IngestCoordinator(Builder<INCOMINGDATATYPE> builder) {
         LOGGER.info("Creating IngestCoordinator with schema of {}", builder.schema);
 
         // Supplied member variables
@@ -96,7 +96,7 @@ public class IngestCoordinator<INCOMINGDATATYPE> implements AutoCloseable {
         this.sleeperIteratorClassName = builder.iteratorClassName;
         this.sleeperIteratorConfig = builder.iteratorConfig;
         this.ingestPartitionRefreshFrequencyInSeconds = builder.ingestPartitionRefreshFrequencyInSeconds;
-        this.recordBatchFactory = requireNonNull(recordBatchFactory);
+        this.recordBatchFactory = requireNonNull(builder.recordBatchFactory);
 
         // Other member variables
         this.ingestCoordinatorCreationTime = System.currentTimeMillis();
@@ -468,7 +468,7 @@ public class IngestCoordinator<INCOMINGDATATYPE> implements AutoCloseable {
         }
 
         public IngestCoordinator<T> build() {
-            return new IngestCoordinator<>(this, recordBatchFactory);
+            return new IngestCoordinator<>(this);
         }
     }
 }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngestCoordinator.java
@@ -185,13 +185,11 @@ public class IngestCoordinator<INCOMINGDATATYPE> implements AutoCloseable {
                 CompletableFuture<List<FileInfo>> consumedFuture = ingesterIntoPartitions
                         .initiateIngest(recordIteratorWithSleeperIteratorApplied, partitionTree)
                         .thenApply(fileInfoList -> {
-                            // Update the state store
                             try {
                                 updateStateStore(sleeperStateStore, fileInfoList);
                             } catch (Exception e) {
                                 throw new RuntimeException(e);
                             }
-                            // Return the total number of records that ave been written
                             return fileInfoList;
                         });
                 ingestFutures.add(consumedFuture);

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
@@ -24,13 +24,13 @@ import sleeper.core.partition.PartitionTree;
 import sleeper.core.range.Range;
 import sleeper.core.record.Record;
 import sleeper.core.schema.Schema;
-import sleeper.ingest.IngestResult;
 import sleeper.ingest.impl.partitionfilewriter.PartitionFileWriter;
 import sleeper.statestore.FileInfo;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,7 +108,7 @@ class IngesterIntoPartitions {
      * partition file that has been created
      * @throws IOException -
      */
-    public CompletableFuture<IngestResult> initiateIngest(
+    public CompletableFuture<List<FileInfo>> initiateIngest(
             RecordIteratorWithSleeperIteratorApplied orderedRecordIterator, PartitionTree partitionTree) throws IOException {
 
         List<String> rowKeyNames = sleeperSchema.getRowKeyFieldNames();
@@ -124,7 +124,7 @@ class IngesterIntoPartitions {
         // Log and return if the iterator is empty
         if (!orderedRecordIterator.hasNext()) {
             LOGGER.info("There are no records");
-            return CompletableFuture.completedFuture(IngestResult.noFiles());
+            return CompletableFuture.completedFuture(Collections.emptyList());
         }
 
         // Loop through the iterator, creating new partition files whenever this is required.
@@ -163,8 +163,8 @@ class IngesterIntoPartitions {
         // Create a future where all of the partitions have finished uploading and then return the FileInfo
         // objects as a list
         return CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0]))
-                .thenApply(dummy -> IngestResult.from(completableFutures.stream()
+                .thenApply(dummy -> completableFutures.stream()
                         .map(CompletableFuture::join)
-                        .collect(Collectors.toList())));
+                        .collect(Collectors.toList()));
     }
 }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
@@ -109,7 +109,7 @@ class IngesterIntoPartitions {
      * @throws IOException -
      */
     public CompletableFuture<IngestResult> initiateIngest(
-            CloseableIterator<Record> orderedRecordIterator, PartitionTree partitionTree) throws IOException {
+            RecordIteratorWithSleeperIteratorApplied orderedRecordIterator, PartitionTree partitionTree) throws IOException {
 
         List<String> rowKeyNames = sleeperSchema.getRowKeyFieldNames();
         String firstDimensionRowKey = rowKeyNames.get(0);

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
@@ -24,6 +24,7 @@ import sleeper.core.partition.PartitionTree;
 import sleeper.core.range.Range;
 import sleeper.core.record.Record;
 import sleeper.core.schema.Schema;
+import sleeper.ingest.IngestResult;
 import sleeper.ingest.impl.partitionfilewriter.PartitionFileWriter;
 import sleeper.statestore.FileInfo;
 
@@ -107,8 +108,9 @@ class IngesterIntoPartitions {
      * partition file that has been created
      * @throws IOException -
      */
-    public CompletableFuture<List<FileInfo>> initiateIngest(CloseableIterator<Record> orderedRecordIterator,
-                                                            PartitionTree partitionTree) throws IOException {
+    public CompletableFuture<IngestResult> initiateIngest(
+            CloseableIterator<Record> orderedRecordIterator, PartitionTree partitionTree) throws IOException {
+
         List<String> rowKeyNames = sleeperSchema.getRowKeyFieldNames();
         String firstDimensionRowKey = rowKeyNames.get(0);
         Map<String, PartitionFileWriter> partitionIdToFileWriterMap = new HashMap<>();
@@ -122,7 +124,7 @@ class IngesterIntoPartitions {
         // Log and return if the iterator is empty
         if (!orderedRecordIterator.hasNext()) {
             LOGGER.info("There are no records");
-            return CompletableFuture.completedFuture(new ArrayList<>());
+            return CompletableFuture.completedFuture(IngestResult.noFiles());
         }
 
         // Loop through the iterator, creating new partition files whenever this is required.
@@ -161,6 +163,8 @@ class IngesterIntoPartitions {
         // Create a future where all of the partitions have finished uploading and then return the FileInfo
         // objects as a list
         return CompletableFuture.allOf(completableFutures.toArray(new CompletableFuture[0]))
-                .thenApply(dummy -> completableFutures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
+                .thenApply(dummy -> IngestResult.from(completableFutures.stream()
+                        .map(CompletableFuture::join)
+                        .collect(Collectors.toList())));
     }
 }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/IngesterIntoPartitions.java
@@ -109,7 +109,7 @@ class IngesterIntoPartitions {
      * @throws IOException -
      */
     public CompletableFuture<List<FileInfo>> initiateIngest(
-            RecordIteratorWithSleeperIteratorApplied orderedRecordIterator, PartitionTree partitionTree) throws IOException {
+            CloseableIterator<Record> orderedRecordIterator, PartitionTree partitionTree) throws IOException {
 
         List<String> rowKeyNames = sleeperSchema.getRowKeyFieldNames();
         String firstDimensionRowKey = rowKeyNames.get(0);

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/RetryStateStoreException.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/RetryStateStoreException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.ingest.impl;
+
+import sleeper.statestore.StateStoreException;
+
+public class RetryStateStoreException extends RuntimeException {
+
+    public RetryStateStoreException(String message, StateStoreException e) {
+        super(message, e);
+    }
+}

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/recordbatch/arrow/ArrowRecordBatchAcceptingRecords.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/recordbatch/arrow/ArrowRecordBatchAcceptingRecords.java
@@ -28,7 +28,6 @@ import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sleeper.core.iterator.IteratorException;
 import sleeper.core.record.Record;
 import sleeper.core.schema.Field;
 import sleeper.core.schema.Schema;
@@ -39,11 +38,9 @@ import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.MapType;
 import sleeper.core.schema.type.StringType;
 import sleeper.core.schema.type.Type;
-import sleeper.statestore.StateStoreException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -279,11 +276,4 @@ public class ArrowRecordBatchAcceptingRecords extends ArrowRecordBatchBase<Recor
         }
     }
 
-    public void write(Iterator<Record> recordIterator)
-            throws IOException, IteratorException, InterruptedException, StateStoreException, OutOfMemoryException {
-        // Add each record from the iterator in turn
-        while (recordIterator.hasNext()) {
-            append(recordIterator.next());
-        }
-    }
 }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobQueueConsumer.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobQueueConsumer.java
@@ -120,13 +120,13 @@ public class IngestJobQueueConsumer implements IngestJobSource {
                 .withNamespace(metricsNamespace)
                 .withMetricData(new MetricDatum()
                         .withMetricName("StandardIngestRecordsWritten")
-                        .withValue((double) result.getNumberOfRecords())
+                        .withValue((double) result.getRecordsWritten())
                         .withUnit(StandardUnit.Count)
                         .withDimensions(
                                 new Dimension().withName("instanceId").withValue(instanceId),
                                 new Dimension().withName("tableName").withValue(job.getTableName())
                         )));
 
-        return result.getNumberOfRecords();
+        return result.getRecordsWritten();
     }
 }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobRunner.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobRunner.java
@@ -117,7 +117,7 @@ public class IngestJobRunner implements IngestJobHandler {
 
         // Run the ingest
         IngestResult result = ingestFactory.ingestFromRecordIteratorAndClose(tableProperties, concatenatingIterator);
-        LOGGER.info("Ingest job {}: Wrote {} records from files {}", job.getId(), result.getNumberOfRecords(), paths);
+        LOGGER.info("Ingest job {}: Wrote {} records from files {}", job.getId(), result.getRecordsWritten(), paths);
         return result;
     }
 }

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsFromIteratorIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsFromIteratorIT.java
@@ -37,7 +37,7 @@ public class IngestRecordsFromIteratorIT extends IngestRecordsITBase {
         DynamoDBStateStore stateStore = getStateStore(schema);
 
         // When
-        long numWritten = ingestFromRecordIterator(schema, stateStore, getRecords().iterator()).getNumberOfRecords();
+        long numWritten = ingestFromRecordIterator(schema, stateStore, getRecords().iterator()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsFromIteratorTest.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsFromIteratorTest.java
@@ -37,8 +37,9 @@ import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.createRootPar
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getRecords;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getSingleRecord;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getSketches;
-import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getStateStore;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.readRecordsFromParquetFile;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedPartitions;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 public class IngestRecordsFromIteratorTest extends IngestRecordsTestBase {
 
@@ -55,8 +56,7 @@ public class IngestRecordsFromIteratorTest extends IngestRecordsTestBase {
         Region region2 = new Region(range2);
         Partition partition2 = createLeafPartition("partition2", region2, new LongType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
 
         // When
         long numWritten = ingestFromRecordIterator(schema, stateStore, getRecords().iterator()).getRecordsWritten();
@@ -115,8 +115,7 @@ public class IngestRecordsFromIteratorTest extends IngestRecordsTestBase {
         Region region2 = new Region(range2);
         Partition partition2 = createLeafPartition("partition2", region2, new LongType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
 
         // When
         long numWritten = ingestFromRecordIterator(schema, stateStore, getSingleRecord().iterator()).getRecordsWritten();
@@ -152,7 +151,7 @@ public class IngestRecordsFromIteratorTest extends IngestRecordsTestBase {
     @Test
     public void shouldWriteNoRecordsWhenIteratorIsEmpty() throws Exception {
         // Given
-        StateStore stateStore = getStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
 
         // When
         long numWritten = ingestFromRecordIterator(schema, stateStore, Collections.emptyIterator()).getRecordsWritten();

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsFromIteratorTest.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsFromIteratorTest.java
@@ -59,7 +59,7 @@ public class IngestRecordsFromIteratorTest extends IngestRecordsTestBase {
                 Arrays.asList(rootPartition, partition1, partition2));
 
         // When
-        long numWritten = ingestFromRecordIterator(schema, stateStore, getRecords().iterator()).getNumberOfRecords();
+        long numWritten = ingestFromRecordIterator(schema, stateStore, getRecords().iterator()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -119,7 +119,7 @@ public class IngestRecordsFromIteratorTest extends IngestRecordsTestBase {
                 Arrays.asList(rootPartition, partition1, partition2));
 
         // When
-        long numWritten = ingestFromRecordIterator(schema, stateStore, getSingleRecord().iterator()).getNumberOfRecords();
+        long numWritten = ingestFromRecordIterator(schema, stateStore, getSingleRecord().iterator()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -155,7 +155,7 @@ public class IngestRecordsFromIteratorTest extends IngestRecordsTestBase {
         StateStore stateStore = getStateStore(schema);
 
         // When
-        long numWritten = ingestFromRecordIterator(schema, stateStore, Collections.emptyIterator()).getNumberOfRecords();
+        long numWritten = ingestFromRecordIterator(schema, stateStore, Collections.emptyIterator()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsIT.java
@@ -38,7 +38,7 @@ public class IngestRecordsIT extends IngestRecordsITBase {
         DynamoDBStateStore stateStore = getStateStore(schema);
 
         // When
-        long numWritten = ingestRecords(schema, stateStore, getRecords()).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, getRecords()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -74,7 +74,7 @@ public class IngestRecordsIT extends IngestRecordsITBase {
         DynamoDBStateStore stateStore = getStateStore(schema);
 
         // When
-        long numWritten = ingestRecords(schema, stateStore, Collections.emptyList()).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, Collections.emptyList()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsResultTest.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsResultTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.ingest;
+
+import org.junit.Test;
+import sleeper.core.iterator.SortedRecordIterator;
+import sleeper.core.iterator.impl.AdditionIterator;
+import sleeper.core.iterator.impl.AgeOffIterator;
+import sleeper.core.record.Record;
+import sleeper.core.schema.Field;
+import sleeper.core.schema.Schema;
+import sleeper.core.schema.type.LongType;
+import sleeper.core.schema.type.StringType;
+import sleeper.statestore.StateStore;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.configuration.properties.table.TableProperty.ITERATOR_CLASS_NAME;
+import static sleeper.configuration.properties.table.TableProperty.ITERATOR_CONFIG;
+import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.readIngestedRecords;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
+
+public class IngestRecordsResultTest extends IngestRecordsTestBase {
+
+    private final Schema schema = Schema.builder()
+            .rowKeyFields(new Field("key", new StringType()))
+            .valueFields(new Field("value", new LongType()))
+            .build();
+    private final StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
+
+    @Test
+    public void shouldReturnDifferentReadAndWrittenCountsWhenTableIteratorReducesCount() throws Exception {
+        // Given
+        List<Record> records = Arrays.asList(record("test-1", 1), record("test-1", 2), record("test-2", 3));
+
+        // When
+        IngestResult result = ingestWithTableIterator(AdditionIterator.class, records);
+
+        // Then
+        assertThat(readRecords(result)).containsExactly(record("test-1", 3), record("test-2", 3));
+        assertThat(result).extracting("recordsRead", "recordsWritten")
+                .containsExactly(3L, 2L);
+    }
+
+    @Test
+    public void shouldReturnDifferentReadAndWrittenCountsWhenTableIteratorFiltersOutAll() throws Exception {
+        // Given
+        List<Record> records = Arrays.asList(record("test-1", 1), record("test-1", 2), record("test-2", 3));
+
+        // When
+        IngestResult result = ingestWithTableIterator(AgeOffIterator.class, "value,0", records);
+
+        // Then
+        assertThat(readRecords(result)).isEmpty();
+        assertThat(result).extracting("recordsRead", "recordsWritten")
+                .containsExactly(3L, 0L);
+    }
+
+    private static Record record(String key, long value) {
+        Record record = new Record();
+        record.put("key", key);
+        record.put("value", value);
+        return record;
+    }
+
+    private IngestResult ingestWithTableIterator(
+            Class<? extends SortedRecordIterator> iteratorClass, List<Record> records) throws Exception {
+        return ingestWithTableIterator(iteratorClass, null, records);
+    }
+
+    private IngestResult ingestWithTableIterator(
+            Class<? extends SortedRecordIterator> iteratorClass, String iteratorConfig, List<Record> records) throws Exception {
+        return ingestRecordsWithTableProperties(schema, stateStore, records,
+                tableProperties -> {
+                    tableProperties.set(ITERATOR_CLASS_NAME, iteratorClass.getName());
+                    tableProperties.set(ITERATOR_CONFIG, iteratorConfig);
+                });
+    }
+
+    private List<Record> readRecords(IngestResult result) {
+        return readIngestedRecords(result, schema);
+    }
+}

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsTest.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsTest.java
@@ -68,10 +68,11 @@ import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getRecordsFor
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getRecordsInFirstPartitionOnly;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getRecordsOscillatingBetween2Partitions;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getSketches;
-import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getStateStore;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getUnsortedRecords;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.readRecordsFromParquetFile;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.schemaWithRowKeys;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedPartitions;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 public class IngestRecordsTest extends IngestRecordsTestBase {
     @Test
@@ -87,8 +88,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         Region region2 = new Region(range2);
         Partition partition2 = createLeafPartition("partition2", region2, new LongType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
 
         // When
         long numWritten = ingestRecords(schema, stateStore, getRecords()).getRecordsWritten();
@@ -151,8 +151,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         Region region2 = new Region(range2);
         Partition partition2 = createLeafPartition("partition2", region2, new ByteArrayType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
 
         // When
         long numWritten = ingestRecords(schema, stateStore, getRecordsByteArrayKey()).getRecordsWritten();
@@ -222,8 +221,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         Region region2 = new Region(Arrays.asList(range21, range22));
         Partition partition2 = createLeafPartition("partition2", region2, new ByteArrayType(), new ByteArrayType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
 
         // When
         long numWritten = ingestRecords(schema, stateStore, getRecords2DimByteArrayKey()).getRecordsWritten();
@@ -337,8 +335,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         Partition partition2 = createLeafPartition("partition2", region2, new IntType(), new LongType());
         partition2.setDimension(-1);
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
 
         // When
         //  - When sorted the records in getRecordsOscillateBetweenTwoPartitions
@@ -416,8 +413,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         Region region2 = new Region(range2);
         Partition partition2 = createLeafPartition("partition2", region2, new LongType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
 
         // When
         long numWritten = ingestRecords(schema, stateStore, getRecordsInFirstPartitionOnly()).getRecordsWritten();
@@ -451,7 +447,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
     @Test
     public void shouldWriteDuplicateRecords() throws Exception {
         // Given
-        StateStore stateStore = getStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
 
         // When
         List<Record> records = new ArrayList<>(getRecords());
@@ -499,8 +495,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         Region region2 = new Region(range2);
         Partition partition2 = createLeafPartition("partition2", region2, new LongType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
         List<Record> records = getLotsOfRecords();
 
         // When
@@ -616,8 +611,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         Region region2 = new Region(range2);
         Partition partition2 = createLeafPartition("partition2", region2, new LongType());
         rootPartition.setChildPartitionIds(Arrays.asList(partition1.getId(), partition2.getId()));
-        StateStore stateStore = getStateStore(schema,
-                Arrays.asList(rootPartition, partition1, partition2));
+        StateStore stateStore = inMemoryStateStoreWithFixedPartitions(rootPartition, partition1, partition2);
         List<Record> records = getLotsOfRecords();
 
         // When
@@ -707,7 +701,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
     @Test
     public void shouldSortRecords() throws Exception {
         // Given
-        StateStore stateStore = getStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
 
         // When
         long numWritten = ingestRecords(schema, stateStore, getUnsortedRecords()).getRecordsWritten();
@@ -751,7 +745,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
                 .sortKeyFields(new Field("sort", new LongType()))
                 .valueFields(new Field("value", new LongType()))
                 .build();
-        StateStore stateStore = getStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
 
         // When
         long numWritten = ingestRecordsWithTableProperties(schema, stateStore, getRecordsForAggregationIteratorTest(),

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsTest.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsTest.java
@@ -91,7 +91,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
                 Arrays.asList(rootPartition, partition1, partition2));
 
         // When
-        long numWritten = ingestRecords(schema, stateStore, getRecords()).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, getRecords()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -155,7 +155,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
                 Arrays.asList(rootPartition, partition1, partition2));
 
         // When
-        long numWritten = ingestRecords(schema, stateStore, getRecordsByteArrayKey()).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, getRecordsByteArrayKey()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -226,7 +226,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
                 Arrays.asList(rootPartition, partition1, partition2));
 
         // When
-        long numWritten = ingestRecords(schema, stateStore, getRecords2DimByteArrayKey()).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, getRecords2DimByteArrayKey()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -345,7 +345,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         //  appear in partition 1 then partition 2 then partition 1, then 2, etc
         long numWritten = ingestRecordsWithTableProperties(schema, stateStore,
                 getRecordsOscillatingBetween2Partitions(),
-                tableProperties -> tableProperties.set(COMPRESSION_CODEC, "snappy")).getNumberOfRecords();
+                tableProperties -> tableProperties.set(COMPRESSION_CODEC, "snappy")).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -420,7 +420,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
                 Arrays.asList(rootPartition, partition1, partition2));
 
         // When
-        long numWritten = ingestRecords(schema, stateStore, getRecordsInFirstPartitionOnly()).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, getRecordsInFirstPartitionOnly()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -456,7 +456,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         // When
         List<Record> records = new ArrayList<>(getRecords());
         records.addAll(getRecords());
-        long numWritten = ingestRecords(schema, stateStore, records).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, records).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -507,7 +507,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         long numWritten = ingestRecordsWithInstanceProperties(schema, stateStore, records, instanceProperties -> {
             instanceProperties.setNumber(MAX_RECORDS_TO_WRITE_LOCALLY, 1000L);
             instanceProperties.setNumber(MAX_IN_MEMORY_BATCH_SIZE, 5);
-        }).getNumberOfRecords();
+        }).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -624,7 +624,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         long numWritten = ingestRecordsWithInstanceProperties(schema, stateStore, records, instanceProperties -> {
             instanceProperties.setNumber(MAX_RECORDS_TO_WRITE_LOCALLY, 10L);
             instanceProperties.setNumber(MAX_IN_MEMORY_BATCH_SIZE, 5);
-        }).getNumberOfRecords();
+        }).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -710,7 +710,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         StateStore stateStore = getStateStore(schema);
 
         // When
-        long numWritten = ingestRecords(schema, stateStore, getUnsortedRecords()).getNumberOfRecords();
+        long numWritten = ingestRecords(schema, stateStore, getUnsortedRecords()).getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written
@@ -756,7 +756,7 @@ public class IngestRecordsTest extends IngestRecordsTestBase {
         // When
         long numWritten = ingestRecordsWithTableProperties(schema, stateStore, getRecordsForAggregationIteratorTest(),
                 tableProperties -> tableProperties.set(ITERATOR_CLASS_NAME, AdditionIterator.class.getName()))
-                .getNumberOfRecords();
+                .getRecordsWritten();
 
         // Then:
         //  - Check the correct number of records were written

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestResultTest.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestResultTest.java
@@ -21,13 +21,13 @@ import sleeper.statestore.StateStore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getRecords;
-import static sleeper.ingest.testutils.IngestRecordsTestDataHelper.getStateStore;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 public class IngestResultTest extends IngestRecordsTestBase {
     @Test
     public void shouldReturnNumberOfRecordsFromIngestResult() throws Exception {
         // Given
-        StateStore stateStore = getStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
 
         // When
         IngestResult result = ingestRecords(schema, stateStore, getRecords());
@@ -40,7 +40,7 @@ public class IngestResultTest extends IngestRecordsTestBase {
     @Test
     public void shouldReturnFileInfoListFromIngestResult() throws Exception {
         // Given
-        StateStore stateStore = getStateStore(schema);
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(schema);
 
         // When
         IngestResult result = ingestRecords(schema, stateStore, getRecords());

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestResultTest.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestResultTest.java
@@ -33,7 +33,7 @@ public class IngestResultTest extends IngestRecordsTestBase {
         IngestResult result = ingestRecords(schema, stateStore, getRecords());
 
         // Then
-        assertThat(result.getNumberOfRecords())
+        assertThat(result.getRecordsWritten())
                 .isEqualTo(2L);
     }
 

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobRunnerIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobRunnerIT.java
@@ -42,12 +42,9 @@ import sleeper.ingest.testutils.RecordGenerator;
 import sleeper.ingest.testutils.ResultVerifier;
 import sleeper.io.parquet.record.ParquetRecordWriter;
 import sleeper.io.parquet.record.SchemaConverter;
-import sleeper.statestore.DelegatingStateStore;
 import sleeper.statestore.FixedStateStoreProvider;
 import sleeper.statestore.StateStore;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.statestore.inmemory.FixedPartitionStore;
-import sleeper.statestore.inmemory.InMemoryFileInfoStore;
 
 import java.io.IOException;
 import java.net.URI;
@@ -72,6 +69,7 @@ import static sleeper.configuration.properties.table.TableProperty.PARTITION_TAB
 import static sleeper.configuration.properties.table.TableProperty.READY_FOR_GC_FILEINFO_TABLENAME;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.ingest.job.IngestJobTestData.createJobWithTableAndFiles;
+import static sleeper.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 
 @RunWith(Parameterized.class)
 public class IngestJobRunnerIT {
@@ -201,9 +199,8 @@ public class IngestJobRunnerIT {
         InstanceProperties instanceProperties = getInstanceProperties();
         TableProperties tableProperties = createTable(sleeperSchema);
         TablePropertiesProvider tablePropertiesProvider = new FixedTablePropertiesProvider(tableProperties);
-        StateStore stateStore = new DelegatingStateStore(new InMemoryFileInfoStore(), new FixedPartitionStore(sleeperSchema));
+        StateStore stateStore = inMemoryStateStoreWithFixedSinglePartition(sleeperSchema);
         StateStoreProvider stateStoreProvider = new FixedStateStoreProvider(tablePropertiesProvider.getTableProperties(TEST_TABLE_NAME), stateStore);
-        stateStore.initialise();
 
         // Run the job consumer
         IngestJobRunner ingestJobRunner = new IngestJobRunner(

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/testutils/IngestRecordsTestDataHelper.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/testutils/IngestRecordsTestDataHelper.java
@@ -24,7 +24,6 @@ import sleeper.configuration.jars.ObjectFactory;
 import sleeper.configuration.properties.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.partition.Partition;
-import sleeper.core.partition.PartitionsFromSplitPoints;
 import sleeper.core.range.Region;
 import sleeper.core.record.CloneRecord;
 import sleeper.core.record.Record;
@@ -36,12 +35,7 @@ import sleeper.ingest.IngestFactory;
 import sleeper.io.parquet.record.ParquetRecordReader;
 import sleeper.sketches.Sketches;
 import sleeper.sketches.s3.SketchesSerDeToS3;
-import sleeper.statestore.DelegatingStateStore;
-import sleeper.statestore.StateStore;
-import sleeper.statestore.StateStoreException;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.statestore.inmemory.FixedPartitionStore;
-import sleeper.statestore.inmemory.InMemoryFileInfoStore;
 
 import java.io.File;
 import java.io.IOException;
@@ -324,13 +318,4 @@ public class IngestRecordsTestDataHelper {
         return new SketchesSerDeToS3(schema).loadFromHadoopFS("", sketchFile, new Configuration());
     }
 
-    public static StateStore getStateStore(Schema schema) throws StateStoreException {
-        return getStateStore(schema, new PartitionsFromSplitPoints(schema, Collections.emptyList()).construct());
-    }
-
-    public static StateStore getStateStore(Schema schema, List<Partition> initialPartitions) throws StateStoreException {
-        StateStore stateStore = new DelegatingStateStore(new InMemoryFileInfoStore(), new FixedPartitionStore(schema));
-        stateStore.initialise(initialPartitions);
-        return stateStore;
-    }
 }

--- a/java/statestore/src/test/java/sleeper/statestore/FileInfoTestData.java
+++ b/java/statestore/src/test/java/sleeper/statestore/FileInfoTestData.java
@@ -33,11 +33,15 @@ public class FileInfoTestData {
             .build();
 
     public static FileInfo defaultFileOnRootPartition(String filename) {
+        return defaultFileOnRootPartitionWithRecords(filename, DEFAULT_NUMBER_OF_RECORDS);
+    }
+
+    public static FileInfo defaultFileOnRootPartitionWithRecords(String filename, long records) {
         return FileInfo.builder()
                 .rowKeyTypes(DEFAULT_SCHEMA.getRowKeyTypes())
                 .minRowKey(Key.create("")).maxRowKey(null)
                 .filename(filename).partitionId("root")
-                .numberOfRecords(DEFAULT_NUMBER_OF_RECORDS).fileStatus(FileInfo.FileStatus.ACTIVE)
+                .numberOfRecords(records).fileStatus(FileInfo.FileStatus.ACTIVE)
                 .lastStateStoreUpdateTime(Instant.parse("2022-12-08T11:03:00.001Z"))
                 .build();
     }

--- a/java/statestore/src/test/java/sleeper/statestore/inmemory/FixedPartitionStoreTest.java
+++ b/java/statestore/src/test/java/sleeper/statestore/inmemory/FixedPartitionStoreTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FixedPartitionStoreTest {
@@ -37,10 +38,9 @@ public class FixedPartitionStoreTest {
     public void shouldInitialiseStoreWithSinglePartition() throws Exception {
         // Given
         Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
-        PartitionStore store = new FixedPartitionStore(schema);
 
         // When
-        store.initialise();
+        PartitionStore store = new FixedPartitionStore(schema);
         PartitionTree tree = new PartitionTree(schema, store.getAllPartitions());
         Partition root = tree.getRootPartition();
 
@@ -48,13 +48,13 @@ public class FixedPartitionStoreTest {
         assertThat(store.getAllPartitions()).containsExactly(root);
         assertThat(store.getLeafPartitions()).containsExactly(root);
         assertThat(root.getChildPartitionIds()).isEmpty();
+        assertThatCode(store::initialise).doesNotThrowAnyException();
     }
 
     @Test
     public void shouldInitialiseStoreWithPartitionTree() throws Exception {
         // Given
         Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
-        PartitionStore store = new FixedPartitionStore(schema);
         List<Partition> partitions = new PartitionsBuilder(schema)
                 .leavesWithSplits(Arrays.asList("A", "B"), Collections.singletonList("aaa"))
                 .parentJoining("C", "A", "B")
@@ -62,24 +62,24 @@ public class FixedPartitionStoreTest {
         PartitionTree tree = new PartitionTree(schema, partitions);
 
         // When
-        store.initialise(partitions);
+        PartitionStore store = new FixedPartitionStore(partitions);
 
         // Then
         assertThat(store.getAllPartitions()).containsExactlyInAnyOrder(
                 tree.getPartition("A"), tree.getPartition("B"), tree.getPartition("C"));
         assertThat(store.getLeafPartitions()).containsExactlyInAnyOrder(
                 tree.getPartition("A"), tree.getPartition("B"));
+        assertThatCode(() -> store.initialise(partitions)).doesNotThrowAnyException();
     }
 
     @Test
-    public void shouldRefusePartitionSplit() throws Exception {
+    public void shouldRefusePartitionSplit() {
         // Given
         Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
         List<Partition> partitionsInit = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildList();
-        PartitionStore store = new FixedPartitionStore(schema);
-        store.initialise(partitionsInit);
+        PartitionStore store = new FixedPartitionStore(partitionsInit);
 
         // When / Then
         PartitionTree updateTree = new PartitionsBuilder(schema)
@@ -94,14 +94,13 @@ public class FixedPartitionStoreTest {
     }
 
     @Test
-    public void shouldRefuseInitialiseWhenAlreadyInitialised() throws Exception {
+    public void shouldRefuseInitialiseThatChangesPartitions() {
         // Given
         Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
         List<Partition> partitionsInit = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildList();
-        PartitionStore store = new FixedPartitionStore(schema);
-        store.initialise(partitionsInit);
+        PartitionStore store = new FixedPartitionStore(partitionsInit);
 
         // When / Then
         List<Partition> partitionsUpdate = new PartitionsBuilder(schema)
@@ -109,6 +108,21 @@ public class FixedPartitionStoreTest {
                 .parentJoining("root", "left", "right")
                 .buildList();
         assertThatThrownBy(() -> store.initialise(partitionsUpdate))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void shouldRefuseEmptyInitialiseThatChangesPartitions() {
+        // Given
+        Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
+        List<Partition> partitionsInit = new PartitionsBuilder(schema)
+                .leavesWithSplits(Arrays.asList("left", "right"), Collections.singletonList("aaa"))
+                .parentJoining("root", "left", "right")
+                .buildList();
+        PartitionStore store = new FixedPartitionStore(partitionsInit);
+
+        // When / Then
+        assertThatThrownBy(store::initialise)
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/java/statestore/src/test/java/sleeper/statestore/inmemory/StateStoreTestHelper.java
+++ b/java/statestore/src/test/java/sleeper/statestore/inmemory/StateStoreTestHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.statestore.inmemory;
+
+import sleeper.core.partition.Partition;
+import sleeper.core.schema.Schema;
+import sleeper.statestore.DelegatingStateStore;
+import sleeper.statestore.StateStore;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StateStoreTestHelper {
+
+    public static StateStore inMemoryStateStoreWithFixedPartitions(Partition... partitions) {
+        return inMemoryStateStoreWithFixedPartitions(Arrays.asList(partitions));
+    }
+
+    public static StateStore inMemoryStateStoreWithFixedPartitions(List<Partition> partitions) {
+        return new DelegatingStateStore(new InMemoryFileInfoStore(), new FixedPartitionStore(partitions));
+    }
+
+    public static StateStore inMemoryStateStoreWithFixedSinglePartition(Schema schema) {
+        return new DelegatingStateStore(new InMemoryFileInfoStore(), new FixedPartitionStore(schema));
+    }
+}

--- a/java/statestore/src/test/java/sleeper/statestore/inmemory/StateStoreTestHelper.java
+++ b/java/statestore/src/test/java/sleeper/statestore/inmemory/StateStoreTestHelper.java
@@ -25,6 +25,9 @@ import java.util.List;
 
 public class StateStoreTestHelper {
 
+    private StateStoreTestHelper() {
+    }
+
     public static StateStore inMemoryStateStoreWithFixedPartitions(Partition... partitions) {
         return inMemoryStateStoreWithFixedPartitions(Arrays.asList(partitions));
     }


### PR DESCRIPTION
Resolves #431 

Also stopped IngestCoordinator clearing thread interrupted state incorrectly.

Simplified FixedPartitionStore a bit, and standardised test code for setting it up.