### PR TITLE
Issue 1102 - Fix argument count check in maven deployTest script

### DIFF
--- a/scripts/test/maven/deployTest.sh
+++ b/scripts/test/maven/deployTest.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-if [ "$#" -ne 3 ]; then
+if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <shortId> <vpc> <subnet> <optional-maven-params>"
   exit 1
 fi


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1102

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Fixes nightly tests

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
