### PR TITLE
S3A readahead property now set on query lambdas

### DIFF
--- a/java/athena/src/main/java/sleeper/athena/record/SleeperRecordHandler.java
+++ b/java/athena/src/main/java/sleeper/athena/record/SleeperRecordHandler.java
@@ -63,7 +63,7 @@ public abstract class SleeperRecordHandler extends RecordHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(SleeperRecordHandler.class);
 
     private final TablePropertiesProvider tablePropertiesProvider;
-    protected final InstanceProperties instanceProperties;
+    private final InstanceProperties instanceProperties;
 
     public SleeperRecordHandler() throws IOException {
         this(AmazonS3ClientBuilder.defaultClient(), System.getenv(CONFIG_BUCKET.toEnvironmentVariable()));

--- a/java/clients/src/main/java/sleeper/clients/QueryClient.java
+++ b/java/clients/src/main/java/sleeper/clients/QueryClient.java
@@ -69,7 +69,7 @@ public class QueryClient extends QueryCommandLineClient {
     @Override
     protected void init(TableProperties tableProperties) throws StateStoreException {
         String tableName = tableProperties.get(TABLE_NAME);
-        Configuration conf = HadoopConfigurationProvider.getConfigurationForQueryLambdas(getInstanceProperties());
+        Configuration conf = HadoopConfigurationProvider.getConfigurationForQueryLambdas(getInstanceProperties(), tableProperties);
         conf.set("fs.s3a.aws.credentials.provider", DefaultAWSCredentialsProviderChain.class.getName());
 
         StateStore stateStore = stateStoreProvider.getStateStore(tableProperties);

--- a/java/parquet/src/main/java/sleeper/utils/HadoopConfigurationProvider.java
+++ b/java/parquet/src/main/java/sleeper/utils/HadoopConfigurationProvider.java
@@ -18,7 +18,9 @@ package sleeper.utils;
 import org.apache.hadoop.conf.Configuration;
 
 import sleeper.configuration.properties.InstanceProperties;
+import sleeper.configuration.properties.table.TableProperties;
 
+import static sleeper.configuration.properties.table.TableProperty.S3A_READAHEAD_RANGE;
 import static sleeper.configuration.properties.UserDefinedInstanceProperty.MAXIMUM_CONNECTIONS_TO_S3;
 import static sleeper.configuration.properties.UserDefinedInstanceProperty.MAXIMUM_CONNECTIONS_TO_S3_FOR_QUERIES;
 
@@ -33,9 +35,10 @@ public class HadoopConfigurationProvider {
         return conf;
     }
 
-    public static Configuration getConfigurationForQueryLambdas(InstanceProperties instanceProperties) {
+    public static Configuration getConfigurationForQueryLambdas(InstanceProperties instanceProperties, TableProperties tableProperties) {
         Configuration conf = new Configuration();
         conf.set("fs.s3a.connection.maximum", instanceProperties.get(MAXIMUM_CONNECTIONS_TO_S3_FOR_QUERIES));
+        conf.set("fs.s3a.readahead.range", tableProperties.get(S3A_READAHEAD_RANGE));
         return conf;
     }
 

--- a/java/parquet/src/main/java/sleeper/utils/HadoopConfigurationProvider.java
+++ b/java/parquet/src/main/java/sleeper/utils/HadoopConfigurationProvider.java
@@ -20,9 +20,9 @@ import org.apache.hadoop.conf.Configuration;
 import sleeper.configuration.properties.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 
-import static sleeper.configuration.properties.table.TableProperty.S3A_READAHEAD_RANGE;
 import static sleeper.configuration.properties.UserDefinedInstanceProperty.MAXIMUM_CONNECTIONS_TO_S3;
 import static sleeper.configuration.properties.UserDefinedInstanceProperty.MAXIMUM_CONNECTIONS_TO_S3_FOR_QUERIES;
+import static sleeper.configuration.properties.table.TableProperty.S3A_READAHEAD_RANGE;
 
 public class HadoopConfigurationProvider {
 

--- a/java/query/src/main/java/sleeper/query/executor/QueryExecutor.java
+++ b/java/query/src/main/java/sleeper/query/executor/QueryExecutor.java
@@ -266,8 +266,4 @@ public class QueryExecutor {
         }
         return files;
     }
-
-    public Configuration getConfiguration() {
-        return configuration;
-    }
 }

--- a/java/query/src/main/java/sleeper/query/executor/QueryExecutor.java
+++ b/java/query/src/main/java/sleeper/query/executor/QueryExecutor.java
@@ -266,4 +266,8 @@ public class QueryExecutor {
         }
         return files;
     }
+
+    public Configuration getConfiguration() {
+        return configuration;
+    }
 }

--- a/java/query/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
+++ b/java/query/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
@@ -62,7 +62,6 @@ import static sleeper.configuration.properties.UserDefinedInstanceProperty.QUERY
 
 public class SqsQueryProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqsQueryProcessorLambda.class);
-
     private static final UserDefinedInstanceProperty EXECUTOR_POOL_THREADS = QUERY_PROCESSOR_LAMBDA_RECORD_RETRIEVAL_THREADS;
 
     private final ExecutorService executorService;
@@ -71,19 +70,21 @@ public class SqsQueryProcessor {
     private final TablePropertiesProvider tablePropertiesProvider;
     private final StateStoreProvider stateStoreProvider;
     private final ObjectFactory objectFactory;
-    private final Configuration queryConfiguration;
     private final DynamoDBQueryTracker queryTracker;
     private final Map<String, QueryExecutor> queryExecutorCache = new HashMap<>();
+    private final Map<String, Configuration> configurationCache = new HashMap<>();
 
     private SqsQueryProcessor(Builder builder) throws ObjectFactoryException {
         sqsClient = builder.sqsClient;
         instanceProperties = builder.instanceProperties;
         tablePropertiesProvider = builder.tablePropertiesProvider;
         executorService = Executors.newFixedThreadPool(instanceProperties.getInt(EXECUTOR_POOL_THREADS));
-        queryConfiguration = HadoopConfigurationProvider.getConfigurationForQueryLambdas(instanceProperties);
         objectFactory = new ObjectFactory(instanceProperties, builder.s3Client, "/tmp");
         queryTracker = new DynamoDBQueryTracker(instanceProperties, builder.dynamoClient);
-        stateStoreProvider = new StateStoreProvider(builder.dynamoClient, instanceProperties, queryConfiguration);
+        // The following Configuration is only used in StateStoreProvider for reading from S3 if the S3StateStore is used,
+        // so use the standard Configuration rather than the one for query lambdas which is specific to the table.
+        Configuration confForStateStore = HadoopConfigurationProvider.getConfigurationForLambdas(instanceProperties);
+        stateStoreProvider = new StateStoreProvider(builder.dynamoClient, instanceProperties, confForStateStore);
     }
 
     public static Builder builder() {
@@ -98,7 +99,7 @@ public class SqsQueryProcessor {
         try {
             queryTrackers.queryInProgress(query);
             if (query instanceof LeafPartitionQuery) {
-                results = processLeafPartitionQuery((LeafPartitionQuery) query, tablePropertiesProvider.getTableProperties(query.getTableName()));
+                results = processLeafPartitionQuery((LeafPartitionQuery) query);
             } else {
                 results = processRangeQuery(query, queryTrackers);
             }
@@ -116,7 +117,8 @@ public class SqsQueryProcessor {
         if (!queryExecutorCache.containsKey(query.getTableName())) {
             TableProperties tableProperties = tablePropertiesProvider.getTableProperties(query.getTableName());
             StateStore stateStore = stateStoreProvider.getStateStore(tableProperties);
-            QueryExecutor queryExecutor = new QueryExecutor(objectFactory, tableProperties, stateStore, queryConfiguration, executorService);
+            Configuration conf = getConfiguration(query.getTableName(), tableProperties);
+            QueryExecutor queryExecutor = new QueryExecutor(objectFactory, tableProperties, stateStore, conf, executorService);
             queryExecutor.init();
             queryExecutorCache.put(query.getTableName(), queryExecutor);
         }
@@ -147,10 +149,19 @@ public class SqsQueryProcessor {
         }
     }
 
-    private CloseableIterator<Record> processLeafPartitionQuery(LeafPartitionQuery leafPartitionQuery, TableProperties tableProperties)
-            throws QueryException {
-        LeafPartitionQueryExecutor leafPartitionQueryExecutor = new LeafPartitionQueryExecutor(executorService, objectFactory, queryConfiguration, tableProperties);
+    private CloseableIterator<Record> processLeafPartitionQuery(LeafPartitionQuery leafPartitionQuery) throws QueryException {
+        TableProperties tableProperties = tablePropertiesProvider.getTableProperties(leafPartitionQuery.getTableName());
+        Configuration conf = getConfiguration(leafPartitionQuery.getTableName(), tableProperties);
+        LeafPartitionQueryExecutor leafPartitionQueryExecutor = new LeafPartitionQueryExecutor(executorService, objectFactory, conf, tableProperties);
         return leafPartitionQueryExecutor.getRecords(leafPartitionQuery);
+    }
+
+    private Configuration getConfiguration(String tableName, TableProperties tableProperties) {
+        if (!configurationCache.containsKey(tableName)) {
+            Configuration conf = HadoopConfigurationProvider.getConfigurationForQueryLambdas(instanceProperties, tableProperties);
+            configurationCache.put(tableName, conf);
+        }
+        return configurationCache.get(tableName);
     }
 
     private void publishResults(CloseableIterator<Record> results, Query query, QueryStatusReportListeners queryTrackers) {


### PR DESCRIPTION
Resolves https://github.com/gchq/sleeper/issues/668

Note: there is a need for a unit test for HadoopConfigurationProvider - this is covered in https://github.com/gchq/sleeper/issues/673