### PR TITLE
Issue 1193 - Remove delete markers when removing jars bucket

### DIFF
--- a/java/clients/src/test/java/sleeper/clients/teardown/RemoveJarsBucketIT.java
+++ b/java/clients/src/test/java/sleeper/clients/teardown/RemoveJarsBucketIT.java
@@ -70,6 +70,23 @@ class RemoveJarsBucketIT extends JarsBucketITBase {
     }
 
     @Test
+    void shouldRemoveBucketWithMultipleVersionsWhenOneVersionIsMarkedAsDeleted() throws IOException, InterruptedException {
+        // Given
+        Files.writeString(tempDir.resolve("test.jar"), "data1");
+        uploadJarsToBucket(bucketName);
+        Thread.sleep(1000);
+        Files.writeString(tempDir.resolve("test.jar"), "data2");
+        uploadJarsToBucket(bucketName);
+        s3.deleteObject(builder -> builder.bucket(bucketName).key("test.jar"));
+
+        // When
+        RemoveJarsBucket.remove(s3, bucketName);
+
+        // Then
+        assertThat(doesBucketExist(s3, bucketName)).isFalse();
+    }
+
+    @Test
     void shouldIgnoreIfBucketDoesNotExist() {
         assertThatCode(() -> RemoveJarsBucket.remove(s3, "not-a-bucket"))
                 .doesNotThrowAnyException();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1193

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - RemoveJarsBucket.shouldRemoveBucketWithMultipleVersionsWhenOneVersionIsMarkedAsDeleted

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.