### PR TITLE
Issue 1040 - Use CDK parameters when only one is given for destroy

### DIFF
--- a/scripts/cli/environment/scripts/subcommands/destroy.sh
+++ b/scripts/cli/environment/scripts/subcommands/destroy.sh
@@ -23,7 +23,7 @@ fi
 ENVIRONMENT_ID=$1
 shift
 
-if [ "$#" -lt 2 ]; then
+if [ "$#" -lt 1 ]; then
   CDK_PARAMS=("--all")
   DELETE_ENVIRONMENT_DIR=true
 else


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1040

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
  - Same as change in https://github.com/gchq/sleeper/pull/1029

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
