### PR TITLE
Issue 1033 - Use logger in ReinitialiseTable instead of System.out

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
@@ -29,6 +29,8 @@ import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
@@ -64,6 +66,7 @@ import static sleeper.statestore.s3.S3StateStore.REVISION_ID_KEY;
  * is reinitialised.
  */
 public class ReinitialiseTable {
+    private static final java.util.logging.Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTable.class);
     private final AmazonS3 s3Client;
     private final AmazonDynamoDB dynamoDBClient;
     private final boolean deletePartitions;
@@ -102,17 +105,17 @@ public class ReinitialiseTable {
 
         boolean isS3StateStore = false;
         if (tableProperties.get(STATESTORE_CLASSNAME).equals("sleeper.statestore.s3.S3StateStore")) {
-            System.out.println("S3 State Store detected");
+            LOGGER.fine("S3 State Store detected");
             isS3StateStore = true;
         } else {
-            System.out.println("Dynamo DB State Store detected");
+            LOGGER.fine("Dynamo DB State Store detected");
         }
 
         if (deletePartitions) {
             deleteContentsOfDynamoDbTables(tableProperties, isS3StateStore);
             deleteObjectsInTableBucket(s3TableBucketName, isS3StateStore);
 
-            System.out.println("Fully reinitialising table");
+            LOGGER.fine("Fully reinitialising table");
             StateStore statestore = new StateStoreFactory(dynamoDBClient, instanceProperties, conf)
                     .getStateStore(tableProperties);
             initialiseStateStore(tableProperties, statestore);
@@ -120,7 +123,7 @@ public class ReinitialiseTable {
             deleteContentsOfDynamoDbTables(tableProperties, isS3StateStore);
             deleteObjectsInTableBucket(s3TableBucketName, isS3StateStore);
             if (isS3StateStore) {
-                System.out.println("Recreating files information file and adding it into the revisions table");
+                LOGGER.fine("Recreating files information file and adding it into the revisions table");
                 S3StateStore s3StateStore = new S3StateStore(instanceProperties, tableProperties,
                         dynamoDBClient, conf);
                 s3StateStore.setInitialFileInfos();
@@ -139,7 +142,7 @@ public class ReinitialiseTable {
                 .withMaxKeys(100);
         ListObjectsV2Result result;
 
-        System.out.println("Deleting all objects within partitions in the table's bucket");
+        LOGGER.fine("Deleting all objects within partitions in the table's bucket");
         int totalObjectsDeleted = 0;
         do {
             objectKeysForDeletion.clear();
@@ -161,7 +164,7 @@ public class ReinitialiseTable {
             req.setContinuationToken(token);
             totalObjectsDeleted += deleteObjects(s3TableBucketName, objectKeysForDeletion);
         } while (result.isTruncated());
-        System.out.println("A total of " + totalObjectsDeleted + " objects were deleted");
+        LOGGER.fine("A total of " + totalObjectsDeleted + " objects were deleted");
     }
 
     private int deleteObjects(String bucketName, List<String> keys) {
@@ -172,7 +175,7 @@ public class ReinitialiseTable {
                     .withQuiet(false);
             DeleteObjectsResult delObjRes = s3Client.deleteObjects(multiObjectDeleteRequest);
             successfulDeletes = delObjRes.getDeletedObjects().size();
-            System.out.println(successfulDeletes + " objects successfully deleted from the "
+            LOGGER.fine(successfulDeletes + " objects successfully deleted from the "
                     + bucketName + " S3 bucket");
         }
         return successfulDeletes;
@@ -191,7 +194,7 @@ public class ReinitialiseTable {
     }
 
     private void deleteAllDynamoTableItems(String dynamoTableName, TableProperties tableProperties) {
-        System.out.println("Deleting all items from " + dynamoTableName + " Dynamo DB Table");
+        LOGGER.fine("Deleting all items from " + dynamoTableName + " Dynamo DB Table");
         long countOfDeletedItems = streamPagedItems(dynamoDBClient,
                 new ScanRequest()
                         .withTableName(dynamoTableName)
@@ -207,11 +210,11 @@ public class ReinitialiseTable {
                             new DeleteItemRequest(dynamoTableName, deleteKey));
                 }).count();
 
-        System.out.println(countOfDeletedItems + " items successfully deleted from " + dynamoTableName + " Dynamo DB Table");
+        LOGGER.fine(countOfDeletedItems + " items successfully deleted from " + dynamoTableName + " Dynamo DB Table");
     }
 
     private void deleteRelevantS3StateStoreRevisionInfo(String dynamoTableName) {
-        System.out.println("Deleting files info items from " + dynamoTableName + " Dynamo DB Table");
+        LOGGER.fine("Deleting files info items from " + dynamoTableName + " Dynamo DB Table");
         long countOfDeletedItems = streamPagedItems(dynamoDBClient,
                 new ScanRequest()
                         .withTableName(dynamoTableName)
@@ -224,7 +227,7 @@ public class ReinitialiseTable {
                                 Collections.singletonMap(REVISION_ID_KEY, item.get(REVISION_ID_KEY)))))
                 .count();
 
-        System.out.println(countOfDeletedItems + " items successfully deleted from " + dynamoTableName + " Dynamo DB Table");
+        LOGGER.fine(countOfDeletedItems + " items successfully deleted from " + dynamoTableName + " Dynamo DB Table");
     }
 
     public static void main(String[] args) {
@@ -235,12 +238,12 @@ public class ReinitialiseTable {
         String tableName = args[1];
         boolean deletePartitions = args.length == 2 ? false : Boolean.parseBoolean(args[2]);
 
-        System.out.println("If you continue all data will be deleted in the table.");
+        LOGGER.info("If you continue all data will be deleted in the table.");
         if (deletePartitions) {
-            System.out.println("The metadata about the partitions will be deleted and the "
+            LOGGER.info("The metadata about the partitions will be deleted and the "
                 + "table will be reset to consist of one root partition.");
         } else {
-            System.out.println("The metadata about the partitions will not be deleted.");
+            LOGGER.info("The metadata about the partitions will not be deleted.");
         }
         String choice = System.console().readLine("Are you sure you want to delete the data and " +
                 "reinitialise this table?\nPlease enter Y or N: ");
@@ -253,9 +256,9 @@ public class ReinitialiseTable {
         try {
             ReinitialiseTable reinitialiseTable = new ReinitialiseTable(amazonS3, dynamoDBClient, instanceId, tableName, deletePartitions);
             reinitialiseTable.run();
-            System.out.println("Table reinitialised successfully");
+            LOGGER.info("Table reinitialised successfully");
         } catch (RuntimeException | IOException | StateStoreException e) {
-            System.out.println("\nAn Error occurred while trying to reinitialise the table. " +
+            LOGGER.severe("\nAn Error occurred while trying to reinitialise the table. " +
                     "The error message is as follows:\n\n" + e.getMessage()
                     + "\n\nCause:" + e.getCause());
         }

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
@@ -66,7 +66,7 @@ import static sleeper.statestore.s3.S3StateStore.REVISION_ID_KEY;
  * is reinitialised.
  */
 public class ReinitialiseTable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTable.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTable.class);
     private final AmazonS3 s3Client;
     private final AmazonDynamoDB dynamoDBClient;
     private final boolean deletePartitions;

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
@@ -66,7 +66,7 @@ import static sleeper.statestore.s3.S3StateStore.REVISION_ID_KEY;
  * is reinitialised.
  */
 public class ReinitialiseTable {
-    private static final java.util.logging.Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTable.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTable.class);
     private final AmazonS3 s3Client;
     private final AmazonDynamoDB dynamoDBClient;
     private final boolean deletePartitions;

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromExportedPartitions.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromExportedPartitions.java
@@ -46,7 +46,7 @@ import java.util.List;
  * have been created using the class {@link ExportPartitions}.
  */
 public class ReinitialiseTableFromExportedPartitions extends ReinitialiseTable {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTableFromExportedPartitions.class);
+    private static final java.util.logging.Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTableFromExportedPartitions.class);
 
     private final String partitionsFile;
 
@@ -90,8 +90,8 @@ public class ReinitialiseTableFromExportedPartitions extends ReinitialiseTable {
         String tableName = args[1];
         String exportedPartitionsFile = args[2];
 
-        System.out.println("If you continue all data will be deleted in the table.");
-        System.out.println("The metadata about the partitions will be deleted and replaced "
+        LOGGER.info("If you continue all data will be deleted in the table.");
+        LOGGER.info("The metadata about the partitions will be deleted and replaced "
             + "by new partitions derived from the provided partitions file.");
         String choice = System.console().readLine("Are you sure you want to delete the data and " +
                 "reinitialise this table?\nPlease enter Y or N: ");
@@ -104,9 +104,9 @@ public class ReinitialiseTableFromExportedPartitions extends ReinitialiseTable {
         try {
             ReinitialiseTable reinitialiseTable = new ReinitialiseTableFromExportedPartitions(amazonS3, dynamoDBClient, instanceId, tableName, exportedPartitionsFile);
             reinitialiseTable.run();
-            System.out.println("Table reinitialised successfully");
+            LOGGER.info("Table reinitialised successfully");
         } catch (RuntimeException | IOException | StateStoreException e) {
-            System.out.println("\nAn Error occurred while trying to reinitialise the table. " +
+            LOGGER.severe("\nAn Error occurred while trying to reinitialise the table. " +
                     "The error message is as follows:\n\n" + e.getMessage()
                     + "\n\nCause:" + e.getCause());
         }

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromExportedPartitions.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromExportedPartitions.java
@@ -46,8 +46,7 @@ import java.util.List;
  * have been created using the class {@link ExportPartitions}.
  */
 public class ReinitialiseTableFromExportedPartitions extends ReinitialiseTable {
-    private static final java.util.logging.Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTableFromExportedPartitions.class);
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTableFromExportedPartitions.class);
     private final String partitionsFile;
 
     public ReinitialiseTableFromExportedPartitions(

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromExportedPartitions.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromExportedPartitions.java
@@ -89,8 +89,8 @@ public class ReinitialiseTableFromExportedPartitions extends ReinitialiseTable {
         String tableName = args[1];
         String exportedPartitionsFile = args[2];
 
-        LOGGER.info("If you continue all data will be deleted in the table.");
-        LOGGER.info("The metadata about the partitions will be deleted and replaced "
+        System.out.println("If you continue all data will be deleted in the table.");
+        System.out.println("The metadata about the partitions will be deleted and replaced "
             + "by new partitions derived from the provided partitions file.");
         String choice = System.console().readLine("Are you sure you want to delete the data and " +
                 "reinitialise this table?\nPlease enter Y or N: ");
@@ -105,7 +105,7 @@ public class ReinitialiseTableFromExportedPartitions extends ReinitialiseTable {
             reinitialiseTable.run();
             LOGGER.info("Table reinitialised successfully");
         } catch (RuntimeException | IOException | StateStoreException e) {
-            LOGGER.severe("\nAn Error occurred while trying to reinitialise the table. " +
+            LOGGER.error("\nAn Error occurred while trying to reinitialise the table. " +
                     "The error message is as follows:\n\n" + e.getMessage()
                     + "\n\nCause:" + e.getCause());
         }

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromSplitPoints.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromSplitPoints.java
@@ -49,7 +49,7 @@ import java.util.List;
  * is reinitialised using the split points in the provided file.
  */
 public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
-    private static final java.util.logging.Logger LOGGER = Logger.getLogger(ReinitialiseTableFromSplitPoints.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReinitialiseTableFromSplitPoints.class);
     private final boolean splitPointStringsBase64Encoded;
     private final String splitPointsFileLocation;
 

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromSplitPoints.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromSplitPoints.java
@@ -20,6 +20,8 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.apache.commons.codec.binary.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.schema.type.ByteArrayType;
@@ -47,6 +49,7 @@ import java.util.List;
  * is reinitialised using the split points in the provided file.
  */
 public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
+    private static final java.util.logging.Logger LOGGER = Logger.getLogger(ReinitialiseTableFromSplitPoints.class.getName());
     private final boolean splitPointStringsBase64Encoded;
     private final String splitPointsFileLocation;
 
@@ -103,7 +106,7 @@ public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
                     throw new RuntimeException("Unknown key type " + rowKey1Type);
                 }
             }
-            System.out.println("Read " + splitPoints.size() + " split points from file");
+            LOGGER.fine("Read " + splitPoints.size() + " split points from file");
         }
         return splitPoints;
     }
@@ -119,8 +122,8 @@ public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
         String splitPointsFile = args[2];
         boolean splitPointsFileBase64Encoded = args.length == 3 ? false : Boolean.parseBoolean(args[3]);
 
-        System.out.println("If you continue all data will be deleted in the table.");
-        System.out.println("The metadata about the partitions will be deleted and replaced "
+        LOGGER.info("If you continue all data will be deleted in the table.");
+        LOGGER.info("The metadata about the partitions will be deleted and replaced "
             + "by new partitions derived from the provided split points.");
         String choice = System.console().readLine("Are you sure you want to delete the data and " +
                 "reinitialise this table?\nPlease enter Y or N: ");
@@ -134,9 +137,9 @@ public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
             ReinitialiseTable reinitialiseTable = new ReinitialiseTableFromSplitPoints(amazonS3, dynamoDBClient, instanceId, tableName,
                 true, splitPointsFile, splitPointsFileBase64Encoded);
             reinitialiseTable.run();
-            System.out.println("Table reinitialised successfully");
+            LOGGER.info("Table reinitialised successfully");
         } catch (RuntimeException | IOException | StateStoreException e) {
-            System.out.println("\nAn Error occurred while trying to reinitialise the table. " +
+            LOGGER.severe("\nAn Error occurred while trying to reinitialise the table. " +
                     "The error message is as follows:\n\n" + e.getMessage()
                     + "\n\nCause:" + e.getCause());
         }

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromSplitPoints.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTableFromSplitPoints.java
@@ -106,7 +106,7 @@ public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
                     throw new RuntimeException("Unknown key type " + rowKey1Type);
                 }
             }
-            LOGGER.fine("Read " + splitPoints.size() + " split points from file");
+            LOGGER.info("Read {} split points from file", splitPoints.size());
         }
         return splitPoints;
     }
@@ -122,8 +122,8 @@ public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
         String splitPointsFile = args[2];
         boolean splitPointsFileBase64Encoded = args.length == 3 ? false : Boolean.parseBoolean(args[3]);
 
-        LOGGER.info("If you continue all data will be deleted in the table.");
-        LOGGER.info("The metadata about the partitions will be deleted and replaced "
+        System.out.println("If you continue all data will be deleted in the table.");
+        System.out.println("The metadata about the partitions will be deleted and replaced "
             + "by new partitions derived from the provided split points.");
         String choice = System.console().readLine("Are you sure you want to delete the data and " +
                 "reinitialise this table?\nPlease enter Y or N: ");
@@ -139,7 +139,7 @@ public class ReinitialiseTableFromSplitPoints extends ReinitialiseTable {
             reinitialiseTable.run();
             LOGGER.info("Table reinitialised successfully");
         } catch (RuntimeException | IOException | StateStoreException e) {
-            LOGGER.severe("\nAn Error occurred while trying to reinitialise the table. " +
+            LOGGER.error("\nAn Error occurred while trying to reinitialise the table. " +
                     "The error message is as follows:\n\n" + e.getMessage()
                     + "\n\nCause:" + e.getCause());
         }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

#1033 Issue

- [X] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1033

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Doesn't need testing (it is for logging that was previously implemented)

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
