### PR TITLE
Issue 1077 - Remove hard coded teardown for Maven system tests

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/OutputInstanceIds.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/OutputInstanceIds.java
@@ -26,6 +26,9 @@ import static java.nio.file.StandardOpenOption.CREATE;
 
 public class OutputInstanceIds {
 
+    private OutputInstanceIds() {
+    }
+
     public static void addInstanceIdToOutput(String instanceId, SystemTestParameters parameters) {
         Path outputDirectory = parameters.getOutputDirectory();
         if (outputDirectory == null) {

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/OutputInstanceIds.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/OutputInstanceIds.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.drivers.instance;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+
+public class OutputInstanceIds {
+
+    public static void addInstanceIdToOutput(String instanceId, SystemTestParameters parameters) {
+        Path outputDirectory = parameters.getOutputDirectory();
+        if (outputDirectory == null) {
+            return;
+        }
+        try {
+            Files.writeString(outputDirectory.resolve("instanceIds.txt"),
+                    instanceId + "\n", CREATE, APPEND);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SleeperInstanceContext.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SleeperInstanceContext.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import static sleeper.configuration.properties.instance.CommonProperty.JARS_BUCKET;
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_BUCKET;
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_ROLE;
+import static sleeper.systemtest.drivers.instance.OutputInstanceIds.addInstanceIdToOutput;
 
 public class SleeperInstanceContext {
     private static final Logger LOGGER = LoggerFactory.getLogger(SleeperInstanceContext.class);
@@ -152,8 +153,10 @@ public class SleeperInstanceContext {
             InstanceProperties instanceProperties = new InstanceProperties();
             instanceProperties.loadFromS3GivenInstanceId(s3Client, instanceId);
             TablePropertiesProvider tablePropertiesProvider = new TablePropertiesProvider(s3Client, instanceProperties);
+            TableProperties tableProperties = tablePropertiesProvider.getTableProperties(tableName);
             StateStoreProvider stateStoreProvider = new StateStoreProvider(dynamoDBClient, instanceProperties);
-            return new Instance(instanceProperties, tablePropertiesProvider.getTableProperties(tableName), tablePropertiesProvider, stateStoreProvider);
+            addInstanceIdToOutput(instanceId, parameters);
+            return new Instance(instanceProperties, tableProperties, tablePropertiesProvider, stateStoreProvider);
         } catch (IOException e) {
             throw new RuntimeIOException(e);
         }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SystemTestParameters.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SystemTestParameters.java
@@ -25,6 +25,8 @@ import sleeper.systemtest.cdk.SystemTestBucketStack;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import static java.util.function.Predicate.not;
+
 public class SystemTestParameters {
 
     private final String shortTestId;
@@ -57,6 +59,7 @@ public class SystemTestParameters {
                 .subnetIds(System.getProperty("sleeper.system.test.subnet.ids"))
                 .scriptsDirectory(findScriptsDir())
                 .outputDirectory(Optional.ofNullable(System.getProperty("sleeper.system.test.output.dir"))
+                        .filter(not(String::isEmpty))
                         .map(Path::of)
                         .orElse(null))
                 .systemTestClusterEnabled(Optional.ofNullable(System.getProperty("sleeper.system.test.cluster.enabled"))

--- a/scripts/functions/systemTestUtils.sh
+++ b/scripts/functions/systemTestUtils.sh
@@ -1,0 +1,25 @@
+#
+# Copyright 2022-2023 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source "$(dirname "${BASH_SOURCE[0]}")/arrayUtils.sh"
+
+read_instance_ids_to_array() {
+    local ARRAY_OUT_NAME=$2
+    eval "$ARRAY_OUT_NAME=()"
+    while read -r id; do
+      eval "$ARRAY_OUT_NAME+=(\"$id\")"
+    done <"$1"
+}

--- a/scripts/functions/test/testSystemTestUtils.sh
+++ b/scripts/functions/test/testSystemTestUtils.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022-2023 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source "$(dirname "${BASH_SOURCE[0]}")/../systemTestUtils.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/runTestUtils.sh"
+
+echo "instance-1" > testInstanceIds.txt
+echo "instance-2" >> testInstanceIds.txt
+EXPECTED=("instance-1" "instance-2")
+
+PREDEFINED_ARRAY=()
+read_instance_ids_to_array testInstanceIds.txt PREDEFINED_ARRAY
+array_equals PREDEFINED_ARRAY EXPECTED || fail_test "PREDEFINED_ARRAY should equal EXPECTED"
+
+read_instance_ids_to_array testInstanceIds.txt NEW_ARRAY
+array_equals NEW_ARRAY EXPECTED || fail_test "NEW_ARRAY should equal EXPECTED"
+
+rm testInstanceIds.txt
+
+end_tests

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -33,6 +33,7 @@ SUBNETS=$2
 RESULTS_BUCKET=$3
 
 source "$SCRIPTS_DIR/functions/timeUtils.sh"
+source "$SCRIPTS_DIR/functions/systemTestUtils.sh"
 START_TIMESTAMP=$(record_time)
 START_TIME=$(recorded_time_str "$START_TIMESTAMP" "%Y%m%d-%H%M%S")
 OUTPUT_DIR="/tmp/sleeper/performanceTests/$START_TIME"
@@ -100,8 +101,7 @@ runMavenSystemTests() {
       -Dsleeper.system.test.output.dir="$OUTPUT_DIR/$TEST_NAME" \
       &> "$OUTPUT_DIR/$TEST_NAME.log"
     EXIT_CODE=$?
-    INSTANCE_ID="$SHORT_ID-main"
-    echo -n "$EXIT_CODE $INSTANCE_ID" > "$OUTPUT_DIR/$TEST_NAME.status"
+    echo -n "$EXIT_CODE $SHORT_ID" > "$OUTPUT_DIR/$TEST_NAME.status"
     pushd "$MAVEN_DIR"
     mvn --batch-mode site site:stage -pl system-test/system-test-suite \
        -DskipTests=true \
@@ -112,10 +112,8 @@ runMavenSystemTests() {
     popd
     rm -rf "$OUTPUT_DIR/site"
     INSTANCE_IDS=()
-    while read -r INSTANCE_ID; do
-      INSTANCE_IDS+=("$INSTANCE_ID")
-    done <"$OUTPUT_DIR/instanceIds.txt"
-    ./maven/tearDown.sh "$SHORT_ID" "$INSTANCE_ID" &> "$OUTPUT_DIR/$TEST_NAME.tearDown.log"
+    read_instance_ids_to_array "$OUTPUT_DIR/instanceIds.txt" INSTANCE_IDS
+    ./maven/tearDown.sh "$SHORT_ID" "${INSTANCE_IDS[@]}" &> "$OUTPUT_DIR/$TEST_NAME.tearDown.log"
 }
 
 runSystemTest bulkImportPerformance "bulk-imprt-$START_TIME" "ingest"

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -111,7 +111,9 @@ runMavenSystemTests() {
     zip -r "../site.zip" "."
     popd
     rm -rf "$OUTPUT_DIR/site"
-    ./../deploy/tearDown.sh "$INSTANCE_ID" &> "$OUTPUT_DIR/$TEST_NAME.tearDown.log"
+    while read -r INSTANCE_ID; do
+      ./../deploy/tearDown.sh "$INSTANCE_ID" >> "$OUTPUT_DIR/$TEST_NAME.tearDown.log" 2>&1
+    done <"$OUTPUT_DIR/instanceIds.txt"
     aws s3 rb "s3://sleeper-$SHORT_ID-ingest-source-bucket" --force
 }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1077

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - testSystemTestUtils.sh
    - Manually tested tear down in AWS
    - Tear down is included in nightly test script

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.