### PR TITLE
Issue 1115 - In-memory scenarios for splitting compaction store changes

### DIFF
--- a/java/core/src/main/java/sleeper/core/statestore/AddFileRequest.java
+++ b/java/core/src/main/java/sleeper/core/statestore/AddFileRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore;
+
+import java.util.function.Consumer;
+
+public class AddFileRequest {
+    private final String filename;
+    private final String partitionId;
+    private final FileDataStatistics statistics;
+
+    private AddFileRequest(Builder builder) {
+        filename = builder.filename;
+        partitionId = builder.partitionId;
+        statistics = builder.statistics;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static AddFileRequest addFile(Consumer<Builder> config) {
+        Builder builder = builder();
+        config.accept(builder);
+        return builder.build();
+    }
+
+    public FileInfoV2 buildFileInfo() {
+        return FileInfoV2.builder()
+                .filename(filename)
+                .partitionId(partitionId)
+                .statistics(statistics)
+                .build();
+    }
+
+    public static final class Builder {
+        private String filename;
+        private String partitionId;
+        private FileDataStatistics statistics;
+
+        private Builder() {
+        }
+
+        public Builder filename(String filename) {
+            this.filename = filename;
+            return this;
+        }
+
+        public Builder partitionId(String partitionId) {
+            this.partitionId = partitionId;
+            return this;
+        }
+
+        public Builder statistics(FileDataStatistics statistics) {
+            this.statistics = statistics;
+            return this;
+        }
+
+        public AddFileRequest build() {
+            return new AddFileRequest(this);
+        }
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/AddFilesRequest.java
+++ b/java/core/src/main/java/sleeper/core/statestore/AddFilesRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class AddFilesRequest {
+    private final String jobId;
+    private final List<AddFileRequest> files;
+
+    private AddFilesRequest(Builder builder) {
+        jobId = builder.jobId;
+        files = builder.files;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static AddFilesRequest addFiles(Consumer<Builder> config) {
+        Builder builder = builder();
+        config.accept(builder);
+        return builder.build();
+    }
+
+    public Stream<FileInfoV2> buildFileInfos() {
+        return files.stream()
+                .map(AddFileRequest::buildFileInfo);
+    }
+
+    public static final class Builder {
+        private String jobId;
+        private List<AddFileRequest> files;
+
+        private Builder() {
+        }
+
+        public Builder jobId(String jobId) {
+            this.jobId = jobId;
+            return this;
+        }
+
+        public Builder files(List<AddFileRequest> files) {
+            this.files = files;
+            return this;
+        }
+
+        public AddFilesRequest build() {
+            return new AddFilesRequest(this);
+        }
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/AddFilesRequest.java
+++ b/java/core/src/main/java/sleeper/core/statestore/AddFilesRequest.java
@@ -21,11 +21,9 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public class AddFilesRequest {
-    private final String jobId;
     private final List<AddFileRequest> files;
 
     private AddFilesRequest(Builder builder) {
-        jobId = builder.jobId;
         files = builder.files;
     }
 
@@ -45,15 +43,9 @@ public class AddFilesRequest {
     }
 
     public static final class Builder {
-        private String jobId;
         private List<AddFileRequest> files;
 
         private Builder() {
-        }
-
-        public Builder jobId(String jobId) {
-            this.jobId = jobId;
-            return this;
         }
 
         public Builder files(List<AddFileRequest> files) {

--- a/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStoreV2.java
+++ b/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStoreV2.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore;
+
+import sleeper.core.partition.Partition;
+
+import java.util.List;
+
+public class DelegatingStateStoreV2 implements StateStoreV2 {
+    private final PartitionStore partitionStore;
+
+    public DelegatingStateStoreV2(PartitionStore partitionStore) {
+        this.partitionStore = partitionStore;
+    }
+
+    @Override
+    public void atomicallyUpdatePartitionAndCreateNewOnes(Partition splitPartition, Partition newPartition1, Partition newPartition2) throws StateStoreException {
+        partitionStore.atomicallyUpdatePartitionAndCreateNewOnes(splitPartition, newPartition1, newPartition2);
+    }
+
+    @Override
+    public List<Partition> getAllPartitions() throws StateStoreException {
+        return partitionStore.getAllPartitions();
+    }
+
+    @Override
+    public List<Partition> getLeafPartitions() throws StateStoreException {
+        return partitionStore.getLeafPartitions();
+    }
+
+    @Override
+    public void initialise() throws StateStoreException {
+        partitionStore.initialise();
+    }
+
+    @Override
+    public void initialise(List<Partition> partitions) throws StateStoreException {
+        partitionStore.initialise(partitions);
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStoreV2.java
+++ b/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStoreV2.java
@@ -55,8 +55,8 @@ public class DelegatingStateStoreV2 implements StateStoreV2 {
     }
 
     @Override
-    public void completeIngest(AddFilesRequest request) {
-        fileStore.completeIngest(request);
+    public void finishIngest(AddFilesRequest request) {
+        fileStore.finishIngest(request);
     }
 
     @Override

--- a/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStoreV2.java
+++ b/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStoreV2.java
@@ -22,9 +22,11 @@ import java.util.List;
 
 public class DelegatingStateStoreV2 implements StateStoreV2 {
     private final PartitionStore partitionStore;
+    private final FileInfoStoreV2 fileStore;
 
-    public DelegatingStateStoreV2(PartitionStore partitionStore) {
+    public DelegatingStateStoreV2(PartitionStore partitionStore, FileInfoStoreV2 fileStore) {
         this.partitionStore = partitionStore;
+        this.fileStore = fileStore;
     }
 
     @Override
@@ -50,5 +52,15 @@ public class DelegatingStateStoreV2 implements StateStoreV2 {
     @Override
     public void initialise(List<Partition> partitions) throws StateStoreException {
         partitionStore.initialise(partitions);
+    }
+
+    @Override
+    public void completeIngest(AddFilesRequest request) {
+        fileStore.completeIngest(request);
+    }
+
+    @Override
+    public List<FileInfoV2> getPartitionFiles() {
+        return fileStore.getPartitionFiles();
     }
 }

--- a/java/core/src/main/java/sleeper/core/statestore/FileDataStatistics.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileDataStatistics.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore;
+
+import sleeper.core.key.Key;
+
+import java.util.Objects;
+
+public class FileDataStatistics {
+    private final Key minRowKey;
+    private final Key maxRowKey;
+    private final Long numberOfRecords;
+
+    private FileDataStatistics(Builder builder) {
+        minRowKey = builder.minRowKey;
+        maxRowKey = builder.maxRowKey;
+        numberOfRecords = builder.numberOfRecords;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Key getMinRowKey() {
+        return minRowKey;
+    }
+
+    public Key getMaxRowKey() {
+        return maxRowKey;
+    }
+
+    public Long getNumberOfRecords() {
+        return numberOfRecords;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FileDataStatistics that = (FileDataStatistics) o;
+        return Objects.equals(minRowKey, that.minRowKey) && Objects.equals(maxRowKey, that.maxRowKey) && Objects.equals(numberOfRecords, that.numberOfRecords);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minRowKey, maxRowKey, numberOfRecords);
+    }
+
+    public static final class Builder {
+        private Key minRowKey;
+        private Key maxRowKey;
+        private long numberOfRecords;
+
+        private Builder() {
+        }
+
+        public Builder minRowKey(Key minRowKey) {
+            this.minRowKey = minRowKey;
+            return this;
+        }
+
+        public Builder maxRowKey(Key maxRowKey) {
+            this.maxRowKey = maxRowKey;
+            return this;
+        }
+
+        public Builder numberOfRecords(long numberOfRecords) {
+            this.numberOfRecords = numberOfRecords;
+            return this;
+        }
+
+        public FileDataStatistics build() {
+            return new FileDataStatistics(this);
+        }
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStoreV2.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStoreV2.java
@@ -19,7 +19,7 @@ package sleeper.core.statestore;
 import java.util.List;
 
 public interface FileInfoStoreV2 {
-    void completeIngest(AddFilesRequest request);
+    void finishIngest(AddFilesRequest request);
 
     List<FileInfoV2> getPartitionFiles();
 }

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStoreV2.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStoreV2.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore;
+
+public interface FileInfoStoreV2 {
+}

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoV2.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoV2.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public class FileInfoV2 {
+    private final String filename;
+    private final String partitionId;
+    private final FileDataStatistics statistics;
+    private final FileInfoV2 parent;
+    private final String compactionJobId;
+    private final Instant updateTime;
+
+    private FileInfoV2(Builder builder) {
+        filename = builder.filename;
+        partitionId = builder.partitionId;
+        statistics = builder.statistics;
+        parent = builder.parent;
+        compactionJobId = builder.compactionJobId;
+        updateTime = builder.updateTime;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FileInfoV2 that = (FileInfoV2) o;
+        return Objects.equals(filename, that.filename) && Objects.equals(partitionId, that.partitionId) && Objects.equals(statistics, that.statistics) && Objects.equals(parent, that.parent) && Objects.equals(compactionJobId, that.compactionJobId) && Objects.equals(updateTime, that.updateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filename, partitionId, statistics, parent, compactionJobId, updateTime);
+    }
+
+    public static final class Builder {
+        private String filename;
+        private String partitionId;
+        private FileDataStatistics statistics;
+        private FileInfoV2 parent;
+        private String compactionJobId;
+        private Instant updateTime;
+
+        private Builder() {
+        }
+
+        public Builder filename(String filename) {
+            this.filename = filename;
+            return this;
+        }
+
+        public Builder partitionId(String partitionId) {
+            this.partitionId = partitionId;
+            return this;
+        }
+
+        public Builder statistics(FileDataStatistics statistics) {
+            this.statistics = statistics;
+            return this;
+        }
+
+        public Builder parent(FileInfoV2 parent) {
+            this.parent = parent;
+            return this;
+        }
+
+        public Builder compactionJobId(String compactionJobId) {
+            this.compactionJobId = compactionJobId;
+            return this;
+        }
+
+        public Builder updateTime(Instant updateTime) {
+            this.updateTime = updateTime;
+            return this;
+        }
+
+        public FileInfoV2 build() {
+            return new FileInfoV2(this);
+        }
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/StateStoreV2.java
+++ b/java/core/src/main/java/sleeper/core/statestore/StateStoreV2.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore;
+
+public interface StateStoreV2 extends PartitionStore, FileInfoStoreV2 {
+}

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreV2.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreV2.java
@@ -14,12 +14,26 @@
  * limitations under the License.
  */
 
-package sleeper.core.statestore;
+package sleeper.core.statestore.inmemory;
 
+import sleeper.core.statestore.AddFilesRequest;
+import sleeper.core.statestore.FileInfoStoreV2;
+import sleeper.core.statestore.FileInfoV2;
+
+import java.util.ArrayList;
 import java.util.List;
 
-public interface FileInfoStoreV2 {
-    void completeIngest(AddFilesRequest request);
+public class InMemoryFileInfoStoreV2 implements FileInfoStoreV2 {
 
-    List<FileInfoV2> getPartitionFiles();
+    private final List<FileInfoV2> files = new ArrayList<>();
+
+    @Override
+    public void completeIngest(AddFilesRequest request) {
+        request.buildFileInfos().forEach(files::add);
+    }
+
+    @Override
+    public List<FileInfoV2> getPartitionFiles() {
+        return files;
+    }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreV2.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreV2.java
@@ -28,7 +28,7 @@ public class InMemoryFileInfoStoreV2 implements FileInfoStoreV2 {
     private final List<FileInfoV2> files = new ArrayList<>();
 
     @Override
-    public void completeIngest(AddFilesRequest request) {
+    public void finishIngest(AddFilesRequest request) {
         request.buildFileInfos().forEach(files::add);
     }
 

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreV2Test.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreV2Test.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore.inmemory;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.core.partition.PartitionTree;
+import sleeper.core.partition.PartitionsBuilder;
+import sleeper.core.schema.Field;
+import sleeper.core.schema.Schema;
+import sleeper.core.schema.type.StringType;
+import sleeper.core.statestore.StateStoreV2;
+
+import static sleeper.core.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreV2WithFixedPartitions;
+
+public class InMemoryFileInfoStoreV2Test {
+
+    @Test
+    public void shouldAddAndReadActiveFiles() {
+        // Given
+        Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
+        PartitionTree tree = new PartitionsBuilder(schema)
+                .rootFirst("root")
+                .buildTree();
+        StateStoreV2 store = inMemoryStateStoreV2WithFixedPartitions(tree.getAllPartitions());
+    }
+}

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/StateStoreTestHelper.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/StateStoreTestHelper.java
@@ -18,7 +18,9 @@ package sleeper.core.statestore.inmemory;
 import sleeper.core.partition.Partition;
 import sleeper.core.schema.Schema;
 import sleeper.core.statestore.DelegatingStateStore;
+import sleeper.core.statestore.DelegatingStateStoreV2;
 import sleeper.core.statestore.StateStore;
+import sleeper.core.statestore.StateStoreV2;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,6 +36,10 @@ public class StateStoreTestHelper {
 
     public static StateStore inMemoryStateStoreWithFixedPartitions(List<Partition> partitions) {
         return new DelegatingStateStore(new InMemoryFileInfoStore(), new FixedPartitionStore(partitions));
+    }
+
+    public static StateStoreV2 inMemoryStateStoreV2WithFixedPartitions(List<Partition> partitions) {
+        return new DelegatingStateStoreV2(new FixedPartitionStore(partitions));
     }
 
     public static StateStore inMemoryStateStoreWithFixedSinglePartition(Schema schema) {

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/StateStoreTestHelper.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/StateStoreTestHelper.java
@@ -39,7 +39,7 @@ public class StateStoreTestHelper {
     }
 
     public static StateStoreV2 inMemoryStateStoreV2WithFixedPartitions(List<Partition> partitions) {
-        return new DelegatingStateStoreV2(new FixedPartitionStore(partitions));
+        return new DelegatingStateStoreV2(new FixedPartitionStore(partitions), new InMemoryFileInfoStoreV2());
     }
 
     public static StateStore inMemoryStateStoreWithFixedSinglePartition(Schema schema) {


### PR DESCRIPTION
Raised as a draft so that we can move onto system test changes and come back later.

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1115

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - InMemoryFileInfoStoreV2Test

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
