### PR TITLE
Issue 1127 - Fail validation when instance types property is unset

### DIFF
--- a/java/configuration/src/main/java/sleeper/configuration/properties/validation/EmrInstanceTypeConfig.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/validation/EmrInstanceTypeConfig.java
@@ -75,6 +75,9 @@ public class EmrInstanceTypeConfig {
     }
 
     public static boolean isValidInstanceTypes(String value) {
+        if (value == null) {
+            return false;
+        }
         try {
             List<String> instanceTypes = readInstanceTypesProperty(readList(value), X86_64)
                     .map(EmrInstanceTypeConfig::getInstanceType)

--- a/java/configuration/src/test/java/sleeper/configuration/properties/validation/EmrInstanceTypeConfigTest.java
+++ b/java/configuration/src/test/java/sleeper/configuration/properties/validation/EmrInstanceTypeConfigTest.java
@@ -209,6 +209,12 @@ public class EmrInstanceTypeConfigTest {
             assertThat(EmrInstanceTypeConfig.isValidInstanceTypes("1,type-a"))
                     .isFalse();
         }
+
+        @Test
+        void shouldFailValidationWhenInstanceTypesPropertyIsNull() {
+            assertThat(EmrInstanceTypeConfig.isValidInstanceTypes(null))
+                    .isFalse();
+        }
     }
 
     public static Stream<EmrInstanceTypeConfig> readInstanceTypesProperty(List<String> instanceTypeEntries) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1127

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - EmrInstanceTypeConfigTest.ValidateValue.shouldFailValidationWhenInstanceTypesPropertyIsNull

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
