### PR TITLE
fix(build) remove unnecessary JAR shading.

### DIFF
--- a/java/compaction/compaction-status-store/pom.xml
+++ b/java/compaction/compaction-status-store/pom.xml
@@ -93,12 +93,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/configuration/pom.xml
+++ b/java/configuration/pom.xml
@@ -76,12 +76,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/dynamodb-tools/pom.xml
+++ b/java/dynamodb-tools/pom.xml
@@ -73,13 +73,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/java/ingest/ingest-status-store/pom.xml
+++ b/java/ingest/ingest-status-store/pom.xml
@@ -90,12 +90,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/parquet/pom.xml
+++ b/java/parquet/pom.xml
@@ -95,12 +95,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/statestore/pom.xml
+++ b/java/statestore/pom.xml
@@ -95,12 +95,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/ReportingContext.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/ReportingContext.java
@@ -37,11 +37,15 @@ import static java.nio.file.StandardOpenOption.CREATE;
 public class ReportingContext {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReportingContext.class);
 
-    private final SystemTestParameters parameters;
+    private final Path outputDirectory;
     private Instant recordingStartTime = Instant.now();
 
     public ReportingContext(SystemTestParameters parameters) {
-        this.parameters = parameters;
+        this(parameters.getOutputDirectory());
+    }
+
+    public ReportingContext(Path outputDirectory) {
+        this.outputDirectory = outputDirectory;
     }
 
     public void startRecording() {
@@ -60,7 +64,6 @@ public class ReportingContext {
     }
 
     private ReportHandle openReport(TestContext testContext) {
-        Path outputDirectory = parameters.getOutputDirectory();
         if (outputDirectory != null) {
             return new FileWriter(outputDirectory.resolve(
                     testContext.getTestClassAndMethod() + ".report.log"));

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
@@ -149,7 +149,7 @@ public class SleeperSystemTest {
         return new SystemTestReporting(instance, clients, reportingContext);
     }
 
-    public SystemTestReports.SystemTestBuilder reports() {
+    public SystemTestReports.SystemTestBuilder reportsForExtension() {
         return SystemTestReports.builder(reportingContext, instance, clients);
     }
 

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SleeperSystemTest.java
@@ -31,6 +31,7 @@ import sleeper.systemtest.suite.dsl.ingest.SystemTestIngest;
 import sleeper.systemtest.suite.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.suite.dsl.query.SystemTestQuery;
 import sleeper.systemtest.suite.dsl.reports.SystemTestReporting;
+import sleeper.systemtest.suite.dsl.reports.SystemTestReports;
 import sleeper.systemtest.suite.dsl.sourcedata.SystemTestCluster;
 import sleeper.systemtest.suite.dsl.sourcedata.SystemTestSourceFiles;
 import sleeper.systemtest.suite.fixtures.SystemTestClients;
@@ -146,6 +147,10 @@ public class SleeperSystemTest {
 
     public SystemTestReporting reporting() {
         return new SystemTestReporting(instance, clients, reportingContext);
+    }
+
+    public SystemTestReports.SystemTestBuilder reports() {
+        return SystemTestReports.builder(reportingContext, instance, clients);
     }
 
     public SystemTestCluster systemTestCluster() {

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReporting.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReporting.java
@@ -20,8 +20,6 @@ import sleeper.systemtest.drivers.compaction.CompactionReportsDriver;
 import sleeper.systemtest.drivers.ingest.IngestReportsDriver;
 import sleeper.systemtest.drivers.instance.ReportingContext;
 import sleeper.systemtest.drivers.instance.SleeperInstanceContext;
-import sleeper.systemtest.drivers.partitioning.PartitionReportDriver;
-import sleeper.systemtest.drivers.util.TestContext;
 import sleeper.systemtest.suite.fixtures.SystemTestClients;
 
 public class SystemTestReporting {
@@ -36,30 +34,10 @@ public class SystemTestReporting {
         this.context = context;
     }
 
-    public void startRecording() {
-        context.startRecording();
-    }
-
-    public void printIngestTasksAndJobs(TestContext testContext) {
-        context.print(testContext,
-                new IngestReportsDriver(clients.getDynamoDB(), clients.getSqs(), clients.getEmr(), instance)
-                        .tasksAndJobsReport());
-    }
-
-    public void printPartitionStatus(TestContext testContext) {
-        context.print(testContext, new PartitionReportDriver(instance).partitionStatusReport());
-    }
-
     public SystemTestIngestJobsReport ingestJobs() {
         return new SystemTestIngestJobsReport(
                 new IngestReportsDriver(clients.getDynamoDB(), clients.getSqs(), clients.getEmr(), instance)
                         .jobs(context));
-    }
-
-    public void printCompactionTasksAndJobs(TestContext testContext) {
-        context.print(testContext,
-                new CompactionReportsDriver(clients.getDynamoDB(), instance)
-                        .tasksAndJobsReport());
     }
 
     public SystemTestCompactionJobsReport compactionJobs() {

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReports.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReports.java
@@ -58,7 +58,7 @@ public class SystemTestReports {
     }
 
     public static class Builder {
-        protected final ReportingContext context;
+        private final ReportingContext context;
         private final List<SystemTestReport> reports = new ArrayList<>();
 
         private Builder(ReportingContext context) {

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReports.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReports.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.suite.dsl.reports;
+
+import sleeper.systemtest.drivers.compaction.CompactionReportsDriver;
+import sleeper.systemtest.drivers.ingest.IngestReportsDriver;
+import sleeper.systemtest.drivers.instance.ReportingContext;
+import sleeper.systemtest.drivers.instance.SleeperInstanceContext;
+import sleeper.systemtest.drivers.instance.SystemTestReport;
+import sleeper.systemtest.drivers.partitioning.PartitionReportDriver;
+import sleeper.systemtest.drivers.util.TestContext;
+import sleeper.systemtest.suite.fixtures.SystemTestClients;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SystemTestReports {
+
+    private final ReportingContext context;
+    private final List<SystemTestReport> reports;
+
+    private SystemTestReports(Builder builder) {
+        context = builder.context;
+        reports = builder.reports;
+    }
+
+    public static Builder builder(ReportingContext context) {
+        return new Builder(context);
+    }
+
+    public static SystemTestBuilder builder(ReportingContext context,
+                                            SleeperInstanceContext instance,
+                                            SystemTestClients clients) {
+        return new SystemTestBuilder(context, instance, clients);
+    }
+
+    public void startRecording() {
+        context.startRecording();
+    }
+
+    public void print(TestContext testContext) {
+        context.print(testContext, (out, startTime) ->
+                reports.forEach(report -> report.print(out, startTime)));
+    }
+
+    public static class Builder {
+        protected final ReportingContext context;
+        private final List<SystemTestReport> reports = new ArrayList<>();
+
+        private Builder(ReportingContext context) {
+            this.context = context;
+        }
+
+        public Builder report(SystemTestReport report) {
+            reports.add(report);
+            return this;
+        }
+
+        public SystemTestReports build() {
+            return new SystemTestReports(this);
+        }
+    }
+
+    public static class SystemTestBuilder extends Builder {
+
+        private final SleeperInstanceContext instance;
+        private final SystemTestClients clients;
+
+        public SystemTestBuilder(ReportingContext context, SleeperInstanceContext instance, SystemTestClients clients) {
+            super(context);
+            this.instance = instance;
+            this.clients = clients;
+        }
+
+        public Builder ingestTasksAndJobs() {
+            return report(new IngestReportsDriver(clients.getDynamoDB(), clients.getSqs(), clients.getEmr(), instance)
+                    .tasksAndJobsReport());
+        }
+
+        public Builder compactionTasksAndJobs() {
+            return report(new CompactionReportsDriver(clients.getDynamoDB(), instance)
+                    .tasksAndJobsReport());
+        }
+
+        public Builder partitionStatus() {
+            return report(new PartitionReportDriver(instance).partitionStatusReport());
+        }
+    }
+}

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReports.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/reports/SystemTestReports.java
@@ -80,7 +80,7 @@ public class SystemTestReports {
         private final SleeperInstanceContext instance;
         private final SystemTestClients clients;
 
-        public SystemTestBuilder(ReportingContext context, SleeperInstanceContext instance, SystemTestClients clients) {
+        private SystemTestBuilder(ReportingContext context, SleeperInstanceContext instance, SystemTestClients clients) {
             super(context);
             this.instance = instance;
             this.clients = clients;

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceIT.java
@@ -16,16 +16,16 @@
 
 package sleeper.systemtest.suite;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.configuration.IngestMode;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
+import sleeper.systemtest.suite.testutil.ReportingExtension;
 
 import java.time.Duration;
 
@@ -35,21 +35,18 @@ import static sleeper.systemtest.configuration.SystemTestProperty.NUMBER_OF_RECO
 import static sleeper.systemtest.configuration.SystemTestProperty.NUMBER_OF_WRITERS;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.COMPACTION_PERFORMANCE;
 import static sleeper.systemtest.suite.testutil.FileInfoSystemTestHelper.numberOfRecordsIn;
-import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 
 @Tag("SystemTest")
 public class CompactionPerformanceIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
+    @RegisterExtension
+    public final ReportingExtension reporting = ReportingExtension.reportAlways(
+            sleeper.reports().compactionTasksAndJobs());
+
     @BeforeEach
     void setUp() {
         sleeper.connectToInstance(COMPACTION_PERFORMANCE);
-        sleeper.reporting().startRecording();
-    }
-
-    @AfterEach
-    void tearDown(TestInfo testInfo) {
-        sleeper.reporting().printCompactionTasksAndJobs(testContext(testInfo));
     }
 
     @Test

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceIT.java
@@ -42,7 +42,7 @@ public class CompactionPerformanceIT {
 
     @RegisterExtension
     public final ReportingExtension reporting = ReportingExtension.reportAlways(
-            sleeper.reports().compactionTasksAndJobs());
+            sleeper.reportsForExtension().compactionTasksAndJobs());
 
     @BeforeEach
     void setUp() {

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestBatcherIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestBatcherIT.java
@@ -16,16 +16,16 @@
 
 package sleeper.systemtest.suite;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.datageneration.RecordNumbers;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
 import sleeper.systemtest.suite.dsl.ingest.SystemTestIngestBatcher;
+import sleeper.systemtest.suite.testutil.ReportingExtension;
 
 import java.time.Duration;
 import java.util.stream.LongStream;
@@ -39,23 +39,20 @@ import static sleeper.configuration.properties.table.TableProperty.INGEST_BATCHE
 import static sleeper.configuration.properties.validation.BatchIngestMode.BULK_IMPORT_EMR_SERVERLESS;
 import static sleeper.configuration.properties.validation.BatchIngestMode.STANDARD_INGEST;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
-import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 
 @Tag("SystemTest")
 public class IngestBatcherIT {
 
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
+    @RegisterExtension
+    public final ReportingExtension reporting = ReportingExtension.reportIfFailed(
+            sleeper.reportsForExtension().ingestTasksAndJobs());
+
     @BeforeEach
     void setUp() {
         sleeper.connectToInstance(MAIN);
         sleeper.ingest().batcher().clearStore();
-        sleeper.reporting().startRecording();
-    }
-
-    @AfterEach
-    void tearDown(TestInfo testInfo) {
-        sleeper.reporting().printIngestTasksAndJobs(testContext(testInfo));
     }
 
     @Test

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestIT.java
@@ -16,33 +16,30 @@
 
 package sleeper.systemtest.suite;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
+import sleeper.systemtest.suite.testutil.ReportingExtension;
 
 import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
-import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 
 @Tag("SystemTest")
 public class IngestIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
+    @RegisterExtension
+    public final ReportingExtension reporting = ReportingExtension.reportIfFailed(
+            sleeper.reportsForExtension().ingestTasksAndJobs());
+
     @BeforeEach
     void setUp() {
         sleeper.connectToInstance(MAIN);
-        sleeper.reporting().startRecording();
-    }
-
-    @AfterEach
-    void tearDown(TestInfo testInfo) {
-        sleeper.reporting().printIngestTasksAndJobs(testContext(testInfo));
     }
 
     @Test

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestPerformanceIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestPerformanceIT.java
@@ -16,16 +16,16 @@
 
 package sleeper.systemtest.suite;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.configuration.IngestMode;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
+import sleeper.systemtest.suite.testutil.ReportingExtension;
 
 import java.time.Duration;
 
@@ -36,21 +36,18 @@ import static sleeper.systemtest.configuration.SystemTestProperty.NUMBER_OF_WRIT
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.INGEST_PERFORMANCE;
 import static sleeper.systemtest.suite.testutil.FileInfoSystemTestHelper.numberOfRecordsIn;
 import static sleeper.systemtest.suite.testutil.PartitionsTestHelper.create128Partitions;
-import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 
 @Tag("SystemTest")
 public class IngestPerformanceIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
+    @RegisterExtension
+    public final ReportingExtension reporting = ReportingExtension.reportAlways(
+            sleeper.reportsForExtension().ingestTasksAndJobs());
+
     @BeforeEach
     void setUp() {
         sleeper.connectToInstance(INGEST_PERFORMANCE);
-        sleeper.reporting().startRecording();
-    }
-
-    @AfterEach
-    void tearDown(TestInfo testInfo) {
-        sleeper.reporting().printIngestTasksAndJobs(testContext(testInfo));
     }
 
     @Test

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PartitionSplittingIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PartitionSplittingIT.java
@@ -16,15 +16,15 @@
 
 package sleeper.systemtest.suite;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 import sleeper.core.statestore.FileInfoFactory;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
+import sleeper.systemtest.suite.testutil.ReportingExtension;
 
 import java.nio.file.Path;
 import java.util.stream.LongStream;
@@ -33,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
 import static sleeper.systemtest.suite.testutil.FileInfoSystemTestHelper.fileInfoFactory;
-import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 
 @Tag("SystemTest")
 public class PartitionSplittingIT {
@@ -41,15 +40,13 @@ public class PartitionSplittingIT {
     private Path tempDir;
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
+    @RegisterExtension
+    public final ReportingExtension reporting = ReportingExtension.reportIfFailed(
+            sleeper.reportsForExtension().partitionStatus());
+
     @BeforeEach
     void setUp() {
         sleeper.connectToInstance(MAIN);
-        sleeper.reporting().startRecording();
-    }
-
-    @AfterEach
-    void tearDown(TestInfo testInfo) {
-        sleeper.reporting().printPartitionStatus(testContext(testInfo));
     }
 
     @Test

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PythonApiIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PythonApiIT.java
@@ -22,11 +22,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 import sleeper.configuration.properties.table.TableProperty;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
+import sleeper.systemtest.suite.testutil.ReportingExtension;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -34,7 +35,6 @@ import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
-import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 
 @Tag("SystemTest")
 public class PythonApiIT {
@@ -50,15 +50,10 @@ public class PythonApiIT {
     @Nested
     @DisplayName("Ingest files")
     class IngestFiles {
-        @BeforeEach
-        void setup() {
-            sleeper.reporting().startRecording();
-        }
 
-        @AfterEach
-        void tearDown(TestInfo testInfo) {
-            sleeper.reporting().printIngestTasksAndJobs(testContext(testInfo));
-        }
+        @RegisterExtension
+        public final ReportingExtension reporting = ReportingExtension.reportIfFailed(
+                sleeper.reportsForExtension().ingestTasksAndJobs());
 
         @Test
         void shouldBatchWriteOneFile() throws IOException, InterruptedException {

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtension.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtension.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.suite.testutil;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import sleeper.systemtest.drivers.instance.ReportingContext;
+import sleeper.systemtest.drivers.instance.SystemTestReport;
+
+import java.util.List;
+
+import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
+
+public class ReportingExtension implements BeforeEachCallback, AfterEachCallback {
+
+    private final ReportingContext context;
+    private final List<SystemTestReport> reports;
+
+    public ReportingExtension(ReportingContext context, List<SystemTestReport> reports) {
+        this.context = context;
+        this.reports = reports;
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext testContext) {
+        context.startRecording();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext testContext) {
+        context.print(testContext(testContext), (out, startTime) ->
+                reports.forEach(report -> report.print(out, startTime)));
+    }
+}

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtension.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtension.java
@@ -20,37 +20,32 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import sleeper.systemtest.drivers.instance.ReportingContext;
-import sleeper.systemtest.drivers.instance.SystemTestReport;
 import sleeper.systemtest.drivers.util.TestContext;
-
-import java.util.List;
+import sleeper.systemtest.suite.dsl.reports.SystemTestReports;
 
 import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 
 public class ReportingExtension implements BeforeEachCallback, AfterEachCallback {
 
-    private final ReportingContext context;
-    private final List<SystemTestReport> reports;
+    private final SystemTestReports reports;
     private final boolean reportIfPassed;
 
-    public ReportingExtension(ReportingContext context, List<SystemTestReport> reports, boolean reportIfPassed) {
-        this.context = context;
+    public ReportingExtension(SystemTestReports reports, boolean reportIfPassed) {
         this.reports = reports;
         this.reportIfPassed = reportIfPassed;
     }
 
-    public static ReportingExtension reportAlways(ReportingContext context, SystemTestReport... reports) {
-        return new ReportingExtension(context, List.of(reports), true);
+    public static ReportingExtension reportAlways(SystemTestReports.Builder reports) {
+        return new ReportingExtension(reports.build(), true);
     }
 
-    public static ReportingExtension reportIfFailed(ReportingContext context, SystemTestReport... reports) {
-        return new ReportingExtension(context, List.of(reports), false);
+    public static ReportingExtension reportIfFailed(SystemTestReports.Builder reports) {
+        return new ReportingExtension(reports.build(), false);
     }
 
     @Override
     public void beforeEach(ExtensionContext testContext) {
-        context.startRecording();
+        reports.startRecording();
     }
 
     @Override
@@ -64,16 +59,11 @@ public class ReportingExtension implements BeforeEachCallback, AfterEachCallback
 
     public void afterTestPassed(TestContext testContext) {
         if (reportIfPassed) {
-            printReports(testContext);
+            reports.print(testContext);
         }
     }
 
     public void afterTestFailed(TestContext testContext) {
-        printReports(testContext);
-    }
-
-    private void printReports(TestContext testContext) {
-        context.print(testContext, (out, startTime) ->
-                reports.forEach(report -> report.print(out, startTime)));
+        reports.print(testContext);
     }
 }

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
@@ -17,6 +17,8 @@
 package sleeper.systemtest.suite.testutil;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,19 +35,24 @@ public class ReportingExtensionTest {
 
     @TempDir
     private static Path TEMP_DIR;
-    private final ReportingContext context = new ReportingContext(TEMP_DIR);
 
-    @RegisterExtension
-    public final ReportingExtension extension = new ReportingExtension(context, List.of(fixedReport("test report")));
+    @Nested
+    @DisplayName("Run reports as a JUnit extension")
+    class RunAsExtension {
 
-    @Test
-    void shouldOutputAReport() {
-        // Reporting handled by extension
+        @RegisterExtension
+        public final ReportingExtension extension = new ReportingExtension(
+                new ReportingContext(TEMP_DIR), List.of(fixedReport("test report")));
+
+        @Test
+        void shouldOutputAReport() {
+            // Reporting handled by extension
+        }
     }
 
     @AfterAll
     static void afterAll() {
-        assertThat(TEMP_DIR.resolve("ReportingExtensionTest.shouldOutputAReport.report.log"))
+        assertThat(TEMP_DIR.resolve("ReportingExtensionTest.RunAsExtension.shouldOutputAReport.report.log"))
                 .content().isEqualTo("test report");
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
@@ -68,21 +68,21 @@ public class ReportingExtensionTest {
 
         @Test
         void shouldNotOutputReportWhenTestPassed(TestInfo info) {
-            extensionReportIfFailed().afterTestPassed(testContext(info));
+            extensionReportIfFailed("test passed").afterTestPassed(testContext(info));
             assertThat(tempDir).isEmptyDirectory();
         }
 
         @Test
         void shouldOutputReportWhenTestFailed(TestInfo info) {
-            extensionReportIfFailed().afterTestFailed(testContext(info));
+            extensionReportIfFailed("test failed").afterTestFailed(testContext(info));
             assertThat(tempDir.resolve("ReportingExtensionTest.OnlyReportWhenTestFailed.shouldOutputReportWhenTestFailed.report.log"))
-                    .hasContent("test report");
+                    .hasContent("test failed");
         }
 
-        private ReportingExtension extensionReportIfFailed() {
+        private ReportingExtension extensionReportIfFailed(String report) {
             return ReportingExtension.reportIfFailed(
                     SystemTestReports.builder(new ReportingContext(tempDir))
-                            .report(fixedReport("test report")));
+                            .report(fixedReport(report)));
         }
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.suite.testutil;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import sleeper.systemtest.drivers.instance.ReportingContext;
+import sleeper.systemtest.drivers.instance.SystemTestReport;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReportingExtensionTest {
+
+    @TempDir
+    private static Path TEMP_DIR;
+    private final ReportingContext context = new ReportingContext(TEMP_DIR);
+
+    @RegisterExtension
+    private final ReportingExtension extension = new ReportingExtension(context, List.of(fixedReport("test report")));
+
+    @Test
+    void shouldOutputAReport() {
+        // Reporting handled by extension
+    }
+
+    @AfterAll
+    static void afterAll() {
+        assertThat(TEMP_DIR.resolve("ReportingExtensionTest.shouldOutputAReport.report.log"))
+                .content().isEqualTo("test report");
+    }
+
+    private static SystemTestReport fixedReport(String report) {
+        return (out, startTime) -> out.print(report);
+    }
+}

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
@@ -36,7 +36,7 @@ import static sleeper.systemtest.suite.testutil.TestContextFactory.testContext;
 public class ReportingExtensionTest {
 
     @TempDir
-    private static Path TEMP_DIR;
+    private static Path staticTempDir;
 
     @Nested
     @DisplayName("Run reports as a JUnit extension")
@@ -44,7 +44,7 @@ public class ReportingExtensionTest {
 
         @RegisterExtension
         public final ReportingExtension extension = ReportingExtension.reportAlways(
-                SystemTestReports.builder(new ReportingContext(TEMP_DIR))
+                SystemTestReports.builder(new ReportingContext(staticTempDir))
                         .report(fixedReport("test report")));
 
         @Test
@@ -55,7 +55,7 @@ public class ReportingExtensionTest {
 
     @AfterAll
     static void afterAll() {
-        assertThat(TEMP_DIR.resolve("ReportingExtensionTest.RunAsExtension.shouldOutputAReport.report.log"))
+        assertThat(staticTempDir.resolve("ReportingExtensionTest.RunAsExtension.shouldOutputAReport.report.log"))
                 .hasContent("test report");
     }
 
@@ -88,5 +88,8 @@ public class ReportingExtensionTest {
 
     private static SystemTestReport fixedReport(String report) {
         return (out, startTime) -> out.print(report);
+    }
+
+    private ReportingExtensionTest() {
     }
 }

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
@@ -36,7 +36,7 @@ public class ReportingExtensionTest {
     private final ReportingContext context = new ReportingContext(TEMP_DIR);
 
     @RegisterExtension
-    private final ReportingExtension extension = new ReportingExtension(context, List.of(fixedReport("test report")));
+    public final ReportingExtension extension = new ReportingExtension(context, List.of(fixedReport("test report")));
 
     @Test
     void shouldOutputAReport() {

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/ReportingExtensionTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import sleeper.systemtest.drivers.instance.ReportingContext;
 import sleeper.systemtest.drivers.instance.SystemTestReport;
+import sleeper.systemtest.suite.dsl.reports.SystemTestReports;
 
 import java.nio.file.Path;
 
@@ -43,7 +44,8 @@ public class ReportingExtensionTest {
 
         @RegisterExtension
         public final ReportingExtension extension = ReportingExtension.reportAlways(
-                new ReportingContext(TEMP_DIR), fixedReport("test report"));
+                SystemTestReports.builder(new ReportingContext(TEMP_DIR))
+                        .report(fixedReport("test report")));
 
         @Test
         void shouldOutputAReport() {
@@ -79,8 +81,8 @@ public class ReportingExtensionTest {
 
         private ReportingExtension extensionReportIfFailed() {
             return ReportingExtension.reportIfFailed(
-                    new ReportingContext(tempDir),
-                    fixedReport("test report"));
+                    SystemTestReports.builder(new ReportingContext(tempDir))
+                            .report(fixedReport("test report")));
         }
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/TestContextFactory.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/TestContextFactory.java
@@ -17,6 +17,7 @@
 package sleeper.systemtest.suite.testutil;
 
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import sleeper.systemtest.drivers.util.TestContext;
 
@@ -31,6 +32,15 @@ public class TestContextFactory {
                 .tags(info.getTags())
                 .testClass(info.getTestClass().orElse(null))
                 .testMethod(info.getTestMethod().orElse(null))
+                .build();
+    }
+
+    public static TestContext testContext(ExtensionContext context) {
+        return TestContext.builder()
+                .displayName(context.getDisplayName())
+                .tags(context.getTags())
+                .testClass(context.getTestClass().orElse(null))
+                .testMethod(context.getTestMethod().orElse(null))
                 .build();
     }
 }


### PR DESCRIPTION
Remove shade plugin from 6 modules that are never used externally>

Make sure you have checked _all_ steps below.

### Issue

- Resolves https://github.com/gchq/sleeper/issues/1245

### Tests

Jar files in scripts/jars after build are identical.
