### PR TITLE
Issue 1239 - Include nested test class name in report filename

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/TestContext.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/TestContext.java
@@ -20,6 +20,8 @@ import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TestContext {
 
@@ -56,7 +58,22 @@ public class TestContext {
     }
 
     public String getTestClassAndMethod() {
-        return testClass.getSimpleName() + "." + testMethod.getName();
+        return getTestClassName() + "." + testMethod.getName();
+    }
+
+    private String getTestClassName() {
+        return classAndAncestors(testClass)
+                .map(Class::getSimpleName)
+                .collect(Collectors.joining("."));
+    }
+
+    private static Stream<Class<?>> classAndAncestors(Class<?> clazz) {
+        Class<?> host = clazz.getNestHost();
+        if (host == clazz) {
+            return Stream.of(clazz);
+        } else {
+            return Stream.concat(classAndAncestors(host), Stream.of(clazz));
+        }
     }
 
     public static final class Builder {

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/TestContextTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/TestContextTest.java
@@ -16,6 +16,8 @@
 
 package sleeper.systemtest.suite.testutil;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -28,5 +30,16 @@ public class TestContextTest {
     void shouldGetTestNameAndClass(TestInfo info) {
         assertThat(testContext(info).getTestClassAndMethod())
                 .isEqualTo("TestContextTest.shouldGetTestNameAndClass");
+    }
+
+    @DisplayName("Test nested class")
+    @Nested
+    class NestedClass {
+
+        @Test
+        void shouldGetNestedTestNameAndClass(TestInfo info) {
+            assertThat(testContext(info).getTestClassAndMethod())
+                    .isEqualTo("TestContextTest.NestedClass.shouldGetNestedTestNameAndClass");
+        }
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1239

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - TestContextTest.NestedClass

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.