### PR TITLE
Issue 1113 - Stop preventing duplicate property descriptions

### DIFF
--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperties.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperties.java
@@ -24,8 +24,18 @@ import sleeper.configuration.properties.instance.InstanceProperty;
  * run the system tests that add random data to Sleeper.
  */
 public class SystemTestProperties extends InstanceProperties {
+
+    static final SleeperPropertyIndex<InstanceProperty> PROPERTY_INDEX = createPropertyIndex();
+
+    private static SleeperPropertyIndex<InstanceProperty> createPropertyIndex() {
+        SleeperPropertyIndex<InstanceProperty> index = new SleeperPropertyIndex<>();
+        index.addAll(InstanceProperty.getAll());
+        index.addAll(SystemTestProperty.getAll());
+        return index;
+    }
+
     @Override
     public SleeperPropertyIndex<InstanceProperty> getPropertiesIndex() {
-        return SystemTestProperty.Index.INSTANCE;
+        return PROPERTY_INDEX;
     }
 }

--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
@@ -102,13 +102,7 @@ public interface SystemTestProperty extends InstanceProperty {
         private Index() {
         }
 
-        static final SleeperPropertyIndex<InstanceProperty> INSTANCE = createInstance();
-
-        private static SleeperPropertyIndex<InstanceProperty> createInstance() {
-            SleeperPropertyIndex<InstanceProperty> index = new SleeperPropertyIndex<>();
-            index.addAll(InstanceProperty.getAll());
-            return index;
-        }
+        static final SleeperPropertyIndex<InstanceProperty> INSTANCE = new SleeperPropertyIndex<>();
 
         private static SystemTestPropertyImpl.Builder propertyBuilder(String propertyName) {
             return SystemTestPropertyImpl.named(propertyName)

--- a/java/system-test/system-test-configuration/src/test/java/sleeper/systemtest/configuration/SystemTestPropertyTest.java
+++ b/java/system-test/system-test-configuration/src/test/java/sleeper/systemtest/configuration/SystemTestPropertyTest.java
@@ -24,10 +24,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SystemTestPropertyTest {
 
     @Test
-    void shouldSetUniqueDescriptionsOnAllProperties() {
+    void shouldGetAllPropertiesInSystemTestPropertiesIndex() {
+        SystemTestProperties properties = new SystemTestProperties();
+        assertThat(properties.getPropertiesIndex().getAll())
+                .containsAll(InstanceProperty.getAll())
+                .containsAll(SystemTestProperty.getAll());
+    }
+
+    @Test
+    void shouldNotReturnAnyInstancePropertiesAsSystemTestProperties() {
         assertThat(SystemTestProperty.getAll())
-                .extracting(InstanceProperty::getDescription)
-                .doesNotContainNull()
-                .doesNotHaveDuplicates();
+                .doesNotContainAnyElementsOf(InstanceProperty.getAll());
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1113

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - SystemTestPropertyTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
