### PR TITLE
Issue 1163 - Only build Maven site if tests failed

### DIFF
--- a/.github/workflows/chunk.yaml
+++ b/.github/workflows/chunk.yaml
@@ -37,16 +37,18 @@ jobs:
         run: mvn --batch-mode clean install -am -pl ${{ steps.config.outputs.moduleList }} -Pquick,skipShade -Dmaven.repo.local=.m2/repository
         working-directory: ./java
       - name: Test
+        id: test
         run: mvn --batch-mode --fail-at-end verify -pl ${{ steps.config.outputs.moduleList }} -Dmaven.repo.local=.m2/repository -e
         working-directory: ./java
       - name: Generate site
-        if: always()
+        id: site
+        if: failure() && steps.test.conclusion == 'failure'
         run: |
           mvn --batch-mode clean site-deploy -PcleanForSite -pl sleeper:aws,${{ steps.config.outputs.moduleList }} \
             -Dmaven.repo.local=.m2/repository
         working-directory: ./java
       - name: Upload site as artifact
-        if: always()
+        if: failure() && steps.site.conclusion == 'success'
         uses: actions/upload-artifact@v3
         with:
           name: site


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1163

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Just GitHub workflow changes
    - Site generation tested in PR: https://github.com/gchq/sleeper/pull/1166

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
