### PR TITLE
Issue 745 - Refactor tests for how bulk import jobs are started

### DIFF
--- a/java/bulk-import/bulk-import-starter/pom.xml
+++ b/java/bulk-import/bulk-import-starter/pom.xml
@@ -61,6 +61,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>sleeper</groupId>
+            <artifactId>configuration</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/ExecutorIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/ExecutorIT.java
@@ -41,7 +41,7 @@ import static sleeper.configuration.properties.SystemDefinedInstanceProperty.BUL
 import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
 
 @Testcontainers
-public class ExecutorTest {
+class ExecutorIT {
 
     @Container
     public static LocalStackContainer localStackContainer = new LocalStackContainer(DockerImageName.parse(CommonTestConstants.LOCALSTACK_DOCKER_IMAGE))
@@ -57,7 +57,7 @@ public class ExecutorTest {
     private static final Schema SCHEMA = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
 
     @Test
-    public void shouldCallRunOnPlatformIfJobIsValid() {
+    void shouldCallRunOnPlatformIfJobIsValid() {
         // Given
         AmazonS3 s3 = createS3Client();
         String bucketName = UUID.randomUUID().toString();
@@ -84,7 +84,7 @@ public class ExecutorTest {
     }
 
     @Test
-    public void shouldFailIfFileListIsEmpty() {
+    void shouldFailIfFileListIsEmpty() {
         // Given
         AmazonS3 s3 = createS3Client();
         String bucketName = UUID.randomUUID().toString();
@@ -107,7 +107,7 @@ public class ExecutorTest {
     }
 
     @Test
-    public void shouldSucceedIfS3ObjectIsADirectoryContainingFiles() {
+    void shouldSucceedIfS3ObjectIsADirectoryContainingFiles() {
         // Given
         AmazonS3 s3 = createS3Client();
         String bucketName = UUID.randomUUID().toString();
@@ -132,7 +132,7 @@ public class ExecutorTest {
     }
 
     @Test
-    public void shouldFailIfJobPointsAtNonExistentTable() {
+    void shouldFailIfJobPointsAtNonExistentTable() {
         // Given
         AmazonS3 s3 = createS3Client();
         String bucketName = UUID.randomUUID().toString();
@@ -155,7 +155,7 @@ public class ExecutorTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfJobIdContainsMoreThan63Characters() {
+    void shouldThrowExceptionIfJobIdContainsMoreThan63Characters() {
         // Given
         String invalidId = UUID.randomUUID().toString() + UUID.randomUUID();
         BulkImportJob importJob = new BulkImportJob.Builder()
@@ -173,7 +173,7 @@ public class ExecutorTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfTableNameIsNull() {
+    void shouldThrowExceptionIfTableNameIsNull() {
         // Given
         BulkImportJob importJob = new BulkImportJob.Builder()
                 .id("my-job")
@@ -189,7 +189,7 @@ public class ExecutorTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfJobIdContainsUppercaseLetters() {
+    void shouldThrowExceptionIfJobIdContainsUppercaseLetters() {
         // Given
         BulkImportJob importJob = new BulkImportJob.Builder()
                 .tableName("myTable")
@@ -206,7 +206,7 @@ public class ExecutorTest {
     }
 
     @Test
-    public void shouldDoNothingWhenJobIsNull() {
+    void shouldDoNothingWhenJobIsNull() {
         // Given
         ExecutorMock executorMock = new ExecutorMock(new InstanceProperties(), null, null);
 

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/ExecutorIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/ExecutorIT.java
@@ -26,6 +26,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import sleeper.bulkimport.job.BulkImportJob;
 import sleeper.configuration.properties.InstanceProperties;
+import sleeper.configuration.properties.table.FixedTablePropertiesProvider;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.CommonTestConstants;
@@ -38,7 +39,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.configuration.properties.SystemDefinedInstanceProperty.BULK_IMPORT_BUCKET;
-import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
+import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
 @Testcontainers
 class ExecutorIT {
@@ -70,10 +71,7 @@ class ExecutorIT {
                 .id("my-job")
                 .files(Lists.newArrayList(bucketName + "/file1.parquet", bucketName + "/file2.parquet", bucketName + "/directory/file3.parquet"))
                 .build();
-        TablePropertiesProvider tablePropertiesProvider = new TestTablePropertiesProvider(SCHEMA);
-        InstanceProperties instanceProperties = new InstanceProperties();
-        instanceProperties.set(BULK_IMPORT_BUCKET, bucketName);
-        ExecutorMock executorMock = new ExecutorMock(instanceProperties, tablePropertiesProvider, s3);
+        ExecutorMock executorMock = buildExecutorWithBulkImportBucketAndTable(bucketName, "myTable", s3);
 
         // When
         executorMock.runJob(importJob);
@@ -94,10 +92,7 @@ class ExecutorIT {
                 .id("my-job")
                 .files(Lists.newArrayList())
                 .build();
-        TablePropertiesProvider tablePropertiesProvider = new TestTablePropertiesProvider(SCHEMA);
-        InstanceProperties instanceProperties = new InstanceProperties();
-        instanceProperties.set(BULK_IMPORT_BUCKET, bucketName);
-        ExecutorMock executorMock = new ExecutorMock(instanceProperties, tablePropertiesProvider, s3);
+        ExecutorMock executorMock = buildExecutorWithBulkImportBucketAndTable(bucketName, "myTable", s3);
 
         // When
         assertThatThrownBy(() -> executorMock.runJob(importJob))
@@ -118,10 +113,7 @@ class ExecutorIT {
                 .id("my-job")
                 .files(Lists.newArrayList(bucketName + "/directory", bucketName + "/directory/"))
                 .build();
-        TablePropertiesProvider tablePropertiesProvider = new TestTablePropertiesProvider(SCHEMA);
-        InstanceProperties instanceProperties = new InstanceProperties();
-        instanceProperties.set(BULK_IMPORT_BUCKET, bucketName);
-        ExecutorMock executorMock = new ExecutorMock(instanceProperties, tablePropertiesProvider, s3);
+        ExecutorMock executorMock = buildExecutorWithBulkImportBucketAndTable(bucketName, "myTable", s3);
 
         // When
         executorMock.runJob(importJob);
@@ -142,10 +134,7 @@ class ExecutorIT {
                 .id("my-job")
                 .files(Lists.newArrayList("file1.parquet"))
                 .build();
-        TablePropertiesProvider tablePropertiesProvider = new TestTablePropertiesProvider(SCHEMA);
-        InstanceProperties instanceProperties = new InstanceProperties();
-        instanceProperties.set(BULK_IMPORT_BUCKET, bucketName);
-        ExecutorMock executorMock = new ExecutorMock(instanceProperties, tablePropertiesProvider, s3);
+        ExecutorMock executorMock = buildExecutorWithBulkImportBucketAndTable(bucketName, "myTable", s3);
 
         // When / Then
         assertThatThrownBy(() -> executorMock.runJob(importJob))
@@ -163,8 +152,7 @@ class ExecutorIT {
                 .files(Lists.newArrayList("file1.parquet"))
                 .id(invalidId)
                 .build();
-        TablePropertiesProvider tablePropertiesProvider = new TestTablePropertiesProvider(SCHEMA);
-        ExecutorMock executorMock = new ExecutorMock(new InstanceProperties(), tablePropertiesProvider, null);
+        ExecutorMock executorMock = buildExecutorWithTable("myTable");
 
         // When / Then
         assertThatThrownBy(() -> executorMock.runJob(importJob))
@@ -179,8 +167,7 @@ class ExecutorIT {
                 .id("my-job")
                 .files(Lists.newArrayList("file1.parquet"))
                 .build();
-        TablePropertiesProvider tablePropertiesProvider = new TestTablePropertiesProvider(SCHEMA);
-        ExecutorMock executorMock = new ExecutorMock(new InstanceProperties(), tablePropertiesProvider, null);
+        ExecutorMock executorMock = buildExecutorWithTable("myTable");
 
         // When / Then
         assertThatThrownBy(() -> executorMock.runJob(importJob))
@@ -196,8 +183,7 @@ class ExecutorIT {
                 .id("importJob")
                 .files(Lists.newArrayList("file1.parquet"))
                 .build();
-        TablePropertiesProvider tablePropertiesProvider = new TestTablePropertiesProvider(SCHEMA);
-        ExecutorMock executorMock = new ExecutorMock(new InstanceProperties(), tablePropertiesProvider, null);
+        ExecutorMock executorMock = buildExecutorWithTable("myTable");
 
         // When / Then
         assertThatThrownBy(() -> executorMock.runJob(importJob))
@@ -208,7 +194,7 @@ class ExecutorIT {
     @Test
     void shouldDoNothingWhenJobIsNull() {
         // Given
-        ExecutorMock executorMock = new ExecutorMock(new InstanceProperties(), null, null);
+        ExecutorMock executorMock = buildExecutorWithTable("myTable");
 
         // When
         executorMock.runJob(null);
@@ -220,6 +206,25 @@ class ExecutorIT {
     private String getExpectedErrorMessage(String message) {
         return "The bulk import job failed validation with the following checks failing: \n"
                 + message;
+    }
+
+    private ExecutorMock buildExecutorWithBulkImportBucketAndTable(String bucketName, String tableName, AmazonS3 s3) {
+        InstanceProperties instanceProperties = new InstanceProperties();
+        instanceProperties.set(BULK_IMPORT_BUCKET, bucketName);
+        TableProperties tableProperties = new TableProperties(instanceProperties);
+        tableProperties.set(TABLE_NAME, tableName);
+        tableProperties.setSchema(SCHEMA);
+        TablePropertiesProvider tablePropertiesProvider = new FixedTablePropertiesProvider(tableProperties);
+        return new ExecutorMock(instanceProperties, tablePropertiesProvider, s3);
+    }
+
+    private ExecutorMock buildExecutorWithTable(String tableName) {
+        InstanceProperties instanceProperties = new InstanceProperties();
+        TableProperties tableProperties = new TableProperties(instanceProperties);
+        tableProperties.set(TABLE_NAME, tableName);
+        tableProperties.setSchema(SCHEMA);
+        TablePropertiesProvider tablePropertiesProvider = new FixedTablePropertiesProvider(tableProperties);
+        return new ExecutorMock(instanceProperties, tablePropertiesProvider, null);
     }
 
     private static class ExecutorMock extends Executor {
@@ -246,29 +251,4 @@ class ExecutorIT {
         }
     }
 
-    private static class TestTablePropertiesProvider extends TablePropertiesProvider {
-        private final Schema schema;
-        private final long splitThreshold;
-
-        TestTablePropertiesProvider(Schema schema, long splitThreshold) {
-            super(null, null);
-            this.schema = schema;
-            this.splitThreshold = splitThreshold;
-        }
-
-        TestTablePropertiesProvider(Schema schema) {
-            this(schema, 1_000_000_000L);
-        }
-
-        @Override
-        public TableProperties getTableProperties(String tableName) {
-            if (tableName.equals("table-that-does-not-exist")) {
-                return null;
-            }
-            TableProperties tableProperties = new TableProperties(new InstanceProperties());
-            tableProperties.setSchema(schema);
-            tableProperties.set(PARTITION_SPLIT_THRESHOLD, "" + splitThreshold);
-            return tableProperties;
-        }
-    }
 }


### PR DESCRIPTION
Resolves #745.

We decided not to start the bulk import job in the executor (the Lambda that takes jobs off the queue and submits them to Spark). This will be picked up in https://github.com/gchq/sleeper/issues/746 instead.

We refactored the tests a little while we were looking through it.