### PR TITLE
Issue 1345 - Make Docker containers use default `bridged` network mode

### DIFF
--- a/docs/10-deploy-to-localstack.md
+++ b/docs/10-deploy-to-localstack.md
@@ -31,8 +31,14 @@ This will also output commands you can use to point Sleeper scripts to your Loca
 
 For Sleeper commands to interact with LocalStack, ensure that the `AWS_ENDPOINT_URL` environment variable
 is set. Commands to do this are provided by the `startContainer.sh` script, but you can also manually set this by
-running the following command:
+running the following commands:
 
+- If you are inside a docker container:
+```shell
+export AWS_ENDPOINT_URL=http://host.docker.internal:4566
+```
+
+- If you are on your host machine:
 ```shell
 export AWS_ENDPOINT_URL=http://localhost:4566
 ```

--- a/scripts/cli/runInDocker.sh
+++ b/scripts/cli/runInDocker.sh
@@ -33,6 +33,7 @@ run_in_docker() {
     --rm
     -v /var/run/docker.sock:/var/run/docker.sock
     -v "$HOME/.aws:$HOME_IN_IMAGE/.aws"
+    -e IN_CLI_CONTAINER=true \
     -e AWS_ACCESS_KEY_ID
     -e AWS_SECRET_ACCESS_KEY
     -e AWS_SESSION_TOKEN
@@ -56,7 +57,6 @@ run_in_environment_docker() {
 
 run_in_deployment_docker() {
   run_in_docker \
-    -e IN_DEPLOYMENT_CONTAINER=true \
     -v "$HOME/.sleeper/generated:/sleeper/generated" \
     sleeper-deployment:current "$@"
 }

--- a/scripts/cli/runInDocker.sh
+++ b/scripts/cli/runInDocker.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#
 # Copyright 2022-2023 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 set -e
 unset CDPATH
@@ -33,7 +31,6 @@ run_in_docker() {
   fi
   RUN_PARAMS+=(
     --rm
-    --network=host
     -v /var/run/docker.sock:/var/run/docker.sock
     -v "$HOME/.aws:$HOME_IN_IMAGE/.aws"
     -e AWS_ACCESS_KEY_ID
@@ -59,6 +56,7 @@ run_in_environment_docker() {
 
 run_in_deployment_docker() {
   run_in_docker \
+    -e IN_DEPLOYMENT_CONTAINER=true \
     -v "$HOME/.sleeper/generated:/sleeper/generated" \
     sleeper-deployment:current "$@"
 }

--- a/scripts/deploy/localstack/startContainer.sh
+++ b/scripts/deploy/localstack/startContainer.sh
@@ -18,7 +18,7 @@ THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 docker compose -f "$THIS_DIR/docker-compose.yml" up -d 
 echo "Running localstack container on port 4566"
 echo "To use sleeper with this container, set the AWS_ENDPOINT_URL environment variable:"
-if [ "$IN_DEPLOYMENT_CONTAINER" = "true" ]; then
+if [ "$IN_CLI_CONTAINER" = "true" ]; then
   echo "export AWS_ENDPOINT_URL=http://host.docker.internal:4566"
 else
   echo "export AWS_ENDPOINT_URL=http://localhost:4566"

--- a/scripts/deploy/localstack/startContainer.sh
+++ b/scripts/deploy/localstack/startContainer.sh
@@ -18,7 +18,11 @@ THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 docker compose -f "$THIS_DIR/docker-compose.yml" up -d 
 echo "Running localstack container on port 4566"
 echo "To use sleeper with this container, set the AWS_ENDPOINT_URL environment variable:"
-echo "export AWS_ENDPOINT_URL=http://localhost:4566"
+if [ "$IN_DEPLOYMENT_CONTAINER" = "true" ]; then
+  echo "export AWS_ENDPOINT_URL=http://host.docker.internal:4566"
+else
+  echo "export AWS_ENDPOINT_URL=http://localhost:4566"
+fi
 echo ""
 echo "To revert to using the default AWS endpoint, you can unset this environment variable:"
 echo "unset AWS_ENDPOINT_URL"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1345

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Docker configuration

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
  - Updated deploy to LocalStack documentation
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.