### PR TITLE
Revert "Issue 929 - Force consistent reads in IngestBatcher integration tests"

### DIFF
--- a/java/ingest/ingest-batcher-job-creator/src/test/java/sleeper/ingest/batcher/job/creator/IngestBatcherJobCreatorLambdaIT.java
+++ b/java/ingest/ingest-batcher-job-creator/src/test/java/sleeper/ingest/batcher/job/creator/IngestBatcherJobCreatorLambdaIT.java
@@ -73,8 +73,8 @@ public class IngestBatcherJobCreatorLambdaIT {
         properties.set(DEFAULT_INGEST_BATCHER_MIN_JOB_SIZE, "0");
     });
     private final TableProperties tableProperties = createTestTableProperties(instanceProperties, schemaWithKey("key"), s3);
-    private final IngestBatcherStore store = DynamoDBIngestBatcherStore.withConsistentReads(
-            dynamoDB, instanceProperties, new TablePropertiesProvider(s3, instanceProperties));
+    private final IngestBatcherStore store = new DynamoDBIngestBatcherStore(dynamoDB, instanceProperties,
+            new TablePropertiesProvider(s3, instanceProperties));
 
     private IngestBatcherJobCreatorLambda lambdaWithTimesAndJobIds(List<Instant> times, List<String> jobIds) {
         return new IngestBatcherJobCreatorLambda(
@@ -103,7 +103,6 @@ public class IngestBatcherJobCreatorLambdaIT {
                 .fileSizeBytes(1024)
                 .receivedTime(Instant.parse("2023-05-25T14:43:00Z"))
                 .build());
-        store.getAllFilesNewestFirst(); // Use consistent reads to ensure PutItem is completed
 
         // When
         lambdaWithTimesAndJobIds(

--- a/java/ingest/ingest-batcher-store/src/main/java/sleeper/ingest/batcher/store/DynamoDBIngestBatcherStore.java
+++ b/java/ingest/ingest-batcher-store/src/main/java/sleeper/ingest/batcher/store/DynamoDBIngestBatcherStore.java
@@ -54,29 +54,13 @@ public class DynamoDBIngestBatcherStore implements IngestBatcherStore {
     private final AmazonDynamoDB dynamoDB;
     private final String requestsTableName;
     private final TablePropertiesProvider tablePropertiesProvider;
-    private final boolean consistentReads;
 
     public DynamoDBIngestBatcherStore(AmazonDynamoDB dynamoDB,
                                       InstanceProperties instanceProperties,
                                       TablePropertiesProvider tablePropertiesProvider) {
-        this(dynamoDB, instanceProperties, tablePropertiesProvider, false);
-    }
-
-    private DynamoDBIngestBatcherStore(AmazonDynamoDB dynamoDB,
-                                       InstanceProperties instanceProperties,
-                                       TablePropertiesProvider tablePropertiesProvider,
-                                       boolean consistentReads) {
         this.dynamoDB = dynamoDB;
         this.requestsTableName = ingestRequestsTableName(instanceProperties.get(ID));
         this.tablePropertiesProvider = tablePropertiesProvider;
-        this.consistentReads = consistentReads;
-    }
-
-    public static DynamoDBIngestBatcherStore withConsistentReads(
-            AmazonDynamoDB dynamoDB,
-            InstanceProperties instanceProperties,
-            TablePropertiesProvider tablePropertiesProvider) {
-        return new DynamoDBIngestBatcherStore(dynamoDB, instanceProperties, tablePropertiesProvider, true);
     }
 
     public static String ingestRequestsTableName(String instanceId) {
@@ -113,8 +97,7 @@ public class DynamoDBIngestBatcherStore implements IngestBatcherStore {
     @Override
     public List<FileIngestRequest> getAllFilesNewestFirst() {
         return streamPagedItems(dynamoDB, new ScanRequest()
-                .withTableName(requestsTableName)
-                .withConsistentRead(consistentReads))
+                .withTableName(requestsTableName))
                 .map(DynamoDBIngestRequestFormat::readRecord)
                 .sorted(comparing(FileIngestRequest::getReceivedTime).reversed())
                 .collect(Collectors.toList());
@@ -124,7 +107,6 @@ public class DynamoDBIngestBatcherStore implements IngestBatcherStore {
     public List<FileIngestRequest> getPendingFilesOldestFirst() {
         return streamPagedItems(dynamoDB, new QueryRequest()
                 .withTableName(requestsTableName)
-                .withConsistentRead(consistentReads)
                 .withKeyConditionExpression("#JobId = :not_assigned")
                 .withExpressionAttributeNames(Map.of("#JobId", JOB_ID))
                 .withExpressionAttributeValues(new DynamoDBRecordBuilder()

--- a/java/ingest/ingest-batcher-store/src/test/java/sleeper/ingest/batcher/store/DynamoDBIngestBatcherStoreIT.java
+++ b/java/ingest/ingest-batcher-store/src/test/java/sleeper/ingest/batcher/store/DynamoDBIngestBatcherStoreIT.java
@@ -118,13 +118,6 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
             // When
             store.addFile(fileIngestRequest1);
             store.addFile(fileIngestRequest2);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
-
             store.assignJob("test-job", List.of(fileIngestRequest1, fileIngestRequest2));
 
             // Then
@@ -144,13 +137,6 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
 
             // When
             store.addFile(fileIngestRequest1);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
-
             store.assignJob("test-job", List.of(fileIngestRequest1));
             store.addFile(fileIngestRequest2);
 
@@ -173,13 +159,6 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
 
             // When
             store.addFile(fileIngestRequest);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
-
             store.assignJob("test-job", List.of(fileIngestRequest));
 
             // Then
@@ -199,13 +178,6 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
             FileIngestRequest fileIngestRequest = fileRequest()
                     .file("test-bucket/test.parquet").build();
             store.addFile(fileIngestRequest);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
-
             store.assignJob("test-job-1", List.of(fileIngestRequest));
 
             // When / Then
@@ -225,13 +197,6 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
                     .file("test-bucket/test-2.parquet").build();
             store.addFile(fileIngestRequest1);
             store.addFile(fileIngestRequest2);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
-
             store.assignJob("test-job-1", List.of(fileIngestRequest1));
 
             // When / Then
@@ -262,21 +227,8 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
             FileIngestRequest fileIngestRequest = fileRequest()
                     .file("test-bucket/sendTwice.parquet").build();
             store.addFile(fileIngestRequest);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
-
             store.assignJob("duplicate-job", List.of(fileIngestRequest));
             store.addFile(fileIngestRequest);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
 
             // When / Then
             List<FileIngestRequest> duplicateJob = List.of(fileIngestRequest);
@@ -348,8 +300,7 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
             store.addFile(fileIngestRequest);
 
             // Then
-            assertThat(streamPagedItems(dynamoDBClient, new ScanRequest()
-                    .withTableName(requestsTableName).withConsistentRead(true)))
+            assertThat(streamPagedItems(dynamoDBClient, new ScanRequest().withTableName(requestsTableName)))
                     .extracting(item -> getLongAttribute(item, EXPIRY_TIME, 0L))
                     .containsExactly(expectedExpiryTime.getEpochSecond());
         }
@@ -365,18 +316,10 @@ public class DynamoDBIngestBatcherStoreIT extends DynamoDBIngestBatcherStoreTest
 
             // When
             store.addFile(fileIngestRequest);
-
-            // Scan with consistent reads waits for PutItems to complete.
-            // TransactWriteItems will fail if a PutItem has not yet been committed.
-            // In production, a scan will happen before the update, so only files that exist in the store will be
-            // assigned to jobs.
-            store.getAllFilesNewestFirst();
-
             store.assignJob("test-job", List.of(fileIngestRequest));
 
             // Then
-            assertThat(streamPagedItems(dynamoDBClient, new ScanRequest()
-                    .withTableName(requestsTableName).withConsistentRead(true)))
+            assertThat(streamPagedItems(dynamoDBClient, new ScanRequest().withTableName(requestsTableName)))
                     .extracting(item -> getLongAttribute(item, EXPIRY_TIME, 0L))
                     .containsExactly(expectedExpiryTime.getEpochSecond());
         }

--- a/java/ingest/ingest-batcher-store/src/test/java/sleeper/ingest/batcher/store/DynamoDBIngestBatcherStoreTestBase.java
+++ b/java/ingest/ingest-batcher-store/src/test/java/sleeper/ingest/batcher/store/DynamoDBIngestBatcherStoreTestBase.java
@@ -43,7 +43,7 @@ public class DynamoDBIngestBatcherStoreTestBase extends DynamoDBTestBase {
     private final TablePropertiesProvider tablePropertiesProvider = new FixedTablePropertiesProvider(
             List.of(table1, table2));
     protected final String requestsTableName = DynamoDBIngestBatcherStore.ingestRequestsTableName(instanceProperties.get(ID));
-    protected final IngestBatcherStore store = DynamoDBIngestBatcherStore.withConsistentReads(
+    protected final IngestBatcherStore store = new DynamoDBIngestBatcherStore(
             dynamoDBClient, instanceProperties, tablePropertiesProvider);
 
     @BeforeEach


### PR DESCRIPTION
Reverts gchq/sleeper#1121

These changes complicate the system and didn't work because DynamoDB's local version doesn't support consistent reads:

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html