### PR TITLE
Issue 1160 - Include running processes in reports by period

### DIFF
--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusInPeriodTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusInPeriodTest.java
@@ -18,7 +18,6 @@ package sleeper.compaction.job;
 import org.junit.jupiter.api.Test;
 
 import sleeper.compaction.job.status.CompactionJobStatus;
-import sleeper.core.record.process.RecordsProcessed;
 import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.record.process.RecordsProcessedSummaryTestData;
 
@@ -33,9 +32,6 @@ import static sleeper.core.record.process.status.TestProcessStatusUpdateRecords.
 public class CompactionJobStatusInPeriodTest {
 
     private final CompactionJob job = new CompactionJobTestDataHelper().singleFileCompaction();
-    private final RecordsProcessedSummary summary = new RecordsProcessedSummary(
-            new RecordsProcessed(200L, 100L),
-            Instant.parse("2022-09-23T11:00:00.000Z"), Instant.parse("2022-09-23T11:30:00.000Z"));
 
     private static RecordsProcessedSummary startAndFinishTime(Instant startTime, Instant finishTime) {
         return RecordsProcessedSummaryTestData.summary(startTime, finishTime, 200, 100);

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusInPeriodTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusInPeriodTest.java
@@ -58,7 +58,7 @@ public class CompactionJobStatusInPeriodTest {
         CompactionJobStatus status = jobCreated(job, beforeTime);
 
         // When / Then
-        assertThat(status.isInPeriod(startTime, endTime)).isFalse();
+        assertThat(status.isInPeriod(startTime, endTime)).isTrue();
     }
 
     @Test
@@ -112,7 +112,7 @@ public class CompactionJobStatusInPeriodTest {
                 startedCompactionRun(DEFAULT_TASK_ID, beforeTime2));
 
         // When / Then
-        assertThat(status.isInPeriod(startTime, endTime)).isFalse();
+        assertThat(status.isInPeriod(startTime, endTime)).isTrue();
     }
 
     @Test

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusInPeriodTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusInPeriodTest.java
@@ -54,7 +54,7 @@ public class CompactionJobStatusInPeriodTest {
     }
 
     @Test
-    public void shouldBeBeforePeriodWithCreatedTime() {
+    public void shouldOverlapPeriodWhenCreatedBeforeAndUnstarted() {
         // Given
         Instant beforeTime = Instant.parse("2022-09-23T11:44:00.000Z");
         Instant startTime = Instant.parse("2022-09-23T11:44:01.000Z");
@@ -106,7 +106,7 @@ public class CompactionJobStatusInPeriodTest {
     }
 
     @Test
-    public void shouldBeBeforePeriodWithStartedTime() {
+    public void shouldOverlapPeriodWhenStartedBeforeAndUnfinished() {
         // Given
         Instant beforeTime1 = Instant.parse("2022-09-23T11:43:00.000Z");
         Instant beforeTime2 = Instant.parse("2022-09-23T11:44:00.000Z");

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskStatusInPeriodTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskStatusInPeriodTest.java
@@ -50,13 +50,13 @@ public class CompactionTaskStatusInPeriodTest {
     }
 
     @Test
-    public void shouldNotBeInPeriodWithStartTimeOnlyWhenStartIsStartTime() {
+    public void shouldBeInPeriodWhenUnfinishedTaskStartsAtWindowStartTime() {
         // Given
         Instant startTime = Instant.parse("2022-10-06T11:19:00.001Z");
         CompactionTaskStatus task = taskWithStartTime(startTime);
 
         // When / Then
-        assertThat(task.isInPeriod(startTime, FAR_FUTURE)).isFalse();
+        assertThat(task.isInPeriod(startTime, FAR_FUTURE)).isTrue();
     }
 
     @Test
@@ -112,6 +112,28 @@ public class CompactionTaskStatusInPeriodTest {
 
         // When / Then
         assertThat(task.isInPeriod(startTime, FAR_FUTURE)).isTrue();
+    }
+
+    @Test
+    public void shouldBeInPeriodWhenStartedBeforePeriodAndStillRunning() {
+        // Given
+        Instant startTime = Instant.parse("2022-10-06T11:00:00.001Z");
+        Instant periodStart = Instant.parse("2022-10-06T11:10:00.000Z");
+        Instant periodEnd = Instant.parse("2022-10-06T12:00:00.000Z");
+
+        // When / Then
+        assertThat(taskWithStartTime(startTime).isInPeriod(periodStart, periodEnd)).isTrue();
+    }
+
+    @Test
+    public void shouldNotBeInPeriodWhenStartedAfterPeriodAndStillRunning() {
+        // Given
+        Instant periodStart = Instant.parse("2022-10-06T11:00:00.000Z");
+        Instant periodEnd = Instant.parse("2022-10-06T12:00:00.000Z");
+        Instant startTime = Instant.parse("2022-10-06T12:10:00.001Z");
+
+        // When / Then
+        assertThat(taskWithStartTime(startTime).isInPeriod(periodStart, periodEnd)).isFalse();
     }
 
     private static CompactionTaskStatus taskWithStartTime(Instant startTime) {

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/testutils/CompactionTaskStatusStoreInMemoryTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/testutils/CompactionTaskStatusStoreInMemoryTest.java
@@ -275,7 +275,7 @@ public class CompactionTaskStatusStoreInMemoryTest {
         void shouldGetNoTasksInPeriod() {
             // Given
             CompactionTaskStatus started = startedStatusBuilder(
-                    Instant.parse("2023-03-30T11:44:00Z"))
+                    Instant.parse("2023-03-30T13:44:00Z"))
                     .taskId("test-task").build();
 
             // When

--- a/java/compaction/compaction-status-store/src/test/java/sleeper/compaction/status/store/job/QueryCompactionJobStatusByPeriodIT.java
+++ b/java/compaction/compaction-status-store/src/test/java/sleeper/compaction/status/store/job/QueryCompactionJobStatusByPeriodIT.java
@@ -70,7 +70,7 @@ public class QueryCompactionJobStatusByPeriodIT extends DynamoDBCompactionJobSta
         store.jobCreated(job);
 
         // Then
-        Instant periodStart = Instant.now().plus(Period.ofDays(1));
+        Instant periodStart = Instant.now().minus(Period.ofDays(2));
         Instant periodEnd = periodStart.plus(Period.ofDays(1));
         assertThat(store.getJobsInTimePeriod(tableName, periodStart, periodEnd)).isEmpty();
     }

--- a/java/core/src/main/java/sleeper/core/record/process/status/TimeWindowQuery.java
+++ b/java/core/src/main/java/sleeper/core/record/process/status/TimeWindowQuery.java
@@ -16,18 +16,28 @@
 
 package sleeper.core.record.process.status;
 
+import java.time.Duration;
 import java.time.Instant;
 
 public class TimeWindowQuery {
     private final Instant windowStartTime;
     private final Instant windowEndTime;
+    private final Duration maxRuntime;
 
     public TimeWindowQuery(Instant windowStartTime, Instant windowEndTime) {
+        this(windowStartTime, windowEndTime, null);
+    }
+
+    public TimeWindowQuery(Instant windowStartTime, Instant windowEndTime, Duration maxRuntime) {
         this.windowStartTime = windowStartTime;
         this.windowEndTime = windowEndTime;
+        this.maxRuntime = maxRuntime;
     }
 
     public boolean isUnfinishedProcessInWindow(Instant startTime) {
+        if (maxRuntime != null && startTime.plus(maxRuntime).isBefore(windowStartTime)) {
+            return false;
+        }
         return startTime.isBefore(windowEndTime);
     }
 

--- a/java/core/src/main/java/sleeper/core/record/process/status/TimeWindowQuery.java
+++ b/java/core/src/main/java/sleeper/core/record/process/status/TimeWindowQuery.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.record.process.status;
+
+import java.time.Instant;
+
+public class TimeWindowQuery {
+    private final Instant windowStartTime;
+    private final Instant windowEndTime;
+
+    public TimeWindowQuery(Instant windowStartTime, Instant windowEndTime) {
+        this.windowStartTime = windowStartTime;
+        this.windowEndTime = windowEndTime;
+    }
+
+    public boolean isStartedInWindow(Instant startTime) {
+        return startTime.isAfter(windowStartTime) &&
+                startTime.isBefore(windowEndTime);
+    }
+
+    public boolean isFinishedInWindow(Instant startTime, Instant endTime) {
+        return startTime.isBefore(windowStartTime) &&
+                endTime.isAfter(windowStartTime) &&
+                endTime.isBefore(windowEndTime);
+    }
+
+    public boolean isRunningInWindow(Instant startTime) {
+        return startTime.isBefore(windowStartTime);
+    }
+
+    public boolean isInWindow(Instant startTime, Instant endTime) {
+        return isStartedInWindow(startTime) ||
+                isRunningInWindow(startTime) ||
+                isFinishedInWindow(startTime, endTime);
+    }
+}

--- a/java/core/src/main/java/sleeper/core/record/process/status/TimeWindowQuery.java
+++ b/java/core/src/main/java/sleeper/core/record/process/status/TimeWindowQuery.java
@@ -27,24 +27,12 @@ public class TimeWindowQuery {
         this.windowEndTime = windowEndTime;
     }
 
-    public boolean isStartedInWindow(Instant startTime) {
-        return startTime.isAfter(windowStartTime) &&
+    public boolean isUnfinishedProcessInWindow(Instant startTime) {
+        return startTime.isBefore(windowEndTime);
+    }
+
+    public boolean isFinishedProcessInWindow(Instant startTime, Instant endTime) {
+        return endTime.isAfter(windowStartTime) &&
                 startTime.isBefore(windowEndTime);
-    }
-
-    public boolean isFinishedInWindow(Instant startTime, Instant endTime) {
-        return startTime.isBefore(windowStartTime) &&
-                endTime.isAfter(windowStartTime) &&
-                endTime.isBefore(windowEndTime);
-    }
-
-    public boolean isRunningInWindow(Instant startTime) {
-        return startTime.isBefore(windowStartTime);
-    }
-
-    public boolean isInWindow(Instant startTime, Instant endTime) {
-        return isStartedInWindow(startTime) ||
-                isRunningInWindow(startTime) ||
-                isFinishedInWindow(startTime, endTime);
     }
 }

--- a/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
+++ b/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.record.process.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeWindowQueryTest {
+    @Nested
+    @DisplayName("Process started")
+    class ProcessStarted {
+        @Test
+        void shouldBeInPeriodWhereStartTimeIsBeforePeriodStartTime() {
+            Instant startTime = Instant.parse("2023-08-16T11:00:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isInWindow(startTime, startTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenStartTimeIsAfterPeriodStartTimeButBeforePeriodEndTime() {
+            Instant startTime = Instant.parse("2023-08-16T12:30:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isInWindow(startTime, startTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldNotBeInPeriodWhenStartTimeIsAfterPeriodEndTime() {
+            Instant startTime = Instant.parse("2023-08-16T14:00:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isInWindow(startTime, startTime))
+                    .isFalse();
+        }
+    }
+}

--- a/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
+++ b/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
@@ -133,6 +133,19 @@ public class TimeWindowQueryTest {
             assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
                     .isTrue();
         }
+
+        @Test
+        void shouldBeInPeriodWhenProcessContainsWindowPeriod() {
+            Instant startTime = Instant.parse("2023-08-16T11:00:00Z");
+            Instant endTime = Instant.parse("2023-08-16T14:00:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isTrue();
+        }
     }
 
     @Nested

--- a/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
+++ b/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
@@ -36,7 +36,7 @@ public class TimeWindowQueryTest {
                     Instant.parse("2023-08-16T13:00:00Z")
             );
 
-            assertThat(timeWindowQuery.isInWindow(startTime, startTime))
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
                     .isTrue();
         }
 
@@ -48,7 +48,7 @@ public class TimeWindowQueryTest {
                     Instant.parse("2023-08-16T13:00:00Z")
             );
 
-            assertThat(timeWindowQuery.isInWindow(startTime, startTime))
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
                     .isTrue();
         }
 
@@ -60,8 +60,77 @@ public class TimeWindowQueryTest {
                     Instant.parse("2023-08-16T13:00:00Z")
             );
 
-            assertThat(timeWindowQuery.isInWindow(startTime, startTime))
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
                     .isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Process finished")
+    class ProcessFinished {
+        @Test
+        void shouldBeInPeriodWhenProcessStartsAndFinishesInsidePeriod() {
+            Instant startTime = Instant.parse("2023-08-16T12:20:00Z");
+            Instant endTime = Instant.parse("2023-08-16T12:40:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldNotBeInPeriodWhenProcessFinishesBeforePeriod() {
+            Instant startTime = Instant.parse("2023-08-16T11:20:00Z");
+            Instant endTime = Instant.parse("2023-08-16T11:40:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isFalse();
+        }
+
+        @Test
+        void shouldNotBeInPeriodWhenProcessStartsAfterPeriod() {
+            Instant startTime = Instant.parse("2023-08-16T13:20:00Z");
+            Instant endTime = Instant.parse("2023-08-16T13:40:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isFalse();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenProcessOverlapsEndOfPeriod() {
+            Instant startTime = Instant.parse("2023-08-16T12:40:00Z");
+            Instant endTime = Instant.parse("2023-08-16T13:20:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenProcessOverlapsStartOfPeriod() {
+            Instant startTime = Instant.parse("2023-08-16T11:40:00Z");
+            Instant endTime = Instant.parse("2023-08-16T12:20:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isTrue();
         }
     }
 }

--- a/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
+++ b/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
@@ -67,6 +67,75 @@ public class TimeWindowQueryTest {
     }
 
     @Nested
+    @DisplayName("Process finished")
+    class ProcessFinished {
+        @Test
+        void shouldBeInPeriodWhenProcessStartsAndFinishesInsidePeriod() {
+            Instant startTime = Instant.parse("2023-08-16T12:20:00Z");
+            Instant endTime = Instant.parse("2023-08-16T12:40:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldNotBeInPeriodWhenProcessFinishesBeforePeriod() {
+            Instant startTime = Instant.parse("2023-08-16T11:20:00Z");
+            Instant endTime = Instant.parse("2023-08-16T11:40:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isFalse();
+        }
+
+        @Test
+        void shouldNotBeInPeriodWhenProcessStartsAfterPeriod() {
+            Instant startTime = Instant.parse("2023-08-16T13:20:00Z");
+            Instant endTime = Instant.parse("2023-08-16T13:40:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isFalse();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenProcessOverlapsEndOfPeriod() {
+            Instant startTime = Instant.parse("2023-08-16T12:40:00Z");
+            Instant endTime = Instant.parse("2023-08-16T13:20:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenProcessOverlapsStartOfPeriod() {
+            Instant startTime = Instant.parse("2023-08-16T11:40:00Z");
+            Instant endTime = Instant.parse("2023-08-16T12:20:00Z");
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
+                    .isTrue();
+        }
+    }
+
+    @Nested
     @DisplayName("Process run time can be limited")
     class ProcessRuntimeLimited {
 
@@ -155,72 +224,4 @@ public class TimeWindowQueryTest {
         }
     }
 
-    @Nested
-    @DisplayName("Process finished")
-    class ProcessFinished {
-        @Test
-        void shouldBeInPeriodWhenProcessStartsAndFinishesInsidePeriod() {
-            Instant startTime = Instant.parse("2023-08-16T12:20:00Z");
-            Instant endTime = Instant.parse("2023-08-16T12:40:00Z");
-            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
-                    Instant.parse("2023-08-16T12:00:00Z"),
-                    Instant.parse("2023-08-16T13:00:00Z")
-            );
-
-            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
-                    .isTrue();
-        }
-
-        @Test
-        void shouldNotBeInPeriodWhenProcessFinishesBeforePeriod() {
-            Instant startTime = Instant.parse("2023-08-16T11:20:00Z");
-            Instant endTime = Instant.parse("2023-08-16T11:40:00Z");
-            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
-                    Instant.parse("2023-08-16T12:00:00Z"),
-                    Instant.parse("2023-08-16T13:00:00Z")
-            );
-
-            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
-                    .isFalse();
-        }
-
-        @Test
-        void shouldNotBeInPeriodWhenProcessStartsAfterPeriod() {
-            Instant startTime = Instant.parse("2023-08-16T13:20:00Z");
-            Instant endTime = Instant.parse("2023-08-16T13:40:00Z");
-            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
-                    Instant.parse("2023-08-16T12:00:00Z"),
-                    Instant.parse("2023-08-16T13:00:00Z")
-            );
-
-            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
-                    .isFalse();
-        }
-
-        @Test
-        void shouldBeInPeriodWhenProcessOverlapsEndOfPeriod() {
-            Instant startTime = Instant.parse("2023-08-16T12:40:00Z");
-            Instant endTime = Instant.parse("2023-08-16T13:20:00Z");
-            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
-                    Instant.parse("2023-08-16T12:00:00Z"),
-                    Instant.parse("2023-08-16T13:00:00Z")
-            );
-
-            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
-                    .isTrue();
-        }
-
-        @Test
-        void shouldBeInPeriodWhenProcessOverlapsStartOfPeriod() {
-            Instant startTime = Instant.parse("2023-08-16T11:40:00Z");
-            Instant endTime = Instant.parse("2023-08-16T12:20:00Z");
-            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
-                    Instant.parse("2023-08-16T12:00:00Z"),
-                    Instant.parse("2023-08-16T13:00:00Z")
-            );
-
-            assertThat(timeWindowQuery.isFinishedProcessInWindow(startTime, endTime))
-                    .isTrue();
-        }
-    }
 }

--- a/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
+++ b/java/core/src/test/java/sleeper/core/record/process/status/TimeWindowQueryTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,6 +59,95 @@ public class TimeWindowQueryTest {
             TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
                     Instant.parse("2023-08-16T12:00:00Z"),
                     Instant.parse("2023-08-16T13:00:00Z")
+            );
+
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
+                    .isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Process run time can be limited")
+    class ProcessRuntimeLimited {
+
+        @Test
+        void shouldNotBeInPeriodWhenMaxRuntimeIsMetBeforeWindow() {
+            Instant startTime = Instant.parse("2023-08-16T10:00:00Z");
+            Duration maxRuntime = Duration.ofHours(1);
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z"),
+                    maxRuntime
+            );
+
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
+                    .isFalse();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenMaxRuntimeIsMetDuringWindow() {
+            Instant startTime = Instant.parse("2023-08-16T11:30:00Z");
+            Duration maxRuntime = Duration.ofHours(1);
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z"),
+                    maxRuntime
+            );
+
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenMaxRuntimeIsMetAfterWindow() {
+            Instant startTime = Instant.parse("2023-08-16T11:30:00Z");
+            Duration maxRuntime = Duration.ofHours(2);
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z"),
+                    maxRuntime
+            );
+
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenStartedAndMetMaxRuntimeDuringWindow() {
+            Instant startTime = Instant.parse("2023-08-16T12:15:00Z");
+            Duration maxRuntime = Duration.ofMinutes(30);
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z"),
+                    maxRuntime
+            );
+
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldBeInPeriodWhenStartedDuringWindowAndMaxRuntimeIsAfterWindow() {
+            Instant startTime = Instant.parse("2023-08-16T12:15:00Z");
+            Duration maxRuntime = Duration.ofHours(1);
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z"),
+                    maxRuntime
+            );
+
+            assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))
+                    .isTrue();
+        }
+
+        @Test
+        void shouldNotBeInPeriodWhenStartedAfterWindowWithMaxRuntime() {
+            Instant startTime = Instant.parse("2023-08-16T13:15:00Z");
+            Duration maxRuntime = Duration.ofHours(1);
+            TimeWindowQuery timeWindowQuery = new TimeWindowQuery(
+                    Instant.parse("2023-08-16T12:00:00Z"),
+                    Instant.parse("2023-08-16T13:00:00Z"),
+                    maxRuntime
             );
 
             assertThat(timeWindowQuery.isUnfinishedProcessInWindow(startTime))

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStatus.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStatus.java
@@ -20,6 +20,7 @@ import sleeper.core.record.process.status.JobStatusUpdates;
 import sleeper.core.record.process.status.ProcessRun;
 import sleeper.core.record.process.status.ProcessRuns;
 import sleeper.core.record.process.status.ProcessStatusUpdateRecord;
+import sleeper.core.record.process.status.TimeWindowQuery;
 
 import java.time.Instant;
 import java.util.Comparator;
@@ -99,9 +100,14 @@ public class IngestJobStatus {
                 .orElseThrow();
     }
 
-    public boolean isInPeriod(Instant startTime, Instant endTime) {
-        return startTime.isBefore(jobRuns.lastTime().orElse(endTime))
-                && endTime.isAfter(jobRuns.firstTime().orElse(startTime));
+    public boolean isInPeriod(Instant windowStartTime, Instant windowEndTime) {
+        TimeWindowQuery timeWindowQuery = new TimeWindowQuery(windowStartTime, windowEndTime);
+        if (isFinished()) {
+            return timeWindowQuery.isFinishedProcessInWindow(
+                    jobRuns.firstTime().orElseThrow(), jobRuns.lastTime().orElseThrow());
+        } else {
+            return timeWindowQuery.isUnfinishedProcessInWindow(jobRuns.firstTime().orElseThrow());
+        }
     }
 
     @Override

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/task/IngestTaskStatus.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/task/IngestTaskStatus.java
@@ -18,6 +18,7 @@ package sleeper.ingest.task;
 
 import sleeper.core.record.process.status.ProcessFinishedStatus;
 import sleeper.core.record.process.status.ProcessRun;
+import sleeper.core.record.process.status.TimeWindowQuery;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -48,9 +49,13 @@ public class IngestTaskStatus {
         return finishedStatus;
     }
 
-    public boolean isInPeriod(Instant startTime, Instant endTime) {
-        return startTime.isBefore(getLastTime())
-                && endTime.isAfter(getStartTime());
+    public boolean isInPeriod(Instant windowStartTime, Instant windowEndTime) {
+        TimeWindowQuery timeWindowQuery = new TimeWindowQuery(windowStartTime, windowEndTime);
+        if (isFinished()) {
+            return timeWindowQuery.isFinishedProcessInWindow(startTime, finishedStatus.getFinishTime());
+        } else {
+            return timeWindowQuery.isUnfinishedProcessInWindow(startTime);
+        }
     }
 
     public Instant getStartTime() {
@@ -75,14 +80,6 @@ public class IngestTaskStatus {
 
     public Instant getExpiryDate() {
         return expiryDate;
-    }
-
-    private Instant getLastTime() {
-        if (isFinished()) {
-            return finishedStatus.getFinishTime();
-        } else {
-            return startTime;
-        }
     }
 
     public boolean isFinished() {

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/IngestJobStatusInPeriodTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/IngestJobStatusInPeriodTest.java
@@ -20,11 +20,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import sleeper.core.record.process.status.ProcessFinishedStatus;
+import sleeper.core.record.process.status.ProcessStatusUpdate;
 import sleeper.ingest.job.IngestJob;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summary;
+import static sleeper.core.record.process.status.TestProcessStatusUpdateRecords.records;
+import static sleeper.core.record.process.status.TestRunStatusUpdates.defaultUpdateTime;
+import static sleeper.ingest.job.status.IngestJobStatusTestData.finishedIngestJob;
+import static sleeper.ingest.job.status.IngestJobStatusTestData.singleJobStatusFrom;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.startedIngestJob;
 
 public class IngestJobStatusInPeriodTest {
@@ -75,7 +82,134 @@ public class IngestJobStatusInPeriodTest {
         }
     }
 
+    @Nested
+    @DisplayName("Finished job")
+    class FinishedJob {
+
+        @Test
+        public void shouldIncludeFinishedJobWhenRanInsideWindow() {
+            // Given
+            Instant windowStartTime = Instant.parse("2022-09-23T11:44:00.000Z");
+            Instant jobStartTime = Instant.parse("2022-09-23T11:44:15.000Z");
+            Instant jobFinishTime = Instant.parse("2022-09-23T11:44:45.000Z");
+            Instant windowEndTime = Instant.parse("2022-09-23T11:45:00.000Z");
+
+            // When / Then
+            assertThat(finishedStatus(jobStartTime, jobFinishTime)
+                    .isInPeriod(windowStartTime, windowEndTime))
+                    .isTrue();
+        }
+
+        @Test
+        public void shouldNotIncludeFinishedJobWhenFinishedBeforeWindow() {
+            // Given
+            Instant jobStartTime = Instant.parse("2022-09-23T11:42:00.000Z");
+            Instant jobFinishTime = Instant.parse("2022-09-23T11:43:00.000Z");
+            Instant windowStartTime = Instant.parse("2022-09-23T11:44:00.000Z");
+            Instant windowEndTime = Instant.parse("2022-09-23T11:45:00.000Z");
+
+            // When / Then
+            assertThat(finishedStatus(jobStartTime, jobFinishTime)
+                    .isInPeriod(windowStartTime, windowEndTime))
+                    .isFalse();
+        }
+
+        @Test
+        public void shouldIncludeFinishedJobWhenOverlapsWithWindow() {
+            // Given
+            Instant jobStartTime = Instant.parse("2022-09-23T11:43:30.000Z");
+            Instant windowStartTime = Instant.parse("2022-09-23T11:44:00.000Z");
+            Instant jobFinishTime = Instant.parse("2022-09-23T11:44:30.000Z");
+            Instant windowEndTime = Instant.parse("2022-09-23T11:45:00.000Z");
+
+            // When / Then
+            assertThat(finishedStatus(jobStartTime, jobFinishTime)
+                    .isInPeriod(windowStartTime, windowEndTime))
+                    .isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Job with multiple runs")
+    class MultipleRunsJob {
+
+        @Test
+        public void shouldIncludeUnfinishedJobWhenOneRunFinishedBeforeWindow() {
+            // Given
+            Instant run1StartTime = Instant.parse("2022-09-23T11:43:15.000Z");
+            Instant run1FinishTime = Instant.parse("2022-09-23T11:43:45.000Z");
+            Instant run2StartTime = Instant.parse("2022-09-23T11:43:50.000Z");
+            Instant windowStartTime = Instant.parse("2022-09-23T11:44:00.000Z");
+            Instant windowEndTime = Instant.parse("2022-09-23T11:45:00.000Z");
+
+            // When / Then
+            assertThat(statusFromUpdates(
+                    startedRun(run1StartTime),
+                    finishedRun(run1StartTime, run1FinishTime),
+                    startedRun(run2StartTime))
+                    .isInPeriod(windowStartTime, windowEndTime))
+                    .isTrue();
+        }
+
+        @Test
+        public void shouldNotIncludeFinishedJobWhenTwoRunsFinishedBeforeWindow() {
+            // Given
+            Instant run1StartTime = Instant.parse("2022-09-23T11:43:15.000Z");
+            Instant run1FinishTime = Instant.parse("2022-09-23T11:43:30.000Z");
+            Instant run2StartTime = Instant.parse("2022-09-23T11:43:40.000Z");
+            Instant run2FinishTime = Instant.parse("2022-09-23T11:43:55.000Z");
+            Instant windowStartTime = Instant.parse("2022-09-23T11:44:00.000Z");
+            Instant windowEndTime = Instant.parse("2022-09-23T11:45:00.000Z");
+
+            // When / Then
+            assertThat(statusFromUpdates(
+                    startedRun(run1StartTime),
+                    finishedRun(run1StartTime, run1FinishTime),
+                    startedRun(run2StartTime),
+                    finishedRun(run2StartTime, run2FinishTime))
+                    .isInPeriod(windowStartTime, windowEndTime))
+                    .isFalse();
+        }
+
+        @Test
+        public void shouldIncludeFinishedJobWhenSecondRunFinishedDuringWindow() {
+            // Given
+            Instant run1StartTime = Instant.parse("2022-09-23T11:43:15.000Z");
+            Instant run1FinishTime = Instant.parse("2022-09-23T11:43:45.000Z");
+            Instant run2StartTime = Instant.parse("2022-09-23T11:43:45.000Z");
+            Instant windowStartTime = Instant.parse("2022-09-23T11:44:00.000Z");
+            Instant run2FinishTime = Instant.parse("2022-09-23T11:44:15.000Z");
+            Instant windowEndTime = Instant.parse("2022-09-23T11:45:00.000Z");
+
+            // When / Then
+            assertThat(statusFromUpdates(
+                    startedRun(run1StartTime),
+                    finishedRun(run1StartTime, run1FinishTime),
+                    startedRun(run2StartTime),
+                    finishedRun(run2StartTime, run2FinishTime))
+                    .isInPeriod(windowStartTime, windowEndTime))
+                    .isTrue();
+        }
+    }
+
     private IngestJobStatus unfinishedStatus(Instant startTime) {
         return startedIngestJob(job, "test-task-id", startTime);
+    }
+
+    private IngestJobStatus finishedStatus(Instant startTime, Instant finishTime) {
+        return finishedIngestJob(job, "test-task-id", summary(startTime, finishTime, 100, 100));
+    }
+
+    private IngestJobStatus statusFromUpdates(ProcessStatusUpdate... updates) {
+        return singleJobStatusFrom(records().fromUpdates(updates));
+    }
+
+    private ProcessStatusUpdate startedRun(Instant startedTime) {
+        return IngestJobStartedStatus.startAndUpdateTime(job, startedTime, defaultUpdateTime(startedTime));
+    }
+
+    private ProcessStatusUpdate finishedRun(Instant startedTime, Instant finishedTime) {
+        return ProcessFinishedStatus.updateTimeAndSummary(defaultUpdateTime(finishedTime),
+                summary(startedTime, finishedTime, 100, 100));
     }
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/IngestJobStatusInPeriodTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/IngestJobStatusInPeriodTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.ingest.job.status;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.ingest.job.IngestJob;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.ingest.job.status.IngestJobStatusTestData.startedIngestJob;
+
+public class IngestJobStatusInPeriodTest {
+    private final IngestJob job = IngestJob.builder()
+            .id("test-job").files("test.parquet").tableName("test-table").build();
+
+    @Test
+    public void shouldIncludeUnfinishedJobWhenStartedBeforeWindowStartTime() {
+        // Given
+        Instant jobStartTime = Instant.parse("2022-09-23T11:43:00.000Z");
+        Instant windowStartTime = Instant.parse("2022-09-23T11:44:00.000Z");
+        Instant windowEndTime = Instant.parse("2022-09-23T11:44:02.000Z");
+        IngestJobStatus status = startedIngestJob(job, "test-task-id", jobStartTime);
+
+        // When / Then
+        assertThat(status.isInPeriod(windowStartTime, windowEndTime)).isTrue();
+    }
+}

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskStatusInPeriodTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskStatusInPeriodTest.java
@@ -15,6 +15,7 @@
  */
 package sleeper.ingest.task;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.record.process.RecordsProcessed;
@@ -112,6 +113,29 @@ public class IngestTaskStatusInPeriodTest {
 
         // When / Then
         assertThat(task.isInPeriod(startTime, FAR_FUTURE)).isTrue();
+    }
+
+    @Test
+    @Disabled("TODO")
+    public void shouldBeInPeriodWhenStartedBeforePeriodAndStillRunning() {
+        // Given
+        Instant startTime = Instant.parse("2022-10-06T11:00:00.001Z");
+        Instant periodStart = Instant.parse("2022-10-06T11:10:00.000Z");
+        Instant periodEnd = Instant.parse("2022-10-06T12:00:00.000Z");
+
+        // When / Then
+        assertThat(taskWithStartTime(startTime).isInPeriod(periodStart, periodEnd)).isTrue();
+    }
+
+    @Test
+    public void shouldNotBeInPeriodWhenStartedAfterPeriodAndStillRunning() {
+        // Given
+        Instant periodStart = Instant.parse("2022-10-06T11:00:00.000Z");
+        Instant periodEnd = Instant.parse("2022-10-06T12:00:00.000Z");
+        Instant startTime = Instant.parse("2022-10-06T12:10:00.001Z");
+
+        // When / Then
+        assertThat(taskWithStartTime(startTime).isInPeriod(periodStart, periodEnd)).isFalse();
     }
 
     private static IngestTaskStatus taskWithStartTime(Instant startTime) {

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskStatusInPeriodTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskStatusInPeriodTest.java
@@ -15,7 +15,6 @@
  */
 package sleeper.ingest.task;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.record.process.RecordsProcessed;
@@ -51,13 +50,13 @@ public class IngestTaskStatusInPeriodTest {
     }
 
     @Test
-    public void shouldNotBeInPeriodWithStartTimeOnlyWhenStartIsStartTime() {
+    public void shouldBeInPeriodWhenUnfinishedTaskStartsAtWindowStartTime() {
         // Given
         Instant startTime = Instant.parse("2022-10-06T11:19:00.001Z");
         IngestTaskStatus task = taskWithStartTime(startTime);
 
         // When / Then
-        assertThat(task.isInPeriod(startTime, FAR_FUTURE)).isFalse();
+        assertThat(task.isInPeriod(startTime, FAR_FUTURE)).isTrue();
     }
 
     @Test
@@ -116,7 +115,6 @@ public class IngestTaskStatusInPeriodTest {
     }
 
     @Test
-    @Disabled("TODO")
     public void shouldBeInPeriodWhenStartedBeforePeriodAndStillRunning() {
         // Given
         Instant startTime = Instant.parse("2022-10-06T11:00:00.001Z");


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1160

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - TimeWindowQueryTest
    - Updated tests checking whether each process is in a period

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
