### PR TITLE
Issue 1196 - Upload custom resources jar even when system test cluster is disabled

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SystemTestInstanceContext.java
@@ -136,15 +136,15 @@ public class SystemTestInstanceContext {
     }
 
     private void uploadJarsAndDockerImages() throws IOException, InterruptedException {
-        if (!parameters.isSystemTestClusterEnabled()) {
-            return;
-        }
         boolean jarsChanged = SyncJars.builder().s3(s3v2)
                 .jarsDirectory(parameters.getJarsDirectory())
                 .bucketName(parameters.buildJarsBucketName())
                 .region(parameters.getRegion())
                 .uploadFilter(jar -> BuiltJar.isFileJar(jar, CUSTOM_RESOURCES))
                 .deleteOldJars(false).build().sync();
+        if (!parameters.isSystemTestClusterEnabled()) {
+            return;
+        }
         UploadDockerImages.builder()
                 .baseDockerDirectory(parameters.getDockerDirectory())
                 .uploadDockerImagesScript(parameters.getScriptsDirectory().resolve("deploy/uploadDockerImages.sh"))


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1196

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing system tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.