### PR TITLE
Issue 1177 - Use Python dev version in `updateVersionNumber.sh`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,21 +1,21 @@
-# Copyright 2022-2023 Crown Copyright
-# 
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# 
-#     http://www.apache.org/licenses/LICENSE-2.0
-# 
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-from setuptools import setup, find_packages
+#  Copyright 2022-2023 Crown Copyright
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from setuptools import setup
 
 setup(
     name='sleeper',
-    version='0.19.0-SNAPSHOT',
+    version='0.19.0.dev1',
     description='Python client for Sleeper',
     packages=['sleeper', 'pq'],
     install_requires=[

--- a/scripts/dev/updateVersionNumber.sh
+++ b/scripts/dev/updateVersionNumber.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#
 # Copyright 2022-2023 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 set -e
 
@@ -28,12 +30,13 @@ echo "Setting new version to ${NEW_VERSION}"
 
 # Update the version number in the pom.xml files in the java code
 pushd "${PROJECT_ROOT}/java"
-mvn versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
+mvn versions:set -DnewVersion="${NEW_VERSION}" -DgenerateBackupPoms=false
 popd
 
 source "${PROJECT_ROOT}/scripts/functions/sedInPlace.sh"
 
 # Update the version number in the Python module
+NEW_VERSION_PYTHON="${NEW_VERSION//-SNAPSHOT/.dev1}"
 sed_in_place \
-  -e "s|^    version=.*|    version='${NEW_VERSION}',|" \
+  -e "s|^    version=.*|    version='${NEW_VERSION_PYTHON}',|" \
   "${PROJECT_ROOT}/python/setup.py"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1177

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - Just changed `updateVersionNumber.sh`, tested manually

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.