### PR TITLE
Issue 949 - Update default EMR x86 instance types to m6i equivalents

### DIFF
--- a/docs/05-ingest.md
+++ b/docs/05-ingest.md
@@ -184,8 +184,8 @@ job specification:
   	"my-bucket/my-files/"
   ],
   "platformSpec": {
-  	"sleeper.table.bulk.import.emr.master.x86.instance.types": "m5.xlarge",
-  	"sleeper.table.bulk.import.emr.executor.x86.instance.types": "m5.4xlarge",
+  	"sleeper.table.bulk.import.emr.master.x86.instance.types": "m6i.xlarge",
+  	"sleeper.table.bulk.import.emr.executor.x86.instance.types": "m6i.4xlarge",
   	"sleeper.table.bulk.import.emr.executor.initial.instances": "2",
   	"sleeper.table.bulk.import.emr.executor.max.instances": "10"
   }
@@ -203,8 +203,8 @@ part of the job specification:
 
 ```properties
 sleeper.default.bulk.import.emr.release.label=emr-6.10.0 # The EMR release label to be used when creating an EMR cluster for bulk importing data using Spark running on EMR. This default can be overridden by a table property or by a property in the bulk import job specification.
-sleeper.default.bulk.import.emr.master.x86.instance.types=m5.xlarge # The EC2 x86_64 instance types to be used for the master node of the EMR cluster.
-sleeper.default.bulk.import.emr.executor.x86.instance.types=m5.4xlarge # The EC2 x86_64 instance types to be used for the executor nodes of the EMR cluster.
+sleeper.default.bulk.import.emr.master.x86.instance.types=m6i.xlarge # The EC2 x86_64 instance types to be used for the master node of the EMR cluster.
+sleeper.default.bulk.import.emr.executor.x86.instance.types=m6i.4xlarge # The EC2 x86_64 instance types to be used for the executor nodes of the EMR cluster.
 sleeper.default.bulk.import.emr.executor.initial.instances=2 # The initial number of EC2 instances to be used as executors in the EMR cluster.
 sleeper.default.bulk.import.emr.executor.max.instances=10 # The maximum number of EC2 instances to be used as executors in the EMR cluster.
 ```
@@ -215,8 +215,8 @@ by properties in the job specification.
 
 ```properties
 sleeper.table.bulk.import.emr.release.label=emr-6.10.0 # The EMR release label to be used when creating an EMR cluster for bulk importing data using Spark running on EMR. This value overrides the default value in the instance properties. It can be overridden by a value in the bulk import job specification.
-sleeper.table.bulk.import.emr.master.x86.instance.types=m5.xlarge # The EC2 instance types to be used for the master node of the EMR cluster. This value overrides the default value in the instance properties. It can be overridden by a value in the bulk import job specification.
-sleeper.table.bulk.import.emr.executor.x86.instance.types=m5.4xlarge # The EC2 instance types to be used for the executor nodes of the EMR cluster. This value overrides the default value in the instance properties. It can be overridden by a value in the bulk import job specification.
+sleeper.table.bulk.import.emr.master.x86.instance.types=m6i.xlarge # The EC2 instance types to be used for the master node of the EMR cluster. This value overrides the default value in the instance properties. It can be overridden by a value in the bulk import job specification.
+sleeper.table.bulk.import.emr.executor.x86.instance.types=m6i.4xlarge # The EC2 instance types to be used for the executor nodes of the EMR cluster. This value overrides the default value in the instance properties. It can be overridden by a value in the bulk import job specification.
 sleeper.table.bulk.import.emr.executor.initial.instances=2 # The initial number of EC2 instances to be used as executors in the EMR cluster. This value overrides the default value in the instance properties. It can be overridden by a value in the bulk import job specification.
 sleeper.table.bulk.import.emr.executor.max.instances=10 # The maximum number of EC2 instances to be used as executors in the EMR cluster. This value overrides the default value in the instance properties. It can be overridden by a value in the bulk import job specification.
 ```
@@ -225,10 +225,10 @@ You can define the default instance types that the master node and executor node
 properties. Each property can also be overridden in the table properties or in the bulk import job specification as demonstrated above.
 ```properties
 # The following properties are specific to x86_64 instance types
-sleeper.default.bulk.import.emr.master.x86.instance.types=m5.xlarge # The EC2 x86_64 instance types to be used for the master node of the EMR cluster.
-sleeper.default.bulk.import.emr.executor.x86.instance.types=m5.4xlarge # The EC2 x86_64 instance types to be used for the executor nodes of the EMR cluster.
-sleeper.default.bulk.import.persistent.emr.master.x86.instance.types=m5.xlarge # The EC2 x86_64 instance types to be used for the master node of the EMR cluster.
-sleeper.default.bulk.import.persistent.emr.executor.x86.instance.types=m5.4xlarge # The EC2 x86_64 instance types to be used for the executor nodes of the EMR cluster.
+sleeper.default.bulk.import.emr.master.x86.instance.types=m6i.xlarge # The EC2 x86_64 instance types to be used for the master node of the EMR cluster.
+sleeper.default.bulk.import.emr.executor.x86.instance.types=m6i.4xlarge # The EC2 x86_64 instance types to be used for the executor nodes of the EMR cluster.
+sleeper.default.bulk.import.persistent.emr.master.x86.instance.types=m6i.xlarge # The EC2 x86_64 instance types to be used for the master node of the EMR cluster.
+sleeper.default.bulk.import.persistent.emr.executor.x86.instance.types=m6i.4xlarge # The EC2 x86_64 instance types to be used for the executor nodes of the EMR cluster.
 
 # The following properties are specific to ARM64 instance types
 sleeper.default.bulk.import.emr.master.arm.instance.types=m6g.xlarge # The EC2 ARM64 instance types to be used for the master node of the EMR cluster.
@@ -244,11 +244,11 @@ after the instance type in this comma separated list. This must be a whole numbe
 
 For example:
 ```properties
-sleeper.default.bulk.import.emr.executor.x86.instance.types=m5.4xlarge,4,m5.xlarge
+sleeper.default.bulk.import.emr.executor.x86.instance.types=m6i.4xlarge,4,m6i.xlarge
 ```
-The above configuration would tell EMR that an m5.4xlarge instance would provide 4 times the capacity of an m5.xlarge instance. 
-The m5.xlarge instance type does not have a weight, so is defaulted to 1. In this example, if you set the 
-initial executor capacity to 3, EMR could fulfil that with one instance of m5.4xlarge, or 3 instances of m5.xlarge.
+The above configuration would tell EMR that an m6i.4xlarge instance would provide 4 times the capacity of an m6i.xlarge instance. 
+The m6i.xlarge instance type does not have a weight, so is defaulted to 1. In this example, if you set the 
+initial executor capacity to 3, EMR could fulfil that with one instance of m6i.4xlarge, or 3 instances of m6i.xlarge.
 
 More information about instance fleet options can be found [here](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-fleet.html#emr-instance-fleet-options)
 
@@ -265,8 +265,8 @@ The other properties of the cluster are controlled using similar properties to t
 
 ```properties
 sleeper.bulk.import.persistent.emr.release.label=emr-6.10.0
-sleeper.bulk.import.persistent.emr.master.x86.instance.types=m5.xlarge
-sleeper.bulk.import.persistent.emr.executor.x86.instance.types=m5.4xlarge
+sleeper.bulk.import.persistent.emr.master.x86.instance.types=m6i.xlarge
+sleeper.bulk.import.persistent.emr.executor.x86.instance.types=m6i.4xlarge
 sleeper.bulk.import.persistent.emr.use.managed.scaling=true
 sleeper.bulk.import.persistent.emr.min.instances=1
 sleeper.bulk.import.persistent.emr.max.instances=10
@@ -349,13 +349,13 @@ a to z. The sort key is a random long in the range 0 to 10,000,000,000. The reco
 
 The table was pre-split into 256 partitions.
 
-A persistent EMR cluster consisting of 10 core nodes of instance type m5.4xlarge and a master of type m5.xlarge was created by setting the
+A persistent EMR cluster consisting of 10 core nodes of instance type m6i.4xlarge and a master of type m6i.xlarge was created by setting the
 following instance properties:
 
 ```properties
 sleeper.bulk.import.persistent.emr.release.label=emr-6.10.0
-sleeper.bulk.import.persistent.emr.master.x86.instance.types=m5.xlarge
-sleeper.bulk.import.persistent.emr.executor.x86.instance.types=m5.4xlarge
+sleeper.bulk.import.persistent.emr.master.x86.instance.types=m6i.xlarge
+sleeper.bulk.import.persistent.emr.executor.x86.instance.types=m6i.4xlarge
 sleeper.bulk.import.persistent.emr.use.managed.scaling=false
 sleeper.bulk.import.persistent.emr.min.instances=10
 sleeper.bulk.import.persistent.emr.step.concurrency.level=2

--- a/docs/08-python-api.md
+++ b/docs/08-python-api.md
@@ -94,8 +94,8 @@ platform_spec = {
     "sleeper.table.bulk.import.emr.executor.initial.instances": "1",
     "sleeper.table.bulk.import.emr.executor.max.instances": "10",
     "sleeper.table.bulk.import.emr.release.label": "emr-6.10.0",
-    "sleeper.table.bulk.import.emr.master.x86.instance.type": "m5.xlarge",
-    "sleeper.table.bulk.import.emr.executor.x86.instance.type": "m5.4xlarge",
+    "sleeper.table.bulk.import.emr.master.x86.instance.type": "m6i.xlarge",
+    "sleeper.table.bulk.import.emr.executor.x86.instance.type": "m6i.4xlarge",
     "sleeper.table.bulk.import.emr.executor.market.type": "SPOT" // Use "ON_DEMAND" for on demand instances
 }
 

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -383,12 +383,12 @@ sleeper.default.bulk.import.emr.release.label=emr-6.10.0
 # (Non-persistent EMR mode only) The default EC2 x86 instance types to be used for the master node of
 # the EMR cluster. For more information, see the Bulk import using EMR - Instance types section in
 # docs/05-ingest.md
-sleeper.default.bulk.import.emr.master.x86.instance.types=m5.xlarge
+sleeper.default.bulk.import.emr.master.x86.instance.types=m6i.xlarge
 
 # (Non-persistent EMR mode only) The default EC2 x86_64 instance types to be used for the executor
 # nodes of the EMR cluster. For more information, see the Bulk import using EMR - Instance types
 # section in docs/05-ingest.md
-sleeper.default.bulk.import.emr.executor.x86.instance.types=m5.4xlarge
+sleeper.default.bulk.import.emr.executor.x86.instance.types=m6i.4xlarge
 
 # (Non-persistent EMR mode only) The default EC2 ARM64 instance types to be used for the master node
 # of the EMR cluster. For more information, see the Bulk import using EMR - Instance types section in
@@ -431,7 +431,7 @@ sleeper.bulk.import.persistent.emr.release.label=emr-6.10.0
 # (Persistent EMR mode only) The EC2 x86 instance types used for the master node of the persistent EMR
 # cluster. For more information, see the Bulk import using EMR - Instance types section in
 # docs/05-ingest.md
-sleeper.bulk.import.persistent.emr.master.x86.instance.types=m5.xlarge
+sleeper.bulk.import.persistent.emr.master.x86.instance.types=m6i.xlarge
 
 # (Persistent EMR mode only) The EC2 x86 instance types used for the executor nodes of the persistent
 # EMR cluster. For more information, see the Bulk import using EMR - Instance types section in

--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -124,12 +124,12 @@ sleeper.table.metadata.s3.dynamo.pointintimerecovery=false
 # (Non-persistent EMR mode only) The EC2 x86_64 instance types to be used for the master node of the
 # EMR cluster. For more information, see the Bulk import using EMR - Instance types section in
 # docs/05-ingest.md
-sleeper.table.bulk.import.emr.master.x86.instance.types=m5.xlarge
+sleeper.table.bulk.import.emr.master.x86.instance.types=m6i.xlarge
 
 # (Non-persistent EMR mode only) The EC2 x86_64 instance types to be used for the executor nodes of
 # the EMR cluster. For more information, see the Bulk import using EMR - Instance types section in
 # docs/05-ingest.md
-sleeper.table.bulk.import.emr.executor.x86.instance.types=m5.4xlarge
+sleeper.table.bulk.import.emr.executor.x86.instance.types=m6i.4xlarge
 
 # (Non-persistent EMR mode only) The EC2 ARM64 instance types to be used for the master node of the
 # EMR cluster. For more information, see the Bulk import using EMR - Instance types section in

--- a/java/configuration/src/main/java/sleeper/configuration/properties/UserDefinedInstanceProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/UserDefinedInstanceProperty.java
@@ -386,7 +386,7 @@ public interface UserDefinedInstanceProperty extends InstanceProperty {
     //          same which allows the following properties to be used across both types):
     //      - Theses are based on this blog
     //      https://aws.amazon.com/blogs/big-data/best-practices-for-successfully-managing-memory-for-apache-spark-applications-on-amazon-emr/
-    //      - Our default core/task instance type is m5.4xlarge. These have 64GB of RAM and 16 vCPU. The amount of
+    //      - Our default core/task instance type is m6i.4xlarge. These have 64GB of RAM and 16 vCPU. The amount of
     //          usable RAM is 56GB.
     //      - The recommended value of spark.executor.cores is 5, irrespective of the number of servers or their specs.
     //      - Number of executors per instance = (number of vCPU per instance - 1) / spark.executors.cores = (16 - 1) / 5 = 3
@@ -582,13 +582,13 @@ public interface UserDefinedInstanceProperty extends InstanceProperty {
             .description("(Non-persistent EMR mode only) The default EC2 x86 instance types to be used for the master " +
                     "node of the EMR cluster. " +
                     "For more information, see the Bulk import using EMR - Instance types section in docs/05-ingest.md")
-            .defaultValue("m5.xlarge")
+            .defaultValue("m6i.xlarge")
             .propertyGroup(InstancePropertyGroup.BULK_IMPORT).build();
     UserDefinedInstanceProperty DEFAULT_BULK_IMPORT_EMR_EXECUTOR_X86_INSTANCE_TYPES = Index.propertyBuilder("sleeper.default.bulk.import.emr.executor.x86.instance.types")
             .description("(Non-persistent EMR mode only) The default EC2 x86_64 instance types to be used for the executor " +
                     "nodes of the EMR cluster. " +
                     "For more information, see the Bulk import using EMR - Instance types section in docs/05-ingest.md")
-            .defaultValue("m5.4xlarge")
+            .defaultValue("m6i.4xlarge")
             .propertyGroup(InstancePropertyGroup.BULK_IMPORT).build();
     UserDefinedInstanceProperty DEFAULT_BULK_IMPORT_EMR_MASTER_ARM_INSTANCE_TYPES = Index.propertyBuilder("sleeper.default.bulk.import.emr.master.arm.instance.types")
             .description("(Non-persistent EMR mode only) The default EC2 ARM64 instance types to be used for the master " +

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -416,12 +416,12 @@ sleeper.default.bulk.import.emr.release.label=emr-6.10.0
 # (Non-persistent EMR mode only) The default EC2 x86 instance types to be used for the master node of
 # the EMR cluster. For more information, see the Bulk import using EMR - Instance types section in
 # docs/05-ingest.md
-sleeper.default.bulk.import.emr.master.x86.instance.types=m5.xlarge
+sleeper.default.bulk.import.emr.master.x86.instance.types=m6i.xlarge
 
 # (Non-persistent EMR mode only) The default EC2 x86_64 instance types to be used for the executor
 # nodes of the EMR cluster. For more information, see the Bulk import using EMR - Instance types
 # section in docs/05-ingest.md
-sleeper.default.bulk.import.emr.executor.x86.instance.types=m5.4xlarge
+sleeper.default.bulk.import.emr.executor.x86.instance.types=m6i.4xlarge
 
 # (Non-persistent EMR mode only) The default EC2 ARM64 instance types to be used for the master node
 # of the EMR cluster. For more information, see the Bulk import using EMR - Instance types section in
@@ -464,7 +464,7 @@ sleeper.bulk.import.persistent.emr.release.label=emr-6.10.0
 # (Persistent EMR mode only) The EC2 x86 instance types used for the master node of the persistent EMR
 # cluster. For more information, see the Bulk import using EMR - Instance types section in
 # docs/05-ingest.md
-sleeper.bulk.import.persistent.emr.master.x86.instance.types=m5.xlarge
+sleeper.bulk.import.persistent.emr.master.x86.instance.types=m6i.xlarge
 
 # (Persistent EMR mode only) The EC2 x86 instance types used for the executor nodes of the persistent
 # EMR cluster. For more information, see the Bulk import using EMR - Instance types section in


### PR DESCRIPTION
Resolves #949 