### PR TITLE
Issue 1081 Add DSL for generating scrambled records

### DIFF
--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/RecordNumbers.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/RecordNumbers.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.datageneration;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+public class RecordNumbers {
+    private final List<Long> records;
+
+    private RecordNumbers(List<Long> records) {
+        this.records = records;
+    }
+
+    public static RecordNumbers scrambleNumberedRecords(LongStream longStream) {
+        List<Long> records = longStream.boxed().collect(Collectors.toList());
+        Collections.shuffle(records, new Random(0L));
+        return new RecordNumbers(records);
+    }
+
+    public List<Long> asList() {
+        return records;
+    }
+
+    public LongStream range(int from, int to) {
+        return records.subList(from, to).stream().mapToLong(Long::longValue);
+    }
+}

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/RecordNumbers.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/RecordNumbers.java
@@ -35,8 +35,8 @@ public class RecordNumbers {
         return new RecordNumbers(records);
     }
 
-    public List<Long> asList() {
-        return records;
+    public LongStream stream() {
+        return records.stream().mapToLong(Long::longValue);
     }
 
     public LongStream range(int from, int to) {

--- a/java/system-test/system-test-data-generation/src/test/java/sleeper/systemtest/datageneration/RecordNumbersTest.java
+++ b/java/system-test/system-test-data-generation/src/test/java/sleeper/systemtest/datageneration/RecordNumbersTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.datageneration;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RecordNumbersTest {
+    @Test
+    void shouldShuffleRecordsWithFixedRandomSeed() {
+        // Given
+        LongStream longStream = LongStream.of(1L, 2L, 3L, 4L, 5L);
+
+        // When/Then
+        assertThat(RecordNumbers.scrambleNumberedRecords(longStream))
+                .extracting(RecordNumbers::asList)
+                .isEqualTo(List.of(5L, 3L, 2L, 4L, 1L));
+    }
+
+    @Test
+    void shouldGetRangeOfShuffledRecordsWithFixedRandomSeed() {
+        // Given
+        LongStream longStream = LongStream.of(1L, 2L, 3L, 4L, 5L);
+        RecordNumbers recordNumbers = RecordNumbers.scrambleNumberedRecords(longStream);
+
+        // When/Then
+        assertThat(recordNumbers.range(1, 4))
+                .containsExactly(3L, 2L, 4L);
+    }
+}

--- a/java/system-test/system-test-data-generation/src/test/java/sleeper/systemtest/datageneration/RecordNumbersTest.java
+++ b/java/system-test/system-test-data-generation/src/test/java/sleeper/systemtest/datageneration/RecordNumbersTest.java
@@ -18,7 +18,6 @@ package sleeper.systemtest.datageneration;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,9 +29,8 @@ public class RecordNumbersTest {
         LongStream longStream = LongStream.of(1L, 2L, 3L, 4L, 5L);
 
         // When/Then
-        assertThat(RecordNumbers.scrambleNumberedRecords(longStream))
-                .extracting(RecordNumbers::asList)
-                .isEqualTo(List.of(5L, 3L, 2L, 4L, 1L));
+        assertThat(RecordNumbers.scrambleNumberedRecords(longStream).stream())
+                .containsExactly(5L, 3L, 2L, 4L, 1L);
     }
 
     @Test

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
@@ -93,6 +93,10 @@ public class SleeperSystemTest {
         }
     }
 
+    public SystemTestStateStore stateStore() {
+        return new SystemTestStateStore(instance);
+    }
+
     public SystemTestSourceFiles sourceFiles() {
         return new SystemTestSourceFiles(instance, sourceFiles);
     }
@@ -109,10 +113,6 @@ public class SleeperSystemTest {
         return () -> GenerateNumberedRecords.from(
                         instance.getTableProperties().getSchema(), numbers)
                 .iterator();
-    }
-
-    public SystemTestStateStore stateStore() {
-        return new SystemTestStateStore(instance);
     }
 
     public RecordNumbers scrambleNumberedRecords(LongStream longStream) {

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
@@ -21,6 +21,7 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.record.Record;
 import sleeper.systemtest.datageneration.GenerateNumberedRecords;
+import sleeper.systemtest.datageneration.RecordNumbers;
 import sleeper.systemtest.drivers.ingest.IngestSourceFilesContext;
 import sleeper.systemtest.drivers.instance.SleeperInstanceContext;
 import sleeper.systemtest.drivers.instance.SystemTestParameters;
@@ -52,7 +53,6 @@ import java.util.stream.LongStream;
  * Try to avoid assigning variables except for data you want to reuse.
  */
 public class SleeperSystemTest {
-
     private static final SleeperSystemTest INSTANCE = new SleeperSystemTest();
 
     private final SystemTestParameters parameters = SystemTestParameters.loadFromSystemProperties();
@@ -113,5 +113,9 @@ public class SleeperSystemTest {
 
     public SystemTestStateStore stateStore() {
         return new SystemTestStateStore(instance);
+    }
+
+    public RecordNumbers scrambleNumberedRecords(LongStream longStream) {
+        return RecordNumbers.scrambleNumberedRecords(longStream);
     }
 }

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestBatcherIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestBatcherIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import sleeper.core.util.PollWithRetries;
+import sleeper.systemtest.datageneration.RecordNumbers;
 import sleeper.systemtest.suite.dsl.IngestBatcherResult;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
 
@@ -66,11 +67,12 @@ public class IngestBatcherIT {
             tableProperties.set(INGEST_BATCHER_MIN_JOB_SIZE, "1K");
             tableProperties.set(INGEST_BATCHER_MAX_JOB_FILES, "3");
         });
+        RecordNumbers numbers = sleeper.scrambleNumberedRecords(LongStream.range(0, 400));
         sleeper.sourceFiles()
-                .createWithNumberedRecords("file1.parquet", LongStream.range(0, 100))
-                .createWithNumberedRecords("file2.parquet", LongStream.range(100, 200))
-                .createWithNumberedRecords("file3.parquet", LongStream.range(200, 300))
-                .createWithNumberedRecords("file4.parquet", LongStream.range(300, 400));
+                .createWithNumberedRecords("file1.parquet", numbers.range(0, 100))
+                .createWithNumberedRecords("file2.parquet", numbers.range(100, 200))
+                .createWithNumberedRecords("file3.parquet", numbers.range(200, 300))
+                .createWithNumberedRecords("file4.parquet", numbers.range(300, 400));
 
         // When
         IngestBatcherResult result = sleeper.ingest().batcher()
@@ -94,11 +96,12 @@ public class IngestBatcherIT {
             tableProperties.set(INGEST_BATCHER_MAX_JOB_FILES, "10");
             tableProperties.set(BULK_IMPORT_MIN_LEAF_PARTITION_COUNT, "1");
         });
+        RecordNumbers numbers = sleeper.scrambleNumberedRecords(LongStream.range(0, 400));
         sleeper.sourceFiles()
-                .createWithNumberedRecords("file1.parquet", LongStream.range(0, 100))
-                .createWithNumberedRecords("file2.parquet", LongStream.range(100, 200))
-                .createWithNumberedRecords("file3.parquet", LongStream.range(200, 300))
-                .createWithNumberedRecords("file4.parquet", LongStream.range(300, 400));
+                .createWithNumberedRecords("file1.parquet", numbers.range(0, 100))
+                .createWithNumberedRecords("file2.parquet", numbers.range(100, 200))
+                .createWithNumberedRecords("file3.parquet", numbers.range(200, 300))
+                .createWithNumberedRecords("file4.parquet", numbers.range(300, 400));
 
         // When
         IngestBatcherResult result = sleeper.ingest().batcher()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1081

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - RecordNumbersTest & IngestBatcherIT

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
