### PR TITLE
Issue 1291 - Remove `m4.large` from EMR instance types in system tests

### DIFF
--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
@@ -63,7 +63,7 @@ public enum SystemTestInstance {
     COMPACTION_PERFORMANCE("compaction", SystemTestInstance::buildCompactionPerformanceConfiguration),
     BULK_IMPORT_PERFORMANCE("emr", SystemTestInstance::buildBulkImportPerformanceConfiguration);
 
-    private static final String MAIN_EMR_INSTANCE_TYPES = "m4.xlarge,m6a.xlarge,m6i.xlarge,m5a.xlarge,m5.xlarge";
+    private static final String MAIN_EMR_INSTANCE_TYPES = "m6a.xlarge,m6i.xlarge,m5a.xlarge,m5.xlarge";
 
     private final String identifier;
     private final Function<SystemTestParameters, DeployInstanceConfiguration> instanceConfiguration;

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
@@ -63,7 +63,7 @@ public enum SystemTestInstance {
     COMPACTION_PERFORMANCE("compaction", SystemTestInstance::buildCompactionPerformanceConfiguration),
     BULK_IMPORT_PERFORMANCE("emr", SystemTestInstance::buildBulkImportPerformanceConfiguration);
 
-    private static final String MAIN_EMR_INSTANCE_TYPES = "m4.large,m6a.xlarge,m6i.xlarge,m5a.xlarge,m5.xlarge";
+    private static final String MAIN_EMR_INSTANCE_TYPES = "m4.xlarge,m6a.xlarge,m6i.xlarge,m5a.xlarge,m5.xlarge";
 
     private final String identifier;
     private final Function<SystemTestParameters, DeployInstanceConfiguration> instanceConfiguration;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1291

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Tested by running EmrPersistentBulkImportIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.