### PR TITLE
Issue 1247 - Assert on partitions created in PartitionSplittingIT

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PartitionSplittingIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PartitionSplittingIT.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import sleeper.core.statestore.FileInfoFactory;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
+import sleeper.systemtest.suite.fixtures.SystemTestSchema;
 import sleeper.systemtest.suite.testutil.ReportingExtension;
 
 import java.nio.file.Path;
@@ -31,8 +32,11 @@ import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
+import static sleeper.systemtest.datageneration.GenerateNumberedValue.stringFromPrefixAndPadToSize;
+import static sleeper.systemtest.datageneration.GenerateNumberedValueOverrides.overrideField;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
 import static sleeper.systemtest.suite.testutil.FileInfoSystemTestHelper.fileInfoFactory;
+import static sleeper.systemtest.suite.testutil.PartitionsTestHelper.partitionsBuilder;
 
 @Tag("SystemTest")
 public class PartitionSplittingIT {
@@ -52,6 +56,9 @@ public class PartitionSplittingIT {
     @Test
     void shouldSplitPartitionsWith100RecordsAndThresholdOf20() throws InterruptedException {
         // Given
+        sleeper.setGeneratorOverrides(
+                overrideField(SystemTestSchema.ROW_KEY_FIELD_NAME,
+                        stringFromPrefixAndPadToSize("row-", 2)));
         sleeper.updateTableProperties(properties -> properties.set(PARTITION_SPLIT_THRESHOLD, "20"));
         sleeper.ingest().direct(tempDir).numberedRecords(LongStream.range(0, 100));
 
@@ -70,13 +77,26 @@ public class PartitionSplittingIT {
         assertThat(sleeper.tableFiles().active())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("filename", "lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrder(
-                        fileFactory.leafFile(12, "row-0000000000000000000", "row-0000000000000000011"),
-                        fileFactory.leafFile(13, "row-0000000000000000012", "row-0000000000000000024"),
-                        fileFactory.leafFile(12, "row-0000000000000000025", "row-0000000000000000036"),
-                        fileFactory.leafFile(13, "row-0000000000000000037", "row-0000000000000000049"),
-                        fileFactory.leafFile(12, "row-0000000000000000050", "row-0000000000000000061"),
-                        fileFactory.leafFile(13, "row-0000000000000000062", "row-0000000000000000074"),
-                        fileFactory.leafFile(12, "row-0000000000000000075", "row-0000000000000000086"),
-                        fileFactory.leafFile(13, "row-0000000000000000087", "row-0000000000000000099"));
+                        fileFactory.leafFile(12, "row-00", "row-11"),
+                        fileFactory.leafFile(13, "row-12", "row-24"),
+                        fileFactory.leafFile(12, "row-25", "row-36"),
+                        fileFactory.leafFile(13, "row-37", "row-49"),
+                        fileFactory.leafFile(12, "row-50", "row-61"),
+                        fileFactory.leafFile(13, "row-62", "row-74"),
+                        fileFactory.leafFile(12, "row-75", "row-86"),
+                        fileFactory.leafFile(13, "row-87", "row-99"));
+        assertThat(sleeper.partitioning().allPartitions())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "parentPartitionId", "childPartitionIds")
+                .containsExactlyInAnyOrderElementsOf(
+                        partitionsBuilder(sleeper)
+                                .rootFirst("root")
+                                .splitToNewChildren("root", "L", "R", "row-50")
+                                .splitToNewChildren("L", "LL", "LR", "row-25")
+                                .splitToNewChildren("R", "RL", "RR", "row-75")
+                                .splitToNewChildren("LL", "LLL", "LLR", "row-12")
+                                .splitToNewChildren("LR", "LRL", "LRR", "row-37")
+                                .splitToNewChildren("RL", "RLL", "RLR", "row-62")
+                                .splitToNewChildren("RR", "RRL", "RRR", "row-87")
+                                .buildList());
     }
 }

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/PartitionsTestHelper.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/PartitionsTestHelper.java
@@ -17,6 +17,7 @@
 package sleeper.systemtest.suite.testutil;
 
 import sleeper.core.partition.PartitionTree;
+import sleeper.core.partition.PartitionsBuilder;
 import sleeper.core.partition.PartitionsFromSplitPoints;
 import sleeper.core.schema.Schema;
 import sleeper.systemtest.suite.dsl.SleeperSystemTest;
@@ -47,5 +48,9 @@ public class PartitionsTestHelper {
     private static PartitionTree createPartitionsFromSplitPoints(Schema schema, List<Object> splitPoints) {
         return new PartitionTree(schema,
                 new PartitionsFromSplitPoints(schema, splitPoints).construct());
+    }
+
+    public static PartitionsBuilder partitionsBuilder(SleeperSystemTest sleeper) {
+        return new PartitionsBuilder(sleeper.tableProperties().getSchema());
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1247

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated PartitionSplittingIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.