### PR TITLE
Issue 555 - Limit task ID count to 100 for each DescribeTaskRequest

### DIFF
--- a/scripts/test/compactionPerformance/system-test-instance.properties
+++ b/scripts/test/compactionPerformance/system-test-instance.properties
@@ -231,13 +231,13 @@ sleeper.ingest.task.status.ttl=604800
 # 'Direct' means that the data is written directly. 'Queue' means that the data
 # is written to a Parquet file and an ingest job is created and posted to the
 # ingest queue.
-sleeper.systemtest.ingest.mode=queue
+sleeper.systemtest.ingest.mode=direct
 
 # The number of containers that write random data
-sleeper.systemtest.writers=11
+sleeper.systemtest.writers=110
 
 # The number of random records that each container should write
-sleeper.systemtest.records-per-writer=40000000
+sleeper.systemtest.records-per-writer=4000000
 
 # The amount of CPU and memory for the containers that write random data
 sleeper.systemtest.task.cpu=1024


### PR DESCRIPTION
Resolves #555 