### PR TITLE
docs(config, docs): normalise CPU architecture names

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -129,7 +129,7 @@ sleeper deployment test/deployAll/deployTest.sh ${ID} ${VPC} ${SUBNETS}
 ```
 
 An S3 bucket will be created for the jars, and ECR repos will be created and Docker images pushed to them.
-Note that this script currently needs to be run from an x86 machine as we do not yet have cross-architecture Docker
+Note that this script currently needs to be run from an x86_64 machine as we do not yet have cross-architecture Docker
 builds. Then CDK will be used to deploy a Sleeper instance. This will take around 20 minutes. Once that is complete,
 some tasks are started on an ECS cluster. These tasks generate some random data and write it to Sleeper. 11 ECS tasks
 will be created. Each of these will write 40 million records. As all writes to Sleeper are asynchronous, it will take a

--- a/docs/02-deployment-guide.md
+++ b/docs/02-deployment-guide.md
@@ -267,7 +267,7 @@ docker push $TAG
 
 #### Building for Graviton
 
-If you'd like to run operations in AWS Graviton-based instances, in ARM64 architecture, you can use Docker BuildX to
+If you'd like to run operations in AWS Graviton-based instances, on the ARM64 architecture, you can use Docker BuildX to
 build multiplatform images.
 
 These commands will create or recreate a builder:

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -387,7 +387,7 @@ sleeper.bulk.import.emr.ebs.volume.type=gp2
 # This can be a number from 1 to 25.
 sleeper.bulk.import.emr.ebs.volumes.per.instance=4
 
-# The architecture for EMR Serverless to use. X86_64 or ARM (Coming soon)
+# The architecture for EMR Serverless to use. X86_64 or ARM64 (Coming soon)
 sleeper.bulk.import.emr.serverless.architecture=X86_64
 
 # The version of EMR Serverless to use.
@@ -664,27 +664,27 @@ sleeper.compaction.max.concurrent.tasks=300
 # must be >= 1).
 sleeper.compaction.task.creation.period.minutes=1
 
-# The CPU architecture to run compaction tasks on.
+# The CPU architecture to run compaction tasks on. Valid values are X86_64 and ARM64.
 # See Task CPU architecture at
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
 sleeper.compaction.task.cpu.architecture=X86_64
 
-# The CPU for a compaction task using an ARM architecture.
+# The CPU for a compaction task using an ARM64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.arm.cpu=1024
 
-# The memory for a compaction task using an ARM architecture.
+# The memory for a compaction task using an ARM64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.arm.memory=4096
 
-# The CPU for a compaction task using an x86 architecture.
+# The CPU for a compaction task using an x86_64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.x86.cpu=1024
 
-# The memory for a compaction task using an x86 architecture.
+# The memory for a compaction task using an x86_64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.x86.memory=4096

--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -122,7 +122,7 @@ sleeper.table.metadata.s3.dynamo.pointintimerecovery=false
 ## on EMR or EKS.
 
 # (Non-persistent EMR mode only) Which architecture to be used for EC2 instance types in the EMR
-# cluster. Must be either "x86" "arm64" or "x86,arm64". For more information, see the Bulk import
+# cluster. Must be either "x86_64" "arm64" or "x86_64,arm64". For more information, see the Bulk import
 # using EMR - Instance types section in docs/05-ingest.md
 sleeper.table.bulk.import.emr.instance.architecture=x86_64
 

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CompactionProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CompactionProperty.java
@@ -68,31 +68,31 @@ public interface CompactionProperty {
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCDKDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_CPU_ARCHITECTURE = Index.propertyBuilder("sleeper.compaction.task.cpu.architecture")
-            .description("The CPU architecture to run compaction tasks on.\n" +
+            .description("The CPU architecture to run compaction tasks on. Valid values are X86_64 and ARM64.\n" +
                     "See Task CPU architecture at https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html")
             .defaultValue("X86_64")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCDKDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_ARM_CPU = Index.propertyBuilder("sleeper.compaction.task.arm.cpu")
-            .description("The CPU for a compaction task using an ARM architecture.\n" +
+            .description("The CPU for a compaction task using an ARM64 architecture.\n" +
                     "See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid options.")
             .defaultValue("1024")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCDKDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_ARM_MEMORY = Index.propertyBuilder("sleeper.compaction.task.arm.memory")
-            .description("The memory for a compaction task using an ARM architecture.\n" +
+            .description("The memory for a compaction task using an ARM64 architecture.\n" +
                     "See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid options.")
             .defaultValue("4096")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCDKDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_X86_CPU = Index.propertyBuilder("sleeper.compaction.task.x86.cpu")
-            .description("The CPU for a compaction task using an x86 architecture.\n" +
+            .description("The CPU for a compaction task using an x86_64 architecture.\n" +
                     "See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid options.")
             .defaultValue("1024")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCDKDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_X86_MEMORY = Index.propertyBuilder("sleeper.compaction.task.x86.memory")
-            .description("The memory for a compaction task using an x86 architecture.\n" +
+            .description("The memory for a compaction task using an x86_64 architecture.\n" +
                     "See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid options.")
             .defaultValue("4096")
             .propertyGroup(InstancePropertyGroup.COMPACTION)

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/EMRServerlessProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/EMRServerlessProperty.java
@@ -26,7 +26,7 @@ public interface EMRServerlessProperty {
 
     UserDefinedInstanceProperty BULK_IMPORT_EMR_SERVERLESS_ARCHITECTURE = Index
             .propertyBuilder("sleeper.bulk.import.emr.serverless.architecture")
-            .description("The architecture for EMR Serverless to use. X86_64 or ARM (Coming soon)")
+            .description("The architecture for EMR Serverless to use. X86_64 or ARM64 (Coming soon)")
             .propertyGroup(InstancePropertyGroup.BULK_IMPORT).defaultValue("X86_64")
             .validationPredicate(Predicate.isEqual("X86_64"))
             .runCDKDeployWhenChanged(true).build();

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
@@ -229,7 +229,7 @@ public interface TableProperty extends SleeperProperty {
     TableProperty BULK_IMPORT_EMR_INSTANCE_ARCHITECTURE = Index.propertyBuilder("sleeper.table.bulk.import.emr.instance.architecture")
             .defaultProperty(DEFAULT_BULK_IMPORT_EMR_INSTANCE_ARCHITECTURE)
             .description("(Non-persistent EMR mode only) Which architecture to be used for EC2 instance types " +
-                    "in the EMR cluster. Must be either \"x86\" \"arm64\" or \"x86,arm64\". " +
+                    "in the EMR cluster. Must be either \"x86_64\" \"arm64\" or \"x86_64,arm64\". " +
                     "For more information, see the Bulk import using EMR - Instance types section in docs/05-ingest.md")
             .propertyGroup(TablePropertyGroup.BULK_IMPORT)
             .build();

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -424,7 +424,7 @@ sleeper.bulk.import.emr.ebs.volume.type=gp2
 # This can be a number from 1 to 25.
 sleeper.bulk.import.emr.ebs.volumes.per.instance=4
 
-# The architecture for EMR Serverless to use. X86_64 or ARM (Coming soon)
+# The architecture for EMR Serverless to use. X86_64 or ARM64 (Coming soon)
 sleeper.bulk.import.emr.serverless.architecture=X86_64
 
 # The version of EMR Serverless to use.
@@ -688,27 +688,27 @@ sleeper.compaction.max.concurrent.tasks=300
 # must be >= 1).
 sleeper.compaction.task.creation.period.minutes=1
 
-# The CPU architecture to run compaction tasks on.
+# The CPU architecture to run compaction tasks on. Valid values are X86_64 and ARM64.
 # See Task CPU architecture at
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
 sleeper.compaction.task.cpu.architecture=X86_64
 
-# The CPU for a compaction task using an ARM architecture.
+# The CPU for a compaction task using an ARM64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.arm.cpu=1024
 
-# The memory for a compaction task using an ARM architecture.
+# The memory for a compaction task using an ARM64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.arm.memory=4096
 
-# The CPU for a compaction task using an x86 architecture.
+# The CPU for a compaction task using an x86_64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.x86.cpu=1024
 
-# The memory for a compaction task using an x86 architecture.
+# The memory for a compaction task using an x86_64 architecture.
 # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid
 # options.
 sleeper.compaction.task.x86.memory=4096


### PR DESCRIPTION
Update documentation and configuration examples to use consistent CPU architecture names.

Make sure you have checked _all_ steps below.

### Issue
- Resolves https://github.com/gchq/sleeper/issues/1229

### Tests

Documentation changes only
