### PR TITLE
Issue 585 - Declare dependencies in built Maven artifacts

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -499,6 +499,7 @@
                             <configuration>
                                 <shadedArtifactAttached>true</shadedArtifactAttached>
                                 <shadedClassifierName>utility</shadedClassifierName>
+                                <createDependencyReducedPom>false</createDependencyReducedPom>
                                 <artifactSet>
                                     <excludes>
                                     </excludes>


### PR DESCRIPTION
Resolves #585

The maven-shade-plugin was generating a dependency-reduced pom which only had the dependencies that are not included in the fat jar. We have configuration to only attach the fat jar rather than replace it in the main Maven artifact, but it was still replacing the pom. That's disabled now.