### PR TITLE
Issue 1251 - Use `ClientUtils.runCommandLogOutput` in PythonRunner

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonRunner.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonRunner.java
@@ -28,7 +28,7 @@ import static sleeper.clients.util.Command.command;
 import static sleeper.clients.util.CommandPipeline.pipeline;
 
 public class PythonRunner {
-    private final CommandPipelineRunner pipelineRunner = ClientUtils::runCommandInheritIO;
+    private final CommandPipelineRunner pipelineRunner = ClientUtils::runCommandLogOutput;
     private final Path pythonDir;
 
     public PythonRunner(Path pythonDir) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1251

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing system tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.