### PR TITLE
Issue 1082 - vscode settings file causes issues if not using Corretto or if Java 11 is not installed

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -36,7 +36,7 @@ There are a number of locations where `settings.json` can live but for this setu
 
 To update the settings in VSCode navigate to `Code - Settings ... - Settings - Workspace`. To the top right of the tab is a file symbol with a hover text `Open Settings (JSON)`.  Clicking this button will open a JSON editor and merge the the `settings.json` file from this repository with the current one.
 
-Note: The following JSON paths will need updating to include the location of your installed Java JDKs.
+Note: The following JSON paths will need updating to include the location of your installed Java JDKs. Remove `comment.` from the start of the keys.
 - `java.configuration.runtimes.[].path`
 - `java.jdt.ls.java.home`
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "java",
         "#"
     ],
-    "java.configuration.runtimes": [
+    "comment.java.configuration.runtimes": [
         {
             "name": "JavaSE-11",
             "path": "/usr/lib/jvm/java-11-amazon-corretto", 
@@ -25,7 +25,7 @@
     "java.debug.settings.exceptionBreakpoint.skipClasses": [],
     "java.format.settings.profile": "Sleeper Checkstyle",
     "java.format.settings.url": "./code-style/eclipse-style.xml",
-    "java.jdt.ls.java.home": "/usr/lib/jvm/java-17-amazon-corretto.x86_64",
+    "comment.java.jdt.ls.java.home": "/usr/lib/jvm/java-17-amazon-corretto.x86_64",
     "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx8G -Xms2G -Xlog:disable",
     "java.templates.fileHeader": [
         "/*\n * Copyright 2022-2023 Crown Copyright\n *\n * Licensed under the Apache License, Version 2.0 (the \"License\");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n *     http://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an \"AS IS\" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n */"
@@ -33,5 +33,7 @@
     "redhat.telemetry.enabled": false,
     "[java]": {
         "editor.defaultFormatter": "redhat.java"
-    }
+    },
+    "java.debug.settings.onBuildFailureProceed": true,
+    "java.configuration.updateBuildConfiguration": "interactive"
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1082

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - No tests needs just an update to settings.json and the README

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
    - .vscode/README.md updated
