### PR TITLE
Issue 1204 - Fix reference to system test instances in nightly test script tear down

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/cdk/TearDownMavenSystemTest.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/cdk/TearDownMavenSystemTest.java
@@ -48,6 +48,7 @@ public class TearDownMavenSystemTest {
         Path scriptsDir = Path.of(args[0]);
         String shortId = args[1];
         List<String> instanceIds = List.of(args).subList(2, args.length);
+        LOGGER.info("Found instance IDs to tear down: {}", instanceIds);
         for (String instanceId : instanceIds) {
             TearDownInstance.builder()
                     .scriptsDir(scriptsDir)

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/OutputInstanceIds.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/OutputInstanceIds.java
@@ -16,6 +16,9 @@
 
 package sleeper.systemtest.drivers.instance;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -25,6 +28,7 @@ import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.CREATE;
 
 public class OutputInstanceIds {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OutputInstanceIds.class);
 
     private OutputInstanceIds() {
     }
@@ -35,8 +39,9 @@ public class OutputInstanceIds {
             return;
         }
         try {
-            Files.writeString(outputDirectory.resolve("instanceIds.txt"),
-                    instanceId + "\n", CREATE, APPEND);
+            Path outputFile = outputDirectory.resolve("instanceIds.txt");
+            LOGGER.info("Appending instance id {} to output file: {}", instanceId, outputFile);
+            Files.writeString(outputFile, instanceId + "\n", CREATE, APPEND);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SleeperInstanceContext.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/SleeperInstanceContext.java
@@ -123,6 +123,7 @@ public class SleeperInstanceContext {
     private Instance createInstanceIfMissing(String identifier, DeployInstanceConfiguration deployInstanceConfiguration) {
         String instanceId = parameters.buildInstanceId(identifier);
         String tableName = "system-test";
+        addInstanceIdToOutput(instanceId, parameters);
         try {
             cloudFormationClient.describeStacks(builder -> builder.stackName(instanceId));
             LOGGER.info("Instance already exists: {}", instanceId);
@@ -157,7 +158,6 @@ public class SleeperInstanceContext {
             TablePropertiesProvider tablePropertiesProvider = new TablePropertiesProvider(s3Client, instanceProperties);
             TableProperties tableProperties = tablePropertiesProvider.getTableProperties(tableName);
             StateStoreProvider stateStoreProvider = new StateStoreProvider(dynamoDBClient, instanceProperties);
-            addInstanceIdToOutput(instanceId, parameters);
             return new Instance(instanceProperties, tableProperties, tablePropertiesProvider, stateStoreProvider);
         } catch (IOException e) {
             throw new RuntimeIOException(e);

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -112,7 +112,7 @@ runMavenSystemTests() {
     popd
     rm -rf "$OUTPUT_DIR/site"
     INSTANCE_IDS=()
-    read_instance_ids_to_array "$OUTPUT_DIR/instanceIds.txt" INSTANCE_IDS
+    read_instance_ids_to_array "$OUTPUT_DIR/$TEST_NAME/instanceIds.txt" INSTANCE_IDS
     ./maven/tearDown.sh "$SHORT_ID" "${INSTANCE_IDS[@]}" &> "$OUTPUT_DIR/$TEST_NAME.tearDown.log"
 }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1204

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Logging, nightly test bash script change

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.