### PR TITLE
Issue 1134 - Exclude runs with rate of NaN from average rate calculation

### DIFF
--- a/java/core/src/main/java/sleeper/core/record/process/AverageRecordRate.java
+++ b/java/core/src/main/java/sleeper/core/record/process/AverageRecordRate.java
@@ -113,10 +113,10 @@ public class AverageRecordRate {
             recordsRead += summary.getRecordsRead();
             recordsWritten += summary.getRecordsWritten();
             totalRunDuration = totalRunDuration.plus(summary.getTimeInProcess());
-            if (!Double.isNaN(summary.getRecordsReadPerSecond())) {
+            if (Double.isFinite(summary.getRecordsReadPerSecond())) {
                 totalRecordsReadPerSecond += summary.getRecordsReadPerSecond();
             }
-            if (!Double.isNaN(summary.getRecordsWrittenPerSecond())) {
+            if (Double.isFinite(summary.getRecordsWrittenPerSecond())) {
                 totalRecordsWrittenPerSecond += summary.getRecordsWrittenPerSecond();
             }
             return this;

--- a/java/core/src/main/java/sleeper/core/record/process/AverageRecordRate.java
+++ b/java/core/src/main/java/sleeper/core/record/process/AverageRecordRate.java
@@ -113,8 +113,12 @@ public class AverageRecordRate {
             recordsRead += summary.getRecordsRead();
             recordsWritten += summary.getRecordsWritten();
             totalRunDuration = totalRunDuration.plus(summary.getTimeInProcess());
-            totalRecordsReadPerSecond += summary.getRecordsReadPerSecond();
-            totalRecordsWrittenPerSecond += summary.getRecordsWrittenPerSecond();
+            if (!Double.isNaN(summary.getRecordsReadPerSecond())) {
+                totalRecordsReadPerSecond += summary.getRecordsReadPerSecond();
+            }
+            if (!Double.isNaN(summary.getRecordsWrittenPerSecond())) {
+                totalRecordsWrittenPerSecond += summary.getRecordsWrittenPerSecond();
+            }
             return this;
         }
 

--- a/java/core/src/test/java/sleeper/core/record/process/AverageRecordRateTest.java
+++ b/java/core/src/test/java/sleeper/core/record/process/AverageRecordRateTest.java
@@ -111,7 +111,23 @@ public class AverageRecordRateTest {
     }
 
     @Test
-    void shouldExcludeRunsWithZeroRecordsReadFromAverageRateCalculation() {
+    void shouldExcludeARunWithNoRecordsProcessedFromAverageRateCalculation() {
+        AverageRecordRate rate = rateFrom(
+                new RecordsProcessedSummary(
+                        new RecordsProcessed(0L, 0L),
+                        Instant.parse("2022-10-13T10:18:00.000Z"), Duration.ofSeconds(10)),
+                new RecordsProcessedSummary(
+                        new RecordsProcessed(10L, 10L),
+                        Instant.parse("2022-10-13T10:18:00.000Z"), Duration.ofSeconds(10)));
+
+        assertThat(rate).extracting("runCount", "recordsRead", "recordsWritten", "totalDuration",
+                "recordsReadPerSecond", "recordsWrittenPerSecond",
+                "averageRunRecordsReadPerSecond", "averageRunRecordsWrittenPerSecond"
+        ).containsExactly(2, 10L, 10L, Duration.ofSeconds(20), 0.5, 0.5, 1.0, 1.0);
+    }
+
+    @Test
+    void shouldExcludeARunWithNoRecordsReadFromAverageReadRateCalculation() {
         AverageRecordRate rate = rateFrom(
                 new RecordsProcessedSummary(
                         new RecordsProcessed(0L, 10L),
@@ -123,11 +139,11 @@ public class AverageRecordRateTest {
         assertThat(rate).extracting("runCount", "recordsRead", "recordsWritten", "totalDuration",
                 "recordsReadPerSecond", "recordsWrittenPerSecond",
                 "averageRunRecordsReadPerSecond", "averageRunRecordsWrittenPerSecond"
-        ).containsExactly(2, 10L, 20L, Duration.ofSeconds(20), 0.5, 1.0, 0.5, 1.0);
+        ).containsExactly(2, 10L, 20L, Duration.ofSeconds(20), 0.5, 1.0, 1.0, 1.0);
     }
 
     @Test
-    void shouldExcludeRunsWithZeroRecordsWrittenFromAverageRateCalculation() {
+    void shouldExcludeARunWithNoRecordsWrittenFromAverageWriteRateCalculation() {
         AverageRecordRate rate = rateFrom(
                 new RecordsProcessedSummary(
                         new RecordsProcessed(10L, 0L),
@@ -139,11 +155,11 @@ public class AverageRecordRateTest {
         assertThat(rate).extracting("runCount", "recordsRead", "recordsWritten", "totalDuration",
                 "recordsReadPerSecond", "recordsWrittenPerSecond",
                 "averageRunRecordsReadPerSecond", "averageRunRecordsWrittenPerSecond"
-        ).containsExactly(2, 20L, 10L, Duration.ofSeconds(20), 1.0, 0.5, 1.0, 0.5);
+        ).containsExactly(2, 20L, 10L, Duration.ofSeconds(20), 1.0, 0.5, 1.0, 1.0);
     }
 
     @Test
-    void shouldExcludeRunsWithZeroDurationFromAverageRateCalculation() {
+    void shouldExcludeARunWithZeroDurationFromAverageRateCalculation() {
         AverageRecordRate rate = rateFrom(
                 new RecordsProcessedSummary(
                         new RecordsProcessed(10L, 10L),
@@ -155,7 +171,7 @@ public class AverageRecordRateTest {
         assertThat(rate).extracting("runCount", "recordsRead", "recordsWritten", "totalDuration",
                 "recordsReadPerSecond", "recordsWrittenPerSecond",
                 "averageRunRecordsReadPerSecond", "averageRunRecordsWrittenPerSecond"
-        ).containsExactly(2, 20L, 20L, Duration.ofSeconds(10), 2.0, 2.0, 0.5, 0.5);
+        ).containsExactly(2, 20L, 20L, Duration.ofSeconds(10), 2.0, 2.0, 1.0, 1.0);
     }
 
     private static AverageRecordRate rateFrom(RecordsProcessedSummary... summaries) {

--- a/java/core/src/test/java/sleeper/core/record/process/AverageRecordRateTest.java
+++ b/java/core/src/test/java/sleeper/core/record/process/AverageRecordRateTest.java
@@ -111,10 +111,42 @@ public class AverageRecordRateTest {
     }
 
     @Test
-    void shouldExcludeRunsWithRateOfNaNFromAverageRateCalculation() {
+    void shouldExcludeRunsWithZeroRecordsReadFromAverageRateCalculation() {
         AverageRecordRate rate = rateFrom(
                 new RecordsProcessedSummary(
-                        new RecordsProcessed(0L, 0L),
+                        new RecordsProcessed(0L, 10L),
+                        Instant.parse("2022-10-13T10:18:00.000Z"), Duration.ofSeconds(10)),
+                new RecordsProcessedSummary(
+                        new RecordsProcessed(10L, 10L),
+                        Instant.parse("2022-10-13T10:18:00.000Z"), Duration.ofSeconds(10)));
+
+        assertThat(rate).extracting("runCount", "recordsRead", "recordsWritten", "totalDuration",
+                "recordsReadPerSecond", "recordsWrittenPerSecond",
+                "averageRunRecordsReadPerSecond", "averageRunRecordsWrittenPerSecond"
+        ).containsExactly(2, 10L, 20L, Duration.ofSeconds(20), 0.5, 1.0, 0.5, 1.0);
+    }
+
+    @Test
+    void shouldExcludeRunsWithZeroRecordsWrittenFromAverageRateCalculation() {
+        AverageRecordRate rate = rateFrom(
+                new RecordsProcessedSummary(
+                        new RecordsProcessed(10L, 0L),
+                        Instant.parse("2022-10-13T10:18:00.000Z"), Duration.ofSeconds(10)),
+                new RecordsProcessedSummary(
+                        new RecordsProcessed(10L, 10L),
+                        Instant.parse("2022-10-13T10:18:00.000Z"), Duration.ofSeconds(10)));
+
+        assertThat(rate).extracting("runCount", "recordsRead", "recordsWritten", "totalDuration",
+                "recordsReadPerSecond", "recordsWrittenPerSecond",
+                "averageRunRecordsReadPerSecond", "averageRunRecordsWrittenPerSecond"
+        ).containsExactly(2, 20L, 10L, Duration.ofSeconds(20), 1.0, 0.5, 1.0, 0.5);
+    }
+
+    @Test
+    void shouldExcludeRunsWithZeroDurationFromAverageRateCalculation() {
+        AverageRecordRate rate = rateFrom(
+                new RecordsProcessedSummary(
+                        new RecordsProcessed(10L, 10L),
                         Instant.parse("2022-10-13T10:18:00.000Z"), Duration.ofSeconds(0)),
                 new RecordsProcessedSummary(
                         new RecordsProcessed(10L, 10L),
@@ -123,7 +155,7 @@ public class AverageRecordRateTest {
         assertThat(rate).extracting("runCount", "recordsRead", "recordsWritten", "totalDuration",
                 "recordsReadPerSecond", "recordsWrittenPerSecond",
                 "averageRunRecordsReadPerSecond", "averageRunRecordsWrittenPerSecond"
-        ).containsExactly(2, 10L, 10L, Duration.ofSeconds(10), 1.0, 1.0, 0.5, 0.5);
+        ).containsExactly(2, 20L, 20L, Duration.ofSeconds(10), 2.0, 2.0, 0.5, 0.5);
     }
 
     private static AverageRecordRate rateFrom(RecordsProcessedSummary... summaries) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1134

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - AverageRecordRateTest.shouldExcludeRunsWithRateOfNaNFromAverageRateCalculation

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
