### PR TITLE
Issue 1087 - Delete EKS bulk import job pods

### DIFF
--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
@@ -150,7 +150,7 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
 
     private static String jobPodPrefix(BulkImportJob job) {
         /* Spark adds extra IDs to the end of this - up to 17 characters, and performs some extra validation:
-         * - whether the pod name prefix is <= 47 characters (https://spark.apache.org/docs/latest/running-on-kubernetes.html)
+         * - whether the pod name prefix is <= 47 characters (https://spark.apache.org/docs/3.3.1/running-on-kubernetes.html)
          * - whether the pod name prefix starts with a letter (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)
          * After adding a "job-" prefix, maximum id length = 47-(17+4) = 26 characters
          */

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
@@ -87,6 +87,7 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
         Map<String, Object> input = new HashMap<>();
         List<String> args = constructArgs(arguments, stateMachineArn);
         input.put("job", bulkImportJob);
+        input.put("jobPodPrefix", jobPodPrefix(bulkImportJob));
         input.put("args", args);
 
         stepFunctions.startExecution(
@@ -105,18 +106,9 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
         defaultConfig.put("spark.app.name", bulkImportJob.getId());
         defaultConfig.put("spark.kubernetes.container.image", imageName);
         defaultConfig.put("spark.kubernetes.namespace", instanceProperties.get(BULK_IMPORT_EKS_NAMESPACE));
-        /* Spark adds extra IDs to the end of this - up to 17 characters, and performs some extra validation:
-         * - whether the pod name prefix is <= 47 characters (https://spark.apache.org/docs/latest/running-on-kubernetes.html)
-         * - whether the pod name prefix starts with a letter (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)
-         * After adding an "eks-" prefix, maximum id length = 47-(17+4) = 26 characters
-         */
-        if (bulkImportJob.getId().length() > 26) {
-            defaultConfig.put("spark.kubernetes.driver.pod.name", "eks-" + bulkImportJob.getId().substring(0, 26));
-            defaultConfig.put("spark.kubernetes.executor.podNamePrefix", "eks-" + bulkImportJob.getId().substring(0, 26));
-        } else {
-            defaultConfig.put("spark.kubernetes.driver.pod.name", "eks-" + bulkImportJob.getId());
-            defaultConfig.put("spark.kubernetes.executor.podNamePrefix", "eks-" + bulkImportJob.getId());
-        }
+        String jobPodPrefix = jobPodPrefix(bulkImportJob);
+        defaultConfig.put("spark.kubernetes.driver.pod.name", jobPodPrefix);
+        defaultConfig.put("spark.kubernetes.executor.podNamePrefix", jobPodPrefix);
 
         defaultConfig.putAll(DEFAULT_CONFIG);
 
@@ -154,5 +146,18 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
                 .sparkConf(sparkProperties)
                 .build();
         return arguments.constructArgs(cloneWithUpdatedProps, taskId, jarLocation);
+    }
+
+    private static String jobPodPrefix(BulkImportJob job) {
+        /* Spark adds extra IDs to the end of this - up to 17 characters, and performs some extra validation:
+         * - whether the pod name prefix is <= 47 characters (https://spark.apache.org/docs/latest/running-on-kubernetes.html)
+         * - whether the pod name prefix starts with a letter (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/)
+         * After adding a "job-" prefix, maximum id length = 47-(17+4) = 26 characters
+         */
+        if (job.getId().length() > 26) {
+            return "job-" + job.getId().substring(0, 26);
+        } else {
+            return "job-" + job.getId();
+        }
     }
 }

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutorTest.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutorTest.java
@@ -266,7 +266,7 @@ class StateMachinePlatformExecutorTest {
         assertThatJson(requested.get().getInput())
                 .inPath("$.args").isArray().extracting(Objects::toString)
                 .filteredOn(s -> s.startsWith("spark.kubernetes.driver.pod.name="))
-                .containsExactly("spark.kubernetes.driver.pod.name=eks-my-job");
+                .containsExactly("spark.kubernetes.driver.pod.name=job-my-job");
     }
 
     @Test

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
@@ -286,7 +286,7 @@ public final class EksBulkImportStack extends NestedStack {
                 .replace("cluster-placeholder", cluster.getClusterName())
                 .replace("ca-placeholder", cluster.getClusterCertificateAuthorityData());
 
-        Map<String, Object> deleteJobState = new Gson().fromJson(parsedDeleteJob, Map.class);
+        Map<String, Object> deleteJobState = new Gson().fromJson(parsedDeleteJob, new StateMachineJsonTypeToken());
 
         SnsPublish publishError = SnsPublish.Builder
                 .create(this, "AlertUserFailedSparkSubmit")

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
@@ -278,7 +278,7 @@ public final class EksBulkImportStack extends NestedStack {
 
         Map<String, Object> runJobState = new Gson().fromJson(parsedSparkJobStepFunction, new StateMachineJsonTypeToken());
 
-        String deleteJobJson = parseJsonFile("/step-functions/delete-driver-pod.json",
+        String deleteJobJson = parseJsonFile("/step-functions/delete-job.json",
                 instanceProperties.get(SystemDefinedInstanceProperty.BULK_IMPORT_EKS_NAMESPACE));
         String parsedDeleteJob = deleteJobJson
                 .replace("endpoint-placeholder", instanceProperties.get(SystemDefinedInstanceProperty.BULK_IMPORT_EKS_CLUSTER_ENDPOINT))
@@ -306,7 +306,7 @@ public final class EksBulkImportStack extends NestedStack {
                         new CustomState(this, "RunSparkJob", CustomStateProps.builder().stateJson(runJobState).build())
                                 .next(Choice.Builder.create(this, "SuccessDecision").build()
                                         .when(Condition.stringMatches("$.output.logs[0]", "*exit code: 0*"),
-                                                CustomState.Builder.create(this, "DeleteDriverPod")
+                                                CustomState.Builder.create(this, "DeleteJob")
                                                         .stateJson(deleteJobState).build())
                                         .otherwise(createErrorMessage.next(publishError).next(Fail.Builder
                                                 .create(this, "FailedJobState").cause("Spark job failed").build()))))

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
@@ -271,6 +271,10 @@ public final class EksBulkImportStack extends NestedStack {
                 "/step-functions/run-job.json", instanceProperties, cluster,
                 replacements(Map.of("image-placeholder", imageName)));
 
+        // Deleting the driver pod is necessary as a Spark job does not delete the pod afterwards:
+        // https://spark.apache.org/docs/3.3.1/running-on-kubernetes.html#how-it-works
+        // Although the Spark documentation says it doesn't use up resources in the completed state, it does when it's
+        // scheduled into AWS Fargate.
         Map<String, Object> deleteDriverPodState = parseEksStepDefinition(
                 "/step-functions/delete-driver-pod.json", instanceProperties, cluster);
 

--- a/java/cdk/src/main/resources/step-functions/delete-driver-pod.json
+++ b/java/cdk/src/main/resources/step-functions/delete-driver-pod.json
@@ -1,0 +1,12 @@
+{
+  "Type": "Task",
+  "Resource": "arn:aws:states:::eks:call",
+  "Parameters": {
+    "ClusterName": "cluster-placeholder",
+    "CertificateAuthority": "ca-placeholder",
+    "Endpoint": "endpoint-placeholder",
+    "Method": "DELETE",
+    "Path.$": "States.Format('/api/v1/namespaces/namespace-placeholder/pods/{}', $.jobPodPrefix)"
+  },
+  "ResultPath": "$.deleteDriverPodOutput"
+}

--- a/java/cdk/src/main/resources/step-functions/delete-driver-pod.json
+++ b/java/cdk/src/main/resources/step-functions/delete-driver-pod.json
@@ -1,0 +1,12 @@
+{
+  "Type": "Task",
+  "Resource": "arn:aws:states:::eks:call",
+  "Parameters": {
+    "ClusterName": "cluster-placeholder",
+    "CertificateAuthority": "ca-placeholder",
+    "Endpoint": "endpoint-placeholder",
+    "Method": "DELETE",
+    "Path.$": "States.Format('/api/v1/namespaces/namespace-placeholder/pods/{}', $.job.id)"
+  },
+  "ResultPath": "$.deleteJobOutput"
+}

--- a/java/cdk/src/main/resources/step-functions/delete-job.json
+++ b/java/cdk/src/main/resources/step-functions/delete-job.json
@@ -6,7 +6,7 @@
     "CertificateAuthority": "ca-placeholder",
     "Endpoint": "endpoint-placeholder",
     "Method": "DELETE",
-    "Path.$": "States.Format('/apis/batch/v1/namespaces/namespace-placeholder/jobs/{}', $.job.id)"
+    "Path.$": "States.Format('/apis/batch/v1/namespaces/namespace-placeholder/jobs/{}?propagationPolicy=Foreground', $.job.id)"
   },
   "ResultPath": "$.deleteJobOutput"
 }

--- a/java/cdk/src/main/resources/step-functions/delete-job.json
+++ b/java/cdk/src/main/resources/step-functions/delete-job.json
@@ -6,7 +6,12 @@
     "CertificateAuthority": "ca-placeholder",
     "Endpoint": "endpoint-placeholder",
     "Method": "DELETE",
-    "Path.$": "States.Format('/apis/batch/v1/namespaces/namespace-placeholder/jobs/{}?propagationPolicy=Foreground', $.job.id)"
+    "Path.$": "States.Format('/apis/batch/v1/namespaces/namespace-placeholder/jobs/{}', $.job.id)",
+    "QueryParameters": {
+      "propagationPolicy": [
+        "Foreground"
+      ]
+    }
   },
   "ResultPath": "$.deleteJobOutput"
 }

--- a/java/cdk/src/main/resources/step-functions/delete-job.json
+++ b/java/cdk/src/main/resources/step-functions/delete-job.json
@@ -6,7 +6,7 @@
     "CertificateAuthority": "ca-placeholder",
     "Endpoint": "endpoint-placeholder",
     "Method": "DELETE",
-    "Path.$": "States.Format('/api/v1/namespaces/namespace-placeholder/pods/{}', $.job.id)"
+    "Path.$": "States.Format('/apis/batch/v1/namespaces/namespace-placeholder/jobs/{}', $.job.id)"
   },
   "ResultPath": "$.deleteJobOutput"
 }

--- a/java/cdk/src/main/resources/step-functions/run-job.json
+++ b/java/cdk/src/main/resources/step-functions/run-job.json
@@ -16,9 +16,6 @@
         "ttlSecondsAfterFinished": 600,
         "backoffLimit": 0,
         "template": {
-          "metadata": {
-            "name.$": "$.jobPodPrefix"
-          },
           "spec": {
             "serviceAccountName": "spark-submit",
             "containers": [

--- a/java/cdk/src/main/resources/step-functions/run-job.json
+++ b/java/cdk/src/main/resources/step-functions/run-job.json
@@ -17,7 +17,7 @@
         "backoffLimit": 0,
         "template": {
           "metadata": {
-            "name.$": "$.job.id"
+            "name.$": "$.jobPodPrefix"
           },
           "spec": {
             "serviceAccountName": "spark-submit",
@@ -36,7 +36,9 @@
     "LogOptions": {
       "RetrieveLogs": true,
       "LogParameters": {
-        "tailLines": [ "10" ]
+        "tailLines": [
+          "10"
+        ]
       }
     }
   },


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1087

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Changes to CDK and Spark configuration. Tested in AWS, saw all EKS pods were deleted after each of 5 jobs.

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
