### PR TITLE
Issue 1278 - Allow loading invalid properties in admin client

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/admin/AdminClientPropertiesStore.java
+++ b/java/clients/src/main/java/sleeper/clients/admin/AdminClientPropertiesStore.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
+import static sleeper.configuration.properties.instance.InstanceProperties.loadPropertiesFromS3GivenInstanceId;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
 public class AdminClientPropertiesStore {
@@ -59,20 +60,17 @@ public class AdminClientPropertiesStore {
     }
 
     public InstanceProperties loadInstanceProperties(String instanceId) {
-        InstanceProperties instanceProperties = new InstanceProperties();
         try {
-            instanceProperties.loadFromS3GivenInstanceId(s3, instanceId);
+            return new InstanceProperties(loadPropertiesFromS3GivenInstanceId(s3, instanceId));
         } catch (IOException | AmazonS3Exception e) {
             throw new CouldNotLoadInstanceProperties(instanceId, e);
         }
-        return instanceProperties;
     }
 
     public TableProperties loadTableProperties(InstanceProperties instanceProperties, String tableName) {
         try {
-            TableProperties properties = new TableProperties(instanceProperties);
-            properties.loadFromS3(s3, tableName);
-            return properties;
+            return new TableProperties(instanceProperties,
+                    TableProperties.loadPropertiesFromS3(s3, instanceProperties, tableName));
         } catch (AmazonS3Exception | IOException e) {
             throw new CouldNotLoadTableProperties(instanceProperties.get(ID), tableName, e);
         }

--- a/java/clients/src/test/java/sleeper/clients/admin/AdminClientPropertiesStoreIT.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/AdminClientPropertiesStoreIT.java
@@ -44,11 +44,13 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static sleeper.configuration.properties.instance.CommonProperty.FARGATE_VERSION;
+import static sleeper.configuration.properties.instance.CommonProperty.MAXIMUM_CONNECTIONS_TO_S3;
 import static sleeper.configuration.properties.instance.CommonProperty.TASK_RUNNER_LAMBDA_MEMORY_IN_MB;
 import static sleeper.configuration.properties.local.LoadLocalProperties.loadInstancePropertiesFromDirectory;
 import static sleeper.configuration.properties.local.LoadLocalProperties.loadTablesFromDirectory;
 import static sleeper.configuration.properties.table.TableProperties.TABLES_PREFIX;
 import static sleeper.configuration.properties.table.TableProperty.ENCRYPTED;
+import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
 import static sleeper.configuration.properties.table.TableProperty.ROW_GROUP_SIZE;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
@@ -341,6 +343,31 @@ public class AdminClientPropertiesStoreIT extends AdminClientITBase {
                         .extracting(table -> table.getBoolean(ENCRYPTED))
                         .containsExactly(true);
             }
+        }
+    }
+
+    @DisplayName("Load invalid properties")
+    @Nested
+    class LoadInvalidProperties {
+
+        @Test
+        void shouldLoadInvalidInstanceProperties() {
+            // Given
+            updateInstanceProperty(INSTANCE_ID, MAXIMUM_CONNECTIONS_TO_S3, "abc");
+
+            // When / Then
+            assertThat(store().loadInstanceProperties(INSTANCE_ID).get(MAXIMUM_CONNECTIONS_TO_S3))
+                    .isEqualTo("abc");
+        }
+
+        @Test
+        void shouldLoadInvalidTableProperties() throws IOException {
+            // Given
+            createTableInS3("test-table", table -> table.set(PARTITION_SPLIT_THRESHOLD, "abc"));
+
+            // When / Then
+            assertThat(store().loadTableProperties(instanceProperties, "test-table").get(PARTITION_SPLIT_THRESHOLD))
+                    .isEqualTo("abc");
         }
     }
 

--- a/java/configuration/src/main/java/sleeper/configuration/properties/PropertiesUtils.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/PropertiesUtils.java
@@ -34,7 +34,6 @@ public class PropertiesUtils {
     private PropertiesUtils() {
     }
 
-
     public static Properties loadProperties(Path file) throws IOException {
         try (BufferedReader reader = Files.newBufferedReader(file)) {
             return loadProperties(reader);

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/InstanceProperties.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/InstanceProperties.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
+import static sleeper.configuration.properties.PropertiesUtils.loadProperties;
 import static sleeper.configuration.properties.instance.CommonProperty.TAGS;
 import static sleeper.configuration.properties.instance.SystemDefinedInstanceProperty.CONFIG_BUCKET;
 
@@ -50,6 +51,7 @@ public class InstanceProperties extends SleeperProperties<InstanceProperty> {
 
     public InstanceProperties(Properties properties) {
         super(properties);
+        tags = csvTagsToMap(get(TAGS));
     }
 
     @Override
@@ -101,6 +103,15 @@ public class InstanceProperties extends SleeperProperties<InstanceProperty> {
 
     public void loadFromS3(AmazonS3 s3Client, String bucket) throws IOException {
         super.loadFromS3(s3Client, bucket, S3_INSTANCE_PROPERTIES_FILE);
+    }
+
+    public static Properties loadPropertiesFromS3GivenInstanceId(AmazonS3 s3Client, String instanceId) throws IOException {
+        return loadProperties(loadStringFromS3GivenInstanceId(s3Client, instanceId));
+    }
+
+    private static String loadStringFromS3GivenInstanceId(AmazonS3 s3Client, String instanceId) {
+        String configBucket = getConfigBucketFromInstanceId(instanceId);
+        return s3Client.getObjectAsString(configBucket, S3_INSTANCE_PROPERTIES_FILE);
     }
 
     public void saveToS3(AmazonS3 s3Client) throws IOException {

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperties.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperties.java
@@ -43,6 +43,7 @@ import java.util.Properties;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static sleeper.configuration.properties.PropertiesUtils.loadProperties;
 import static sleeper.configuration.properties.instance.SystemDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.table.TableProperty.COMPACTION_FILES_BATCH_SIZE;
 import static sleeper.configuration.properties.table.TableProperty.SCHEMA;
@@ -137,8 +138,16 @@ public class TableProperties extends SleeperProperties<TableProperty> {
     }
 
     public void loadFromS3(AmazonS3 s3Client, String tableName) throws IOException {
+        loadFromString(loadStringFromS3(s3Client, instanceProperties, tableName));
+    }
+
+    public static Properties loadPropertiesFromS3(AmazonS3 s3Client, InstanceProperties instanceProperties, String tableName) throws IOException {
+        return loadProperties(loadStringFromS3(s3Client, instanceProperties, tableName));
+    }
+
+    private static String loadStringFromS3(AmazonS3 s3Client, InstanceProperties instanceProperties, String tableName) {
         LOGGER.info("Loading table properties from bucket {}, key {}/{}", instanceProperties.get(CONFIG_BUCKET), TABLES_PREFIX, tableName);
-        loadFromString(s3Client.getObjectAsString(instanceProperties.get(CONFIG_BUCKET), TABLES_PREFIX + "/" + tableName));
+        return s3Client.getObjectAsString(instanceProperties.get(CONFIG_BUCKET), TABLES_PREFIX + "/" + tableName);
     }
 
     @Override


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1278

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - AdminClientPropertiesStoreIT.LoadInvalidProperties

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.