### PR TITLE
Issue 1381 - Ensure FileInfo.lastStateStoreUpdateTime is set consistently in state stores

### DIFF
--- a/java/bulk-import/bulk-import-runner/src/main/java/sleeper/bulkimport/job/runner/SparkFileInfoRow.java
+++ b/java/bulk-import/bulk-import-runner/src/main/java/sleeper/bulkimport/job/runner/SparkFileInfoRow.java
@@ -21,8 +21,6 @@ import org.apache.spark.sql.types.StructType;
 
 import sleeper.core.statestore.FileInfo;
 
-import java.time.Instant;
-
 public class SparkFileInfoRow {
 
     private SparkFileInfoRow() {
@@ -36,7 +34,6 @@ public class SparkFileInfoRow {
         return FileInfo.builder()
                 .filename(row.getAs(FILENAME_FIELD_NAME))
                 .jobId(null)
-                .lastStateStoreUpdateTime(Instant.now())
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId(row.getAs(PARTITION_FIELD_NAME))
                 .numberOfRecords(row.getAs(NUM_RECORDS_FIELD_NAME))

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
@@ -72,7 +72,9 @@ class BulkImportJobDriverTest {
         assertThat(allJobsReported())
                 .containsExactly(finishedIngestJobWithValidation(job.toIngestJob(), "test-task",
                         validationTime, summary(startTime, finishTime, 100, 100)));
-        assertThat(stateStore.getActiveFiles()).isEqualTo(outputFiles);
+        assertThat(stateStore.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .isEqualTo(outputFiles);
     }
 
     @Test

--- a/java/clients/src/test/java/sleeper/clients/status/update/ReinitialiseTableIT.java
+++ b/java/clients/src/test/java/sleeper/clients/status/update/ReinitialiseTableIT.java
@@ -17,13 +17,7 @@ package sleeper.clients.status.update;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.BillingMode;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
-import com.amazonaws.services.dynamodbv2.model.KeyType;
-import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.amazonaws.services.s3.AmazonS3;
@@ -47,7 +41,6 @@ import org.testcontainers.utility.DockerImageName;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.CommonTestConstants;
-import sleeper.core.key.Key;
 import sleeper.core.partition.Partition;
 import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
@@ -67,7 +60,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -555,12 +547,9 @@ public class ReinitialiseTableIT {
         String file2 = folderName + "/file2.parquet";
         String file3 = folderName + "/file3.parquet";
 
-        FileInfo fileInfo1 = createFileInfo(file1, FileInfo.FileStatus.ACTIVE, rootPartition.getId(),
-                Key.create("0"), Key.create("98"));
-        FileInfo fileInfo2 = createFileInfo(file2, FileInfo.FileStatus.ACTIVE, rootPartition.getId(),
-                Key.create("1"), Key.create("9"));
-        FileInfo fileInfo3 = createFileInfo(file3, FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION, rootPartition.getId(),
-                Key.create("1"), Key.create("9"));
+        FileInfo fileInfo1 = createFileInfo(file1, FileInfo.FileStatus.ACTIVE, rootPartition.getId());
+        FileInfo fileInfo2 = createFileInfo(file2, FileInfo.FileStatus.ACTIVE, rootPartition.getId());
+        FileInfo fileInfo3 = createFileInfo(file3, FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION, rootPartition.getId());
 
         //  - Split root partition
         PartitionTree tree = new PartitionsBuilder(KEY_VALUE_SCHEMA)
@@ -575,15 +564,13 @@ public class ReinitialiseTableIT {
         stateStore.addFiles(Arrays.asList(fileInfo1, fileInfo2, fileInfo3));
     }
 
-    private FileInfo createFileInfo(String filename, FileInfo.FileStatus fileStatus, String partitionId,
-                                    Key minRowKey, Key maxRowKey) {
+    private FileInfo createFileInfo(String filename, FileInfo.FileStatus fileStatus, String partitionId) {
         return FileInfo.builder()
                 .rowKeyTypes(new StringType())
                 .filename(filename)
                 .fileStatus(fileStatus)
                 .partitionId(partitionId)
                 .numberOfRecords(100L)
-                .lastStateStoreUpdateTime(100L)
                 .build();
     }
 
@@ -602,18 +589,5 @@ public class ReinitialiseTableIT {
         }
         info.close();
         return splitPointsFileName;
-    }
-
-    private void createRevisionDynamoTable(String tableName) {
-        List<AttributeDefinition> attributeDefinitions = new ArrayList<>();
-        attributeDefinitions.add(new AttributeDefinition(REVISION_ID_KEY, ScalarAttributeType.S));
-        List<KeySchemaElement> keySchemaElements = new ArrayList<>();
-        keySchemaElements.add(new KeySchemaElement(REVISION_ID_KEY, KeyType.HASH));
-        CreateTableRequest request = new CreateTableRequest()
-                .withTableName(tableName)
-                .withAttributeDefinitions(attributeDefinitions)
-                .withKeySchema(keySchemaElements)
-                .withBillingMode(BillingMode.PAY_PER_REQUEST);
-        dynamoDBClient.createTable(request);
     }
 }

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesDynamoDBIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesDynamoDBIT.java
@@ -142,8 +142,8 @@ public class CompactSortedFilesDynamoDBIT extends CompactSortedFilesTestBase {
 
         List<Record> data1 = keyAndTwoValuesSortedEvenLongs();
         List<Record> data2 = keyAndTwoValuesSortedOddLongs();
-        dataHelper.writeRootFile(folderName + "/file1.parquet", data1, 0L, 198L);
-        dataHelper.writeRootFile(folderName + "/file2.parquet", data2, 1L, 199L);
+        dataHelper.writeRootFile(folderName + "/file1.parquet", data1);
+        dataHelper.writeRootFile(folderName + "/file2.parquet", data2);
 
         CompactionJob compactionJob = compactionFactory().createSplittingCompactionJob(
                 dataHelper.allFileInfos(), "C", "A", "B", 100L, 0);
@@ -168,8 +168,8 @@ public class CompactSortedFilesDynamoDBIT extends CompactSortedFilesTestBase {
         assertThat(stateStore.getActiveFiles())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrder(
-                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L, 0L, 99L),
-                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L, 100L, 199L));
+                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L),
+                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L));
     }
 
 }

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesEmptyOutputIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesEmptyOutputIT.java
@@ -123,8 +123,8 @@ class CompactSortedFilesEmptyOutputIT extends CompactSortedFilesTestBase {
 
         List<Record> data1 = keyAndTwoValuesSortedEvenLongs();
         List<Record> data2 = keyAndTwoValuesSortedOddLongs();
-        dataHelper.writeRootFile(folderName + "/file1.parquet", data1, 0L, 198L);
-        dataHelper.writeRootFile(folderName + "/file2.parquet", data2, 1L, 199L);
+        dataHelper.writeRootFile(folderName + "/file1.parquet", data1);
+        dataHelper.writeRootFile(folderName + "/file2.parquet", data2);
 
         CompactionJob compactionJob = compactionFactory().createSplittingCompactionJob(
                 dataHelper.allFileInfos(), "C", "A", "B", 200L, 0);
@@ -149,7 +149,7 @@ class CompactSortedFilesEmptyOutputIT extends CompactSortedFilesTestBase {
         assertThat(stateStore.getActiveFiles())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrder(
-                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 200L, 0L, 199L),
-                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 0L, null, null));
+                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 200L),
+                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 0L));
     }
 }

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIteratorIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIteratorIT.java
@@ -108,8 +108,8 @@ class CompactSortedFilesIteratorIT extends CompactSortedFilesTestBase {
             record.put("timestamp", 0L);
             record.put("value", 123456789L);
         });
-        dataHelper.writeRootFile(folderName + "/file1.parquet", data1, 0L, 198L);
-        dataHelper.writeRootFile(folderName + "/file2.parquet", data2, 1L, 199L);
+        dataHelper.writeRootFile(folderName + "/file1.parquet", data1);
+        dataHelper.writeRootFile(folderName + "/file2.parquet", data2);
 
         CompactionJob compactionJob = compactionFactoryBuilder()
                 .iteratorClassName(AgeOffIterator.class.getName())
@@ -135,7 +135,7 @@ class CompactSortedFilesIteratorIT extends CompactSortedFilesTestBase {
         assertThat(stateStore.getActiveFiles())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrder(
-                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 50L, 0L, 98L),
-                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 50L, 100L, 198L));
+                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 50L),
+                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 50L));
     }
 }

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
@@ -60,8 +60,8 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
 
         List<Record> data1 = keyAndTwoValuesSortedEvenLongs();
         List<Record> data2 = keyAndTwoValuesSortedOddLongs();
-        dataHelper.writeRootFile(folderName + "/file1.parquet", data1, 0L, 198L);
-        dataHelper.writeRootFile(folderName + "/file2.parquet", data2, 1L, 199L);
+        dataHelper.writeRootFile(folderName + "/file1.parquet", data1);
+        dataHelper.writeRootFile(folderName + "/file2.parquet", data2);
 
         CompactionJob compactionJob = compactionFactory().createSplittingCompactionJob(
                 dataHelper.allFileInfos(), "C", "A", "B", 100L, 0);
@@ -86,8 +86,8 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
         assertThat(stateStore.getActiveFiles())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrder(
-                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L, 0L, 99L),
-                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L, 100L, 199L));
+                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L),
+                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L));
     }
 
     @Test
@@ -110,8 +110,8 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             record.put(field1.getName(), (long) odd);
             record.put(field2.getName(), "A");
         });
-        dataHelper.writeRootFile(folderName + "/file1.parquet", data1, 0L, 198L);
-        dataHelper.writeRootFile(folderName + "/file2.parquet", data2, 1L, 199L);
+        dataHelper.writeRootFile(folderName + "/file1.parquet", data1);
+        dataHelper.writeRootFile(folderName + "/file2.parquet", data2);
 
         CompactionJob compactionJob = compactionFactory().createSplittingCompactionJob(
                 dataHelper.allFileInfos(), "C", "A", "B", 100L, 0);
@@ -136,8 +136,8 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
         assertThat(stateStore.getActiveFiles())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrder(
-                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L, 0L, 99L),
-                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L, 100L, 199L));
+                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L),
+                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L));
     }
 
     @Test
@@ -160,8 +160,8 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             record.put(field1.getName(), (long) odd);
             record.put(field2.getName(), "B");
         });
-        dataHelper.writeRootFile(folderName + "/file1.parquet", data1, 0L, 198L);
-        dataHelper.writeRootFile(folderName + "/file2.parquet", data2, 1L, 199L);
+        dataHelper.writeRootFile(folderName + "/file1.parquet", data1);
+        dataHelper.writeRootFile(folderName + "/file2.parquet", data2);
 
         CompactionJob compactionJob = compactionFactory().createSplittingCompactionJob(
                 dataHelper.allFileInfos(), "C", "A", "B", "A2", 1);
@@ -185,7 +185,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
         assertThat(stateStore.getActiveFiles())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrder(
-                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L, 0L, 198L),
-                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L, 1L, 199L));
+                        dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L),
+                        dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L));
     }
 }

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/CompactSortedFilesTestDataHelper.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/CompactSortedFilesTestDataHelper.java
@@ -52,8 +52,8 @@ public class CompactSortedFilesTestDataHelper {
         return fileInfo;
     }
 
-    public FileInfo writeRootFile(String filename, List<Record> records, Object min, Object max) throws IOException {
-        FileInfo fileInfo = fileInfoFactory.rootFile(filename, records.size(), min, max);
+    public FileInfo writeRootFile(String filename, List<Record> records) throws IOException {
+        FileInfo fileInfo = fileInfoFactory.rootFile(filename, records.size());
         writeDataFile(schema, filename, records);
         fileInfos.add(fileInfo);
         return fileInfo;
@@ -63,8 +63,8 @@ public class CompactSortedFilesTestDataHelper {
         return fileInfoFactory.leafFile(filename, records, min, max);
     }
 
-    public FileInfo expectedPartitionFile(String partitionId, String filename, long records, Object min, Object max) {
-        return fileInfoFactory.partitionFile(partitionId, filename, records, min, max);
+    public FileInfo expectedPartitionFile(String partitionId, String filename, long records) {
+        return fileInfoFactory.partitionFile(partitionId, filename, records);
     }
 
     public void addFilesToStateStoreForJob(CompactionJob compactionJob) throws StateStoreException {

--- a/java/compaction/compaction-status-store/src/test/java/sleeper/compaction/status/store/job/StoreCompactionJobCreatedIT.java
+++ b/java/compaction/compaction-status-store/src/test/java/sleeper/compaction/status/store/job/StoreCompactionJobCreatedIT.java
@@ -58,8 +58,8 @@ public class StoreCompactionJobCreatedIT extends DynamoDBCompactionJobStatusStor
                 .parentJoining("C", "A", "B"));
         CompactionJob job = jobFactory.createSplittingCompactionJob(
                 Arrays.asList(
-                        fileFactory.rootFile("file1", 100L, "a", "c"),
-                        fileFactory.rootFile("file2", 100L, "w", "z")),
+                        fileFactory.rootFile("file1", 100L),
+                        fileFactory.rootFile("file2", 100L)),
                 "C", "A", "B", "ggg", 0);
 
         // When
@@ -127,7 +127,7 @@ public class StoreCompactionJobCreatedIT extends DynamoDBCompactionJobStatusStor
         CompactionJob job1 = jobFactory.createCompactionJob(
                 Collections.singletonList(fileFactory.leafFile(100L, "a", "c")), "A");
         CompactionJob job2 = jobFactory.createSplittingCompactionJob(
-                Collections.singletonList(fileFactory.rootFile(100L, "b", "w")),
+                Collections.singletonList(fileFactory.rootFile(100L)),
                 "C", "A", "B", "ggg", 0);
 
         // When

--- a/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
@@ -17,6 +17,7 @@ package sleeper.core.statestore;
 
 import sleeper.core.partition.Partition;
 
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -127,5 +128,10 @@ public class DelegatingStateStore implements StateStore {
     @Override
     public void clearFiles() {
         fileInfoStore.clearTable();
+    }
+
+    @Override
+    public void fixTime(Instant now) {
+        fileInfoStore.fixTime(now);
     }
 }

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
@@ -15,6 +15,7 @@
  */
 package sleeper.core.statestore;
 
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -127,4 +128,6 @@ public interface FileInfoStore {
     boolean hasNoFiles();
 
     void clearTable();
+
+    void fixTime(Instant time);
 }

--- a/java/core/src/test/java/sleeper/core/statestore/FileInfoFactory.java
+++ b/java/core/src/test/java/sleeper/core/statestore/FileInfoFactory.java
@@ -48,27 +48,27 @@ public class FileInfoFactory {
     }
 
     public FileInfo leafFile(long records, Object min, Object max) {
-        return fileForPartition(leafPartition(min, max), records, min, max);
+        return fileForPartition(leafPartition(min, max), records);
     }
 
     public FileInfo middleFile(long records, Object min, Object max) {
-        return fileForPartition(middlePartition(min, max), records, min, max);
+        return fileForPartition(middlePartition(min, max), records);
     }
 
-    public FileInfo rootFile(long records, Object min, Object max) {
-        return fileForPartition(partitionTree.getRootPartition(), records, min, max);
+    public FileInfo rootFile(long records) {
+        return fileForPartition(partitionTree.getRootPartition(), records);
     }
 
     public FileInfo leafFile(String filename, long records, Object min, Object max) {
-        return fileForPartition(leafPartition(min, max), filename, records, min, max);
+        return fileForPartition(leafPartition(min, max), filename, records);
     }
 
-    public FileInfo rootFile(String filename, long records, Object min, Object max) {
-        return fileForPartition(partitionTree.getRootPartition(), filename, records, min, max);
+    public FileInfo rootFile(String filename, long records) {
+        return fileForPartition(partitionTree.getRootPartition(), filename, records);
     }
 
-    public FileInfo partitionFile(String partitionId, String filename, long records, Object min, Object max) {
-        return fileForPartition(partitionTree.getPartition(partitionId), filename, records, min, max);
+    public FileInfo partitionFile(String partitionId, String filename, long records) {
+        return fileForPartition(partitionTree.getPartition(partitionId), filename, records);
     }
 
     public FileInfo partitionFile(Partition partition, long records, Object min, Object max) {
@@ -78,7 +78,7 @@ public class FileInfoFactory {
         if (!partition.isRowKeyInPartition(schema, rowKey(max))) {
             throw new IllegalArgumentException("Max value not in partition: " + min + ", region: " + partition.getRegion());
         }
-        return fileForPartition(partition, records, min, max);
+        return fileForPartition(partition, records);
     }
 
     private Partition leafPartition(Object min, Object max) {
@@ -107,11 +107,11 @@ public class FileInfoFactory {
         return partition;
     }
 
-    private FileInfo fileForPartition(Partition partition, long records, Object min, Object max) {
-        return fileForPartition(partition, partition.getId() + ".parquet", records, min, max);
+    private FileInfo fileForPartition(Partition partition, long records) {
+        return fileForPartition(partition, partition.getId() + ".parquet", records);
     }
 
-    private FileInfo fileForPartition(Partition partition, String filename, long records, Object min, Object max) {
+    private FileInfo fileForPartition(Partition partition, String filename, long records) {
         return FileInfo.builder()
                 .rowKeyTypes(partition.getRowKeyTypes())
                 .filename(filename)

--- a/java/core/src/test/java/sleeper/core/statestore/FileInfoTestData.java
+++ b/java/core/src/test/java/sleeper/core/statestore/FileInfoTestData.java
@@ -15,15 +15,11 @@
  */
 package sleeper.core.statestore;
 
-import sleeper.core.key.Key;
-import sleeper.core.partition.Partition;
-import sleeper.core.range.Range;
 import sleeper.core.schema.Field;
 import sleeper.core.schema.Schema;
 import sleeper.core.schema.type.StringType;
 
 import java.time.Instant;
-import java.util.stream.Collectors;
 
 public class FileInfoTestData {
     private FileInfoTestData() {
@@ -46,26 +42,5 @@ public class FileInfoTestData {
                 .numberOfRecords(records).fileStatus(FileInfo.FileStatus.ACTIVE)
                 .lastStateStoreUpdateTime(Instant.parse("2022-12-08T11:03:00.001Z"))
                 .build();
-    }
-
-    public static FileInfo defaultPartitionSingleFileWithRecords(Partition partition, long records) {
-        return FileInfo.builder()
-                .rowKeyTypes(partition.getRowKeyTypes())
-                .filename(partition.getId() + ".parquet").partitionId(partition.getId())
-                .numberOfRecords(records).fileStatus(FileInfo.FileStatus.ACTIVE)
-                .lastStateStoreUpdateTime(Instant.parse("2022-12-08T11:03:00.001Z"))
-                .build();
-    }
-
-    private static Key minRowKey(Partition partition) {
-        return Key.create(partition.getRegion().getRanges().stream()
-                .map(Range::getMin)
-                .collect(Collectors.toList()));
-    }
-
-    private static Key maxRowKey(Partition partition) {
-        return Key.create(partition.getRegion().getRanges().stream()
-                .map(Range::getMax)
-                .collect(Collectors.toList()));
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
@@ -19,7 +19,9 @@ import sleeper.core.statestore.FileInfo;
 import sleeper.core.statestore.FileInfoStore;
 import sleeper.core.statestore.StateStoreException;
 
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,10 +39,11 @@ public class InMemoryFileInfoStore implements FileInfoStore {
 
     private final Map<String, FileInfo> activeFiles = new HashMap<>();
     private final Map<String, FileInfo> readyForGCFiles = new HashMap<>();
+    private Clock clock = Clock.systemUTC();
 
     @Override
     public void addFile(FileInfo fileInfo) {
-        activeFiles.put(fileInfo.getFilename(), fileInfo);
+        activeFiles.put(fileInfo.getFilename(), fileInfo.toBuilder().lastStateStoreUpdateTime(clock.millis()).build());
     }
 
     @Override
@@ -90,7 +93,9 @@ public class InMemoryFileInfoStore implements FileInfoStore {
     private void moveToGC(FileInfo file) {
         activeFiles.remove(file.getFilename());
         readyForGCFiles.put(file.getFilename(),
-                file.toBuilder().fileStatus(READY_FOR_GARBAGE_COLLECTION).build());
+                file.toBuilder().fileStatus(READY_FOR_GARBAGE_COLLECTION)
+                        .lastStateStoreUpdateTime(clock.millis())
+                        .build());
     }
 
     @Override
@@ -100,7 +105,8 @@ public class InMemoryFileInfoStore implements FileInfoStore {
             throw new StateStoreException("Job ID already set: " + filenamesWithJobId);
         }
         for (FileInfo file : fileInfos) {
-            activeFiles.put(file.getFilename(), file.toBuilder().jobId(jobId).build());
+            activeFiles.put(file.getFilename(), file.toBuilder().jobId(jobId)
+                    .lastStateStoreUpdateTime(clock.millis()).build());
         }
     }
 
@@ -134,5 +140,6 @@ public class InMemoryFileInfoStore implements FileInfoStore {
 
     @Override
     public void fixTime(Instant now) {
+        clock = Clock.fixed(now, ZoneId.of("UTC"));
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
@@ -19,6 +19,7 @@ import sleeper.core.statestore.FileInfo;
 import sleeper.core.statestore.FileInfoStore;
 import sleeper.core.statestore.StateStoreException;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -129,5 +130,9 @@ public class InMemoryFileInfoStore implements FileInfoStore {
     public void clearTable() {
         activeFiles.clear();
         readyForGCFiles.clear();
+    }
+
+    @Override
+    public void fixTime(Instant now) {
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreTest.java
@@ -27,6 +27,7 @@ import sleeper.core.statestore.FileInfoFactory;
 import sleeper.core.statestore.FileInfoStore;
 import sleeper.core.statestore.StateStoreException;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -43,13 +44,17 @@ public class InMemoryFileInfoStoreTest {
         PartitionTree tree = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
-        FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
+        Instant fixedUpdateTime = Instant.parse("2023-10-04T14:08:00Z");
+        FileInfoFactory factory = FileInfoFactory.builder()
+                .schema(schema).partitionTree(tree)
+                .lastStateStoreUpdate(fixedUpdateTime).build();
         FileInfo file1 = factory.rootFile("file1", 100L);
         FileInfo file2 = factory.rootFile("file2", 100L);
         FileInfo file3 = factory.rootFile("file3", 100L);
 
         // When
         FileInfoStore store = new InMemoryFileInfoStore();
+        store.fixTime(fixedUpdateTime);
         store.addFile(file1);
         store.addFiles(Arrays.asList(file2, file3));
 
@@ -70,10 +75,14 @@ public class InMemoryFileInfoStoreTest {
         PartitionTree tree = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
-        FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
+        Instant fixedUpdateTime = Instant.parse("2023-10-04T14:08:00Z");
+        FileInfoFactory factory = FileInfoFactory.builder()
+                .schema(schema).partitionTree(tree)
+                .lastStateStoreUpdate(fixedUpdateTime).build();
         FileInfo oldFile = factory.rootFile("oldFile", 100L);
         FileInfo newFile = factory.rootFile("newFile", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
+        store.fixTime(fixedUpdateTime);
         store.addFile(oldFile);
 
         // When
@@ -97,19 +106,25 @@ public class InMemoryFileInfoStoreTest {
         PartitionTree tree = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
-        FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
+        Instant fixedUpdateTime = Instant.parse("2023-10-04T14:08:00Z");
+        FileInfoFactory factory = FileInfoFactory.builder()
+                .schema(schema).partitionTree(tree)
+                .lastStateStoreUpdate(fixedUpdateTime).build();
         FileInfo oldFile = factory.rootFile("oldFile", 100L);
         FileInfo newLeftFile = factory.rootFile("newLeftFile", 100L);
         FileInfo newRightFile = factory.rootFile("newRightFile", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
+        store.fixTime(fixedUpdateTime);
         store.addFile(oldFile);
 
         // When
         store.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(Collections.singletonList(oldFile), newLeftFile, newRightFile);
 
         // Then
-        assertThat(store.getActiveFiles()).containsExactlyInAnyOrder(newLeftFile, newRightFile);
-        assertThat(store.getActiveFilesWithNoJobId()).containsExactlyInAnyOrder(newLeftFile, newRightFile);
+        assertThat(store.getActiveFiles())
+                .containsExactlyInAnyOrder(newLeftFile, newRightFile);
+        assertThat(store.getActiveFilesWithNoJobId())
+                .containsExactlyInAnyOrder(newLeftFile, newRightFile);
         assertThat(store.getReadyForGCFiles()).toIterable().containsExactly(
                 oldFile.toBuilder().fileStatus(READY_FOR_GARBAGE_COLLECTION).build());
         assertThat(store.getPartitionToActiveFilesMap())
@@ -146,9 +161,13 @@ public class InMemoryFileInfoStoreTest {
         PartitionTree tree = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
-        FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
+        Instant fixedUpdateTime = Instant.parse("2023-10-04T14:08:00Z");
+        FileInfoFactory factory = FileInfoFactory.builder()
+                .schema(schema).partitionTree(tree)
+                .lastStateStoreUpdate(fixedUpdateTime).build();
         FileInfo file = factory.rootFile("file", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
+        store.fixTime(fixedUpdateTime);
         store.addFile(file);
 
         // When
@@ -166,9 +185,13 @@ public class InMemoryFileInfoStoreTest {
         PartitionTree tree = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
-        FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
+        Instant fixedUpdateTime = Instant.parse("2023-10-04T14:08:00Z");
+        FileInfoFactory factory = FileInfoFactory.builder()
+                .schema(schema).partitionTree(tree)
+                .lastStateStoreUpdate(fixedUpdateTime).build();
         FileInfo file = factory.rootFile("file", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
+        store.fixTime(fixedUpdateTime);
         store.addFile(file);
         store.atomicallyUpdateJobStatusOfFiles("job1", Collections.singletonList(file));
 
@@ -186,11 +209,15 @@ public class InMemoryFileInfoStoreTest {
         PartitionTree tree = new PartitionsBuilder(schema)
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
-        FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
+        Instant fixedUpdateTime = Instant.parse("2023-10-04T14:08:00Z");
+        FileInfoFactory factory = FileInfoFactory.builder()
+                .schema(schema).partitionTree(tree)
+                .lastStateStoreUpdate(fixedUpdateTime).build();
         FileInfo file1 = factory.rootFile("file1", 100L);
         FileInfo file2 = factory.rootFile("file2", 100L);
         FileInfo file3 = factory.rootFile("file3", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
+        store.fixTime(fixedUpdateTime);
         store.addFiles(Arrays.asList(file1, file2, file3));
         store.atomicallyUpdateJobStatusOfFiles("job1", Collections.singletonList(file2));
 
@@ -200,5 +227,27 @@ public class InMemoryFileInfoStoreTest {
         assertThat(store.getActiveFiles()).containsExactlyInAnyOrder(
                 file1, file2.toBuilder().jobId("job1").build(), file3);
         assertThat(store.getActiveFilesWithNoJobId()).containsExactlyInAnyOrder(file1, file3);
+    }
+
+    @Test
+    void shouldSetLastUpdateTimeForFileWhenFixingTimeCorrectly() throws Exception {
+        // Given
+        Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
+        PartitionTree tree = new PartitionsBuilder(schema)
+                .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
+                .buildTree();
+        Instant file1Time = Instant.parse("2023-10-04T14:08:00Z");
+        FileInfoFactory factory = FileInfoFactory.builder()
+                .schema(schema).partitionTree(tree)
+                .lastStateStoreUpdate(file1Time).build();
+        FileInfo file1 = factory.rootFile("file1", 100L);
+
+        // When
+        FileInfoStore store = new InMemoryFileInfoStore();
+        store.fixTime(file1Time);
+        store.addFile(file1);
+
+        // Then
+        assertThat(store.getActiveFiles()).containsExactlyInAnyOrder(file1);
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStoreTest.java
@@ -44,9 +44,9 @@ public class InMemoryFileInfoStoreTest {
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
         FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
-        FileInfo file1 = factory.rootFile("file1", 100L, "a", "b");
-        FileInfo file2 = factory.rootFile("file2", 100L, "c", "d");
-        FileInfo file3 = factory.rootFile("file3", 100L, "e", "f");
+        FileInfo file1 = factory.rootFile("file1", 100L);
+        FileInfo file2 = factory.rootFile("file2", 100L);
+        FileInfo file3 = factory.rootFile("file3", 100L);
 
         // When
         FileInfoStore store = new InMemoryFileInfoStore();
@@ -71,8 +71,8 @@ public class InMemoryFileInfoStoreTest {
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
         FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
-        FileInfo oldFile = factory.rootFile("oldFile", 100L, "a", "b");
-        FileInfo newFile = factory.rootFile("newFile", 100L, "a", "b");
+        FileInfo oldFile = factory.rootFile("oldFile", 100L);
+        FileInfo newFile = factory.rootFile("newFile", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
         store.addFile(oldFile);
 
@@ -98,9 +98,9 @@ public class InMemoryFileInfoStoreTest {
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
         FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
-        FileInfo oldFile = factory.rootFile("oldFile", 100L, "a", "c");
-        FileInfo newLeftFile = factory.rootFile("newLeftFile", 100L, "a", "b");
-        FileInfo newRightFile = factory.rootFile("newRightFile", 100L, "b", "c");
+        FileInfo oldFile = factory.rootFile("oldFile", 100L);
+        FileInfo newLeftFile = factory.rootFile("newLeftFile", 100L);
+        FileInfo newRightFile = factory.rootFile("newRightFile", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
         store.addFile(oldFile);
 
@@ -126,8 +126,8 @@ public class InMemoryFileInfoStoreTest {
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
         FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
-        FileInfo oldFile = factory.rootFile("oldFile", 100L, "a", "b");
-        FileInfo newFile = factory.rootFile("newFile", 100L, "a", "b");
+        FileInfo oldFile = factory.rootFile("oldFile", 100L);
+        FileInfo newFile = factory.rootFile("newFile", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
         store.addFile(oldFile);
         store.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFile(Collections.singletonList(oldFile), newFile);
@@ -147,7 +147,7 @@ public class InMemoryFileInfoStoreTest {
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
         FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
-        FileInfo file = factory.rootFile("file", 100L, "a", "b");
+        FileInfo file = factory.rootFile("file", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
         store.addFile(file);
 
@@ -167,7 +167,7 @@ public class InMemoryFileInfoStoreTest {
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
         FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
-        FileInfo file = factory.rootFile("file", 100L, "a", "b");
+        FileInfo file = factory.rootFile("file", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
         store.addFile(file);
         store.atomicallyUpdateJobStatusOfFiles("job1", Collections.singletonList(file));
@@ -187,9 +187,9 @@ public class InMemoryFileInfoStoreTest {
                 .leavesWithSplits(Collections.singletonList("root"), Collections.emptyList())
                 .buildTree();
         FileInfoFactory factory = FileInfoFactory.builder().schema(schema).partitionTree(tree).build();
-        FileInfo file1 = factory.rootFile("file1", 100L, "a", "b");
-        FileInfo file2 = factory.rootFile("file2", 100L, "c", "d");
-        FileInfo file3 = factory.rootFile("file3", 100L, "e", "f");
+        FileInfo file1 = factory.rootFile("file1", 100L);
+        FileInfo file2 = factory.rootFile("file2", 100L);
+        FileInfo file3 = factory.rootFile("file3", 100L);
         FileInfoStore store = new InMemoryFileInfoStore();
         store.addFiles(Arrays.asList(file1, file2, file3));
         store.atomicallyUpdateJobStatusOfFiles("job1", Collections.singletonList(file2));

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/StateStoreTestBuilder.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/StateStoreTestBuilder.java
@@ -15,11 +15,9 @@
  */
 package sleeper.core.statestore.inmemory;
 
-import sleeper.core.key.Key;
 import sleeper.core.partition.Partition;
 import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
-import sleeper.core.range.Range;
 import sleeper.core.schema.Schema;
 import sleeper.core.statestore.FileInfo;
 import sleeper.core.statestore.StateStore;
@@ -27,7 +25,6 @@ import sleeper.core.statestore.StateStore;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class StateStoreTestBuilder {
@@ -103,15 +100,4 @@ public class StateStoreTestBuilder {
                 .build();
     }
 
-    private static Key minRowKey(Partition partition) {
-        return Key.create(partition.getRegion().getRanges().stream()
-                .map(Range::getMin)
-                .collect(Collectors.toList()));
-    }
-
-    private static Key maxRowKey(Partition partition) {
-        return Key.create(partition.getRegion().getRanges().stream()
-                .map(Range::getMax)
-                .collect(Collectors.toList()));
-    }
 }

--- a/java/garbage-collector/src/test/java/sleeper/garbagecollector/GarbageCollectorIT.java
+++ b/java/garbage-collector/src/test/java/sleeper/garbagecollector/GarbageCollectorIT.java
@@ -104,12 +104,13 @@ public class GarbageCollectorIT {
         private TableProperties tableProperties;
         private StateStoreProvider stateStoreProvider;
 
-        void setupStateStoreWithFixedTime(Instant fixedTime) throws Exception {
+        StateStore setupStateStoreAndFixTime(Instant fixedTime) throws Exception {
             new DynamoDBStateStoreCreator(instanceProperties, dynamoDBClient).create();
             stateStoreProvider = new StateStoreProvider(dynamoDBClient, instanceProperties, null);
             DynamoDBStateStore stateStore = (DynamoDBStateStore) stateStoreProvider.getStateStore(tableProperties);
             stateStore.initialise();
             stateStore.fixTime(fixedTime);
+            return stateStore;
         }
 
         @Test
@@ -119,11 +120,12 @@ public class GarbageCollectorIT {
             tableProperties = createTableWithGCDelay(TEST_TABLE_NAME, instanceProperties, 10);
             Instant currentTime = Instant.parse("2023-06-28T13:46:00Z");
             Instant timeAfterDelay = currentTime.minus(Duration.ofMinutes(11));
-            setupStateStoreWithFixedTime(currentTime);
+            StateStore stateStore = setupStateStoreAndFixTime(timeAfterDelay);
             java.nio.file.Path filePath = tempDir.resolve("test-file.parquet");
-            createReadyForGCFile(filePath.toString(), stateStoreProvider.getStateStore(tableProperties), timeAfterDelay);
+            createReadyForGCFile(filePath.toString(), stateStore);
 
             // When
+            stateStore.fixTime(currentTime);
             createGarbageCollector(s3Client, instanceProperties, stateStoreProvider).run();
 
             // Then
@@ -137,9 +139,9 @@ public class GarbageCollectorIT {
             instanceProperties = createInstanceProperties();
             tableProperties = createTable(TEST_TABLE_NAME, instanceProperties);
             Instant currentTime = Instant.parse("2023-06-28T13:46:00Z");
-            setupStateStoreWithFixedTime(currentTime);
+            StateStore stateStore = setupStateStoreAndFixTime(currentTime);
             java.nio.file.Path filePath = tempDir.resolve("test-file.parquet");
-            createActiveFile(filePath.toString(), stateStoreProvider.getStateStore(tableProperties), currentTime);
+            createActiveFile(filePath.toString(), stateStore);
 
             // When
             createGarbageCollector(s3Client, instanceProperties, stateStoreProvider).run();
@@ -155,9 +157,9 @@ public class GarbageCollectorIT {
             instanceProperties = createInstanceProperties();
             tableProperties = createTable(TEST_TABLE_NAME, instanceProperties);
             Instant currentTime = Instant.parse("2023-06-28T13:46:00Z");
-            setupStateStoreWithFixedTime(currentTime);
+            StateStore stateStore = setupStateStoreAndFixTime(currentTime);
             java.nio.file.Path filePath = tempDir.resolve("test-file.parquet");
-            createReadyForGCFile(filePath.toString(), stateStoreProvider.getStateStore(tableProperties), currentTime);
+            createReadyForGCFile(filePath.toString(), stateStore);
 
             // When
             createGarbageCollector(s3Client, instanceProperties, stateStoreProvider).run();
@@ -176,13 +178,14 @@ public class GarbageCollectorIT {
             tableProperties = createTableWithGCDelay(TEST_TABLE_NAME, instanceProperties, 10);
             Instant currentTime = Instant.parse("2023-06-28T13:46:00Z");
             Instant timeAfterDelay = currentTime.minus(Duration.ofMinutes(11));
-            setupStateStoreWithFixedTime(currentTime);
+            StateStore stateStore = setupStateStoreAndFixTime(timeAfterDelay);
             java.nio.file.Path filePath1 = tempDir.resolve("test-file-1.parquet");
             java.nio.file.Path filePath2 = tempDir.resolve("test-file-2.parquet");
-            createReadyForGCFile(filePath1.toString(), stateStoreProvider.getStateStore(tableProperties), timeAfterDelay);
-            createReadyForGCFile(filePath2.toString(), stateStoreProvider.getStateStore(tableProperties), timeAfterDelay);
+            createReadyForGCFile(filePath1.toString(), stateStoreProvider.getStateStore(tableProperties));
+            createReadyForGCFile(filePath2.toString(), stateStoreProvider.getStateStore(tableProperties));
 
             // When
+            stateStore.fixTime(currentTime);
             createGarbageCollector(s3Client, instanceProperties, stateStoreProvider).run();
 
             // Then
@@ -198,15 +201,16 @@ public class GarbageCollectorIT {
             tableProperties = createTableWithGCDelay(TEST_TABLE_NAME, instanceProperties, 10);
             Instant currentTime = Instant.parse("2023-06-28T13:46:00Z");
             Instant timeAfterDelay = currentTime.minus(Duration.ofMinutes(11));
-            setupStateStoreWithFixedTime(currentTime);
+            StateStore stateStore = setupStateStoreAndFixTime(timeAfterDelay);
             java.nio.file.Path filePath1 = tempDir.resolve("test-file-1.parquet");
             java.nio.file.Path filePath2 = tempDir.resolve("test-file-2.parquet");
             java.nio.file.Path filePath3 = tempDir.resolve("test-file-3.parquet");
-            createReadyForGCFile(filePath1.toString(), stateStoreProvider.getStateStore(tableProperties), timeAfterDelay);
-            createReadyForGCFile(filePath2.toString(), stateStoreProvider.getStateStore(tableProperties), timeAfterDelay);
-            createReadyForGCFile(filePath3.toString(), stateStoreProvider.getStateStore(tableProperties), timeAfterDelay);
+            createReadyForGCFile(filePath1.toString(), stateStoreProvider.getStateStore(tableProperties));
+            createReadyForGCFile(filePath2.toString(), stateStoreProvider.getStateStore(tableProperties));
+            createReadyForGCFile(filePath3.toString(), stateStoreProvider.getStateStore(tableProperties));
 
             // When
+            stateStore.fixTime(currentTime);
             createGarbageCollector(s3Client, instanceProperties, stateStoreProvider).run();
 
             // Then
@@ -225,15 +229,13 @@ public class GarbageCollectorIT {
         private TableProperties tableProperties2;
         private StateStoreProvider stateStoreProvider;
 
-        void setupStateStoreWithFixedTime(Instant fixedTime) throws Exception {
+        void setupStateStores() throws Exception {
             new DynamoDBStateStoreCreator(instanceProperties, dynamoDBClient).create();
             stateStoreProvider = new StateStoreProvider(dynamoDBClient, instanceProperties, null);
             DynamoDBStateStore stateStore1 = (DynamoDBStateStore) stateStoreProvider.getStateStore(tableProperties1);
             stateStore1.initialise();
-            stateStore1.fixTime(fixedTime);
             DynamoDBStateStore stateStore2 = (DynamoDBStateStore) stateStoreProvider.getStateStore(tableProperties2);
             stateStore2.initialise();
-            stateStore2.fixTime(fixedTime);
         }
 
         @Test
@@ -244,13 +246,19 @@ public class GarbageCollectorIT {
             tableProperties2 = createTableWithGCDelay(TEST_TABLE_NAME_2, instanceProperties, 10);
             Instant currentTime = Instant.parse("2023-06-28T13:46:00Z");
             Instant timeAfterDelay = currentTime.minus(Duration.ofMinutes(11));
-            setupStateStoreWithFixedTime(currentTime);
+            setupStateStores();
+            StateStore stateStore1 = stateStoreProvider.getStateStore(tableProperties1);
+            StateStore stateStore2 = stateStoreProvider.getStateStore(tableProperties2);
             java.nio.file.Path filePath1 = tempDir.resolve("test-file-1.parquet");
             java.nio.file.Path filePath2 = tempDir.resolve("test-file-2.parquet");
-            createReadyForGCFile(filePath1.toString(), stateStoreProvider.getStateStore(tableProperties1), timeAfterDelay);
-            createReadyForGCFile(filePath2.toString(), stateStoreProvider.getStateStore(tableProperties2), timeAfterDelay);
+            stateStore1.fixTime(timeAfterDelay);
+            stateStore2.fixTime(timeAfterDelay);
+            createReadyForGCFile(filePath1.toString(), stateStore1);
+            createReadyForGCFile(filePath2.toString(), stateStore2);
 
             // When
+            stateStore1.fixTime(currentTime);
+            stateStore2.fixTime(currentTime);
             createGarbageCollector(s3Client, instanceProperties, stateStoreProvider).run();
 
             // Then
@@ -274,22 +282,21 @@ public class GarbageCollectorIT {
         };
     }
 
-    private void createActiveFile(String filename, StateStore stateStore, Instant lastUpdateTime) throws Exception {
-        createFile(filename, stateStore, FileInfo.FileStatus.ACTIVE, lastUpdateTime);
+    private void createActiveFile(String filename, StateStore stateStore) throws Exception {
+        createFile(filename, stateStore, FileInfo.FileStatus.ACTIVE);
     }
 
-    private void createReadyForGCFile(String filename, StateStore stateStore, Instant lastUpdateTime) throws Exception {
-        createFile(filename, stateStore, FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION, lastUpdateTime);
+    private void createReadyForGCFile(String filename, StateStore stateStore) throws Exception {
+        createFile(filename, stateStore, FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION);
     }
 
-    private void createFile(String filename, StateStore stateStore, FileInfo.FileStatus status, Instant lastUpdateTime) throws Exception {
+    private void createFile(String filename, StateStore stateStore, FileInfo.FileStatus status) throws Exception {
         String partitionId = stateStore.getAllPartitions().get(0).getId();
         FileInfo fileInfo = FileInfo.builder()
                 .rowKeyTypes(new IntType())
                 .filename(filename)
                 .partitionId(partitionId)
                 .numberOfRecords(100L)
-                .lastStateStoreUpdateTime(lastUpdateTime)
                 .fileStatus(status)
                 .build();
         ParquetWriter<Record> writer = ParquetRecordWriterFactory.createParquetRecordWriter(new Path(filename), TEST_SCHEMA);

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/AsyncS3PartitionFileWriter.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/AsyncS3PartitionFileWriter.java
@@ -38,11 +38,9 @@ import sleeper.sketches.s3.SketchesSerDeToS3;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -73,7 +71,6 @@ public class AsyncS3PartitionFileWriter implements PartitionFileWriter {
     private final String partitionParquetS3Key;
     private final String quantileSketchesLocalFileName;
     private final String quantileSketchesS3Key;
-    private final Supplier<Instant> timeSupplier;
     private final ParquetWriter<Record> parquetWriter;
     private final Map<String, ItemsSketch> keyFieldToSketchMap;
     private long recordsWrittenToCurrentPartition;
@@ -101,8 +98,7 @@ public class AsyncS3PartitionFileWriter implements PartitionFileWriter {
             String filePathPrefix,
             S3TransferManager s3TransferManager,
             String localWorkingDirectory,
-            String fileName,
-            Supplier<Instant> timeSupplier) throws IOException {
+            String fileName) throws IOException {
         this.s3TransferManager = requireNonNull(s3TransferManager);
         this.sleeperSchema = parquetConfiguration.getTableProperties().getSchema();
         this.partition = requireNonNull(partition);
@@ -112,7 +108,6 @@ public class AsyncS3PartitionFileWriter implements PartitionFileWriter {
         this.quantileSketchesLocalFileName = String.format("%s/partition_%s_%s.sketches", localWorkingDirectory, partition.getId(), fileName);
         this.partitionParquetS3Key = String.format("partition_%s/%s%s.parquet", partition.getId(), filePathPrefix, fileName);
         this.quantileSketchesS3Key = String.format("partition_%s/%s%s.sketches", partition.getId(), filePathPrefix, fileName);
-        this.timeSupplier = timeSupplier;
         this.parquetWriter = parquetConfiguration.createParquetWriter(partitionParquetLocalFileName);
         LOGGER.info("Created Parquet writer for partition {}", partition.getId());
         this.keyFieldToSketchMap = createKeyFieldToSketchMap(sleeperSchema);
@@ -126,22 +121,19 @@ public class AsyncS3PartitionFileWriter implements PartitionFileWriter {
      * @param filename        -
      * @param partitionId     -
      * @param numberOfRecords -
-     * @param updateTime      -
      * @return The {@link FileInfo} object
      */
     private static FileInfo createFileInfo(
             Schema sleeperSchema,
             String filename,
             String partitionId,
-            long numberOfRecords,
-            long updateTime) {
+            long numberOfRecords) {
         return FileInfo.builder()
                 .rowKeyTypes(sleeperSchema.getRowKeyTypes())
                 .filename(filename)
                 .partitionId(partitionId)
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .numberOfRecords(numberOfRecords)
-                .lastStateStoreUpdateTime(updateTime)
                 .build();
     }
 
@@ -260,8 +252,7 @@ public class AsyncS3PartitionFileWriter implements PartitionFileWriter {
                 sleeperSchema,
                 String.format("s3a://%s/%s", s3BucketName, partitionParquetS3Key),
                 partition.getId(),
-                recordsWrittenToCurrentPartition,
-                timeSupplier.get().toEpochMilli());
+                recordsWrittenToCurrentPartition);
         // Start the asynchronous upload of the files to S3
         CompletableFuture<?> partitionFileUploadFuture = asyncUploadLocalFileToS3ThenDeleteLocalCopy(
                 s3TransferManager,

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/AsyncS3PartitionFileWriterFactory.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/AsyncS3PartitionFileWriterFactory.java
@@ -30,7 +30,6 @@ import sleeper.ingest.impl.ParquetConfiguration;
 
 import java.io.IOException;
 import java.net.URI;
-import java.time.Instant;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
@@ -49,7 +48,6 @@ public class AsyncS3PartitionFileWriterFactory implements PartitionFileWriterFac
     private final String filePathPrefix;
     private final String localWorkingDirectory;
     private final Supplier<String> fileNameGenerator;
-    private final Supplier<Instant> timeSupplier;
     private final S3TransferManager s3TransferManager;
     private final S3AsyncClient s3AsyncClient;
     private final boolean closeS3AsyncClient;
@@ -60,7 +58,6 @@ public class AsyncS3PartitionFileWriterFactory implements PartitionFileWriterFac
         filePathPrefix = Objects.requireNonNull(builder.filePathPrefix, "filePathPrefix must not be null");
         localWorkingDirectory = Objects.requireNonNull(builder.localWorkingDirectory, "localWorkingDirectory must not be null");
         fileNameGenerator = Objects.requireNonNull(builder.fileNameGenerator, "fileNameGenerator must not be null");
-        timeSupplier = Objects.requireNonNull(builder.timeSupplier, "timeSupplier must not be null");
         s3AsyncClient = builder.s3AsyncClient;
         closeS3AsyncClient = builder.closeS3AsyncClient;
         if (s3AsyncClient != null) {
@@ -137,8 +134,8 @@ public class AsyncS3PartitionFileWriterFactory implements PartitionFileWriterFac
                     s3BucketName, filePathPrefix,
                     s3TransferManager,
                     localWorkingDirectory,
-                    fileNameGenerator.get(),
-                    timeSupplier);
+                    fileNameGenerator.get()
+            );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -160,7 +157,6 @@ public class AsyncS3PartitionFileWriterFactory implements PartitionFileWriterFac
         private String localWorkingDirectory;
         private boolean closeS3AsyncClient;
         private Supplier<String> fileNameGenerator = () -> UUID.randomUUID().toString();
-        private Supplier<Instant> timeSupplier = Instant::now;
 
         private Builder() {
         }
@@ -203,11 +199,6 @@ public class AsyncS3PartitionFileWriterFactory implements PartitionFileWriterFac
 
         public Builder fileNameGenerator(Supplier<String> fileNameGenerator) {
             this.fileNameGenerator = fileNameGenerator;
-            return this;
-        }
-
-        public Builder timeSupplier(Supplier<Instant> timeSupplier) {
-            this.timeSupplier = timeSupplier;
             return this;
         }
 

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/DirectPartitionFileWriterFactory.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/DirectPartitionFileWriterFactory.java
@@ -21,7 +21,6 @@ import sleeper.core.partition.Partition;
 import sleeper.ingest.impl.ParquetConfiguration;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -35,25 +34,23 @@ public class DirectPartitionFileWriterFactory implements PartitionFileWriterFact
     private final ParquetConfiguration parquetConfiguration;
     private final String filePathPrefix;
     private final Supplier<String> fileNameGenerator;
-    private final Supplier<Instant> timeSupplier;
 
     private DirectPartitionFileWriterFactory(
             ParquetConfiguration parquetConfiguration, String filePathPrefix,
-            Supplier<String> fileNameGenerator, Supplier<Instant> timeSupplier) {
+            Supplier<String> fileNameGenerator) {
         this.parquetConfiguration = Objects.requireNonNull(parquetConfiguration, "parquetWriterConfiguration must not be null");
         this.filePathPrefix = Objects.requireNonNull(filePathPrefix, "filePathPrefix must not be null");
         this.fileNameGenerator = Objects.requireNonNull(fileNameGenerator, "fileNameGenerator must not be null");
-        this.timeSupplier = Objects.requireNonNull(timeSupplier, "timeSupplier must not be null");
     }
 
     public static DirectPartitionFileWriterFactory from(ParquetConfiguration configuration, String filePathPrefix) {
-        return from(configuration, filePathPrefix, () -> UUID.randomUUID().toString(), Instant::now);
+        return from(configuration, filePathPrefix, () -> UUID.randomUUID().toString());
     }
 
     public static DirectPartitionFileWriterFactory from(
             ParquetConfiguration configuration, String filePathPrefix,
-            Supplier<String> fileNameGenerator, Supplier<Instant> timeSupplier) {
-        return new DirectPartitionFileWriterFactory(configuration, filePathPrefix, fileNameGenerator, timeSupplier);
+            Supplier<String> fileNameGenerator) {
+        return new DirectPartitionFileWriterFactory(configuration, filePathPrefix, fileNameGenerator);
     }
 
     public static DirectPartitionFileWriterFactory from(
@@ -72,8 +69,8 @@ public class DirectPartitionFileWriterFactory implements PartitionFileWriterFact
                     partition,
                     parquetConfiguration,
                     filePathPrefix,
-                    fileNameGenerator.get(),
-                    timeSupplier);
+                    fileNameGenerator.get()
+            );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/PartitionFileWriterUtils.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/impl/partitionfilewriter/PartitionFileWriterUtils.java
@@ -47,21 +47,18 @@ public class PartitionFileWriterUtils {
      * @param filename        -
      * @param partitionId     -
      * @param numberOfRecords -
-     * @param updateTime      -
      * @return The {@link FileInfo} object
      */
     public static FileInfo createFileInfo(Schema sleeperSchema,
                                           String filename,
                                           String partitionId,
-                                          long numberOfRecords,
-                                          long updateTime) {
+                                          long numberOfRecords) {
         return FileInfo.builder()
                 .rowKeyTypes(sleeperSchema.getRowKeyTypes())
                 .filename(filename)
                 .partitionId(partitionId)
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .numberOfRecords(numberOfRecords)
-                .lastStateStoreUpdateTime(updateTime)
                 .build();
     }
 

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestResultIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestResultIT.java
@@ -48,6 +48,7 @@ class IngestResultIT extends IngestRecordsTestBase {
 
         // Then
         assertThat(result.getFileInfoList())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrderElementsOf(stateStore.getActiveFiles());
     }
 }

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorCommonIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorCommonIT.java
@@ -160,7 +160,7 @@ public class IngestCoordinatorCommonIT {
                 .lastStateStoreUpdate(stateStoreUpdateTime)
                 .schema(recordListAndSchema.sleeperSchema)
                 .build()
-                .rootFile(ingestType.getFilePrefix(parameters) + "/partition_root/rootFile.parquet", 200, -100L, 99L);
+                .rootFile(ingestType.getFilePrefix(parameters) + "/partition_root/rootFile.parquet", 200);
 
         assertThat(Paths.get(ingestLocalWorkingDirectory)).isEmptyDirectory();
         assertThat(actualFiles).containsExactly(fileInfo);
@@ -212,7 +212,7 @@ public class IngestCoordinatorCommonIT {
                 .lastStateStoreUpdate(stateStoreUpdateTime)
                 .schema(recordListAndSchema.sleeperSchema)
                 .build()
-                .rootFile(ingestType.getFilePrefix(parameters) + "/partition_root/rootFile.parquet", 20000, -10000L, 9999L);
+                .rootFile(ingestType.getFilePrefix(parameters) + "/partition_root/rootFile.parquet", 20000);
 
         assertThat(Paths.get(ingestLocalWorkingDirectory)).isEmptyDirectory();
         assertThat(actualFiles).containsExactly(fileInfo);
@@ -566,9 +566,9 @@ public class IngestCoordinatorCommonIT {
                 .schema(recordListAndSchema.sleeperSchema)
                 .build();
         FileInfo leftFile = fileInfoFactory.partitionFile("left", ingestType.getFilePrefix(parameters) +
-                "/partition_left/leftFile.parquet", 2, new byte[]{1, 1}, new byte[]{5});
+                "/partition_left/leftFile.parquet", 2);
         FileInfo rightFile = fileInfoFactory.partitionFile("right", ingestType.getFilePrefix(parameters) +
-                "/partition_right/rightFile.parquet", 2, new byte[]{11, 2}, new byte[]{64, 65});
+                "/partition_right/rightFile.parquet", 2);
         List<Record> leftRecords = readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, leftFile, hadoopConfiguration);
         List<Record> rightRecords = readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, rightFile, hadoopConfiguration);
         List<Record> allRecords = Stream.of(leftRecords, rightRecords)
@@ -640,9 +640,9 @@ public class IngestCoordinatorCommonIT {
                 .schema(recordListAndSchema.sleeperSchema)
                 .build();
         FileInfo rightFile = fileInfoFactory.partitionFile("right", ingestType.getFilePrefix(parameters) +
-                "/partition_right/rightFile.parquet", 2, 0, 100);
+                "/partition_right/rightFile.parquet", 2);
         FileInfo leftFile = fileInfoFactory.partitionFile("left", ingestType.getFilePrefix(parameters) +
-                "/partition_left/leftFile.parquet", 2, 0, 100);
+                "/partition_left/leftFile.parquet", 2);
         List<Record> leftRecords = ResultVerifier.readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, leftFile, hadoopConfiguration);
         List<Record> rightRecords = ResultVerifier.readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, rightFile, hadoopConfiguration);
         List<Record> allRecords = Stream.of(leftRecords, rightRecords)
@@ -708,9 +708,9 @@ public class IngestCoordinatorCommonIT {
                 .schema(recordListAndSchema.sleeperSchema)
                 .build();
         FileInfo leftFile = fileInfoFactory.partitionFile("left", ingestType.getFilePrefix(parameters) +
-                "/partition_left/leftFile.parquet", 112, -100L, 19L);
+                "/partition_left/leftFile.parquet", 112);
         FileInfo rightFile = fileInfoFactory.partitionFile("right", ingestType.getFilePrefix(parameters) +
-                "/partition_right/rightFile.parquet", 88, 2L, 99L);
+                "/partition_right/rightFile.parquet", 88);
         List<Record> leftRecords = ResultVerifier.readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, leftFile, hadoopConfiguration);
         List<Record> rightRecords = ResultVerifier.readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, rightFile, hadoopConfiguration);
         List<Record> allRecords = Stream.of(leftRecords, rightRecords)

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorCommonIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorCommonIT.java
@@ -140,10 +140,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("rootFile"))
-                .fileUpdatedTimes(List.of(stateStoreUpdateTime))
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -192,10 +192,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("rootFile"))
-                .fileUpdatedTimes(List.of(stateStoreUpdateTime))
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -244,10 +244,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(List.of(stateStoreUpdateTime, stateStoreUpdateTime, stateStoreUpdateTime))
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -300,10 +300,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -359,10 +359,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(List.of(stateStoreUpdateTime, stateStoreUpdateTime, stateStoreUpdateTime))
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -419,10 +419,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(List.of(stateStoreUpdateTime, stateStoreUpdateTime, stateStoreUpdateTime))
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -485,10 +485,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(List.of(stateStoreUpdateTime, stateStoreUpdateTime, stateStoreUpdateTime))
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -546,10 +546,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -620,10 +620,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -688,10 +688,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -763,10 +763,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -817,10 +817,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(duplicatedRecordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -869,7 +869,6 @@ public class IngestCoordinatorCommonIT {
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of())
-                .fileUpdatedTimes(List.of())
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -910,10 +909,10 @@ public class IngestCoordinatorCommonIT {
                 .buildTree();
         stateStore.initialise(tree.getAllPartitions());
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString() + "/path/to/new/sub/directory";
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("rootFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
@@ -134,7 +134,9 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
         List<Record> allRecords = Stream.of(leftRecords, rightRecords).flatMap(List::stream).collect(Collectors.toUnmodifiableList());
 
         assertThat(Paths.get(ingestLocalWorkingDirectory)).isEmptyDirectory();
-        assertThat(actualFiles).containsExactlyInAnyOrder(leftFile, rightFile);
+        assertThat(actualFiles)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactlyInAnyOrder(leftFile, rightFile);
         assertThat(allRecords).containsExactlyInAnyOrderElementsOf(recordListAndSchema.recordList);
         assertThat(leftRecords).extracting(record -> record.getValues(List.of("key0")).get(0))
                 .containsExactly(LongStream.range(-100, 0).boxed().toArray());
@@ -188,8 +190,8 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
         List<Record> firstRightFileRecords = readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, firstRightFile, hadoopConfiguration);
 
         assertThat(Paths.get(ingestLocalWorkingDirectory)).isEmptyDirectory();
-        assertThat(actualFiles)
-                .hasSize(40)
+        assertThat(actualFiles).hasSize(40)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .contains(firstLeftFile, firstRightFile);
         assertThat(actualRecords).containsExactlyInAnyOrderElementsOf(recordListAndSchema.recordList);
         assertThat(firstLeftFileRecords).extracting(record -> record.getValues(List.of("key0")).get(0))

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
@@ -127,8 +127,8 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
                 .lastStateStoreUpdate(stateStoreUpdateTime)
                 .schema(recordListAndSchema.sleeperSchema)
                 .build();
-        FileInfo leftFile = fileInfoFactory.partitionFile("left", "s3a://" + dataBucketName + "/partition_left/leftFile.parquet", 100, -100L, -1L);
-        FileInfo rightFile = fileInfoFactory.partitionFile("right", "s3a://" + dataBucketName + "/partition_right/rightFile.parquet", 100, 0L, 99L);
+        FileInfo leftFile = fileInfoFactory.partitionFile("left", "s3a://" + dataBucketName + "/partition_left/leftFile.parquet", 100);
+        FileInfo rightFile = fileInfoFactory.partitionFile("right", "s3a://" + dataBucketName + "/partition_right/rightFile.parquet", 100);
         List<Record> leftRecords = readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, leftFile, hadoopConfiguration);
         List<Record> rightRecords = readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, rightFile, hadoopConfiguration);
         List<Record> allRecords = Stream.of(leftRecords, rightRecords).flatMap(List::stream).collect(Collectors.toUnmodifiableList());
@@ -181,8 +181,8 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
                 .lastStateStoreUpdate(stateStoreUpdateTime)
                 .schema(recordListAndSchema.sleeperSchema)
                 .build();
-        FileInfo firstLeftFile = fileInfoFactory.partitionFile("left", "s3a://" + dataBucketName + "/partition_left/file0.parquet", 5, -90L, -2L);
-        FileInfo firstRightFile = fileInfoFactory.partitionFile("right", "s3a://" + dataBucketName + "/partition_right/file1.parquet", 5, 12L, 83L);
+        FileInfo firstLeftFile = fileInfoFactory.partitionFile("left", "s3a://" + dataBucketName + "/partition_left/file0.parquet", 5);
+        FileInfo firstRightFile = fileInfoFactory.partitionFile("right", "s3a://" + dataBucketName + "/partition_right/file1.parquet", 5);
         List<Record> actualRecords = readMergedRecordsFromPartitionDataFiles(recordListAndSchema.sleeperSchema, actualFiles, hadoopConfiguration);
         List<Record> firstLeftFileRecords = readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, firstLeftFile, hadoopConfiguration);
         List<Record> firstRightFileRecords = readRecordsFromPartitionDataFile(recordListAndSchema.sleeperSchema, firstRightFile, hadoopConfiguration);

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
@@ -117,8 +117,8 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
                 5,
                 1000L,
                 ingestLocalWorkingDirectory,
-                Stream.of("leftFile", "rightFile"),
-                stateStoreUpdateTime);
+                Stream.of("leftFile", "rightFile")
+        );
 
         // Then
         List<FileInfo> actualFiles = stateStore.getActiveFiles();
@@ -171,8 +171,8 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
                 5,
                 10L,
                 ingestLocalWorkingDirectory,
-                fileNames,
-                stateStoreUpdateTime);
+                fileNames
+        );
 
         // Then
         List<FileInfo> actualFiles = stateStore.getActiveFiles();
@@ -209,8 +209,7 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
             int maxNoOfRecordsInMemory,
             long maxNoOfRecordsInLocalStore,
             String ingestLocalWorkingDirectory,
-            Stream<String> fileNames,
-            Instant stateStoreUpdateTime) throws StateStoreException, IteratorException, IOException {
+            Stream<String> fileNames) throws StateStoreException, IteratorException, IOException {
         ParquetConfiguration parquetConfiguration = parquetConfiguration(
                 recordListAndSchema.sleeperSchema, hadoopConfiguration);
         try (IngestCoordinator<Record> ingestCoordinator = standardIngestCoordinator(
@@ -224,8 +223,8 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
                 DirectPartitionFileWriterFactory.from(
                         parquetConfiguration,
                         "s3a://" + dataBucketName,
-                        fileNames.iterator()::next,
-                        () -> stateStoreUpdateTime))) {
+                        fileNames.iterator()::next
+                ))) {
             for (Record record : recordListAndSchema.recordList) {
                 ingestCoordinator.write(record);
             }

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
@@ -106,10 +106,11 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
                 .rootFirst("root")
                 .splitToNewChildren("root", "left", "right", 0L)
                 .buildTree();
+        Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
         StateStore stateStore = createStateStore(recordListAndSchema.sleeperSchema);
         stateStore.initialise(tree.getAllPartitions());
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
-        Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
 
         ingestRecords(
                 recordListAndSchema,
@@ -134,9 +135,7 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
         List<Record> allRecords = Stream.of(leftRecords, rightRecords).flatMap(List::stream).collect(Collectors.toUnmodifiableList());
 
         assertThat(Paths.get(ingestLocalWorkingDirectory)).isEmptyDirectory();
-        assertThat(actualFiles)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
-                .containsExactlyInAnyOrder(leftFile, rightFile);
+        assertThat(actualFiles).containsExactlyInAnyOrder(leftFile, rightFile);
         assertThat(allRecords).containsExactlyInAnyOrderElementsOf(recordListAndSchema.recordList);
         assertThat(leftRecords).extracting(record -> record.getValues(List.of("key0")).get(0))
                 .containsExactly(LongStream.range(-100, 0).boxed().toArray());
@@ -163,6 +162,7 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
         StateStore stateStore = createStateStore(recordListAndSchema.sleeperSchema);
         stateStore.initialise(tree.getAllPartitions());
+        stateStore.fixTime(stateStoreUpdateTime);
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
         Stream<String> fileNames = IntStream.iterate(0, i -> i + 1).mapToObj(i -> "file" + i);
 
@@ -191,7 +191,6 @@ public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {
 
         assertThat(Paths.get(ingestLocalWorkingDirectory)).isEmptyDirectory();
         assertThat(actualFiles).hasSize(40)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .contains(firstLeftFile, firstRightFile);
         assertThat(actualRecords).containsExactlyInAnyOrderElementsOf(recordListAndSchema.recordList);
         assertThat(firstLeftFileRecords).extracting(record -> record.getValues(List.of("key0")).get(0))

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrowIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrowIT.java
@@ -58,9 +58,9 @@ class IngestCoordinatorUsingDirectWriteBackedByArrowIT extends DirectWriteBacked
         StateStore stateStore = inMemoryStateStoreWithFixedPartitions(tree.getAllPartitions());
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -122,9 +122,9 @@ class IngestCoordinatorUsingDirectWriteBackedByArrowIT extends DirectWriteBacked
         StateStore stateStore = inMemoryStateStoreWithFixedPartitions(tree.getAllPartitions());
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile1", "rightFile1", "leftFile2", "rightFile2"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -195,9 +195,9 @@ class IngestCoordinatorUsingDirectWriteBackedByArrowIT extends DirectWriteBacked
                         .splitToNewChildren("root", "left", "right", 0L).buildList());
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrowRecordWriterAcceptingRecordListIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrowRecordWriterAcceptingRecordListIT.java
@@ -65,9 +65,9 @@ class IngestCoordinatorUsingDirectWriteBackedByArrowRecordWriterAcceptingRecordL
         StateStore stateStore = inMemoryStateStoreWithFixedPartitions(tree.getAllPartitions());
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -131,9 +131,9 @@ class IngestCoordinatorUsingDirectWriteBackedByArrowRecordWriterAcceptingRecordL
         StateStore stateStore = inMemoryStateStoreWithFixedPartitions(tree.getAllPartitions());
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile1", "rightFile1", "leftFile2", "rightFile2"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)
@@ -205,9 +205,9 @@ class IngestCoordinatorUsingDirectWriteBackedByArrowRecordWriterAcceptingRecordL
         );
         String ingestLocalWorkingDirectory = createTempDirectory(temporaryFolder, null).toString();
         Instant stateStoreUpdateTime = Instant.parse("2023-08-08T11:20:00Z");
+        stateStore.fixTime(stateStoreUpdateTime);
         IngestCoordinatorTestParameters parameters = createTestParameterBuilder()
                 .fileNames(List.of("leftFile", "rightFile"))
-                .fileUpdatedTimes(() -> stateStoreUpdateTime)
                 .stateStore(stateStore)
                 .schema(recordListAndSchema.sleeperSchema)
                 .workingDir(ingestLocalWorkingDirectory)

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/testutils/IngestCoordinatorFactory.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/testutils/IngestCoordinatorFactory.java
@@ -55,7 +55,7 @@ public class IngestCoordinatorFactory {
                 arrowConfigBuilder.build(),
                 DirectPartitionFileWriterFactory.from(
                         parquetConfiguration, filePathPrefix,
-                        parameters.getFileNameGenerator(), parameters.getFileUpdatedTimeSupplier()))
+                        parameters.getFileNameGenerator()))
                 .build();
     }
 
@@ -84,7 +84,6 @@ public class IngestCoordinatorFactory {
                             .localWorkingDirectory(parameters.getWorkingDir())
                             .s3BucketName(parameters.getDataBucketName())
                             .fileNameGenerator(parameters.getFileNameGenerator())
-                            .timeSupplier(parameters.getFileUpdatedTimeSupplier())
                             .build())
                     .build();
         } catch (Exception e) {
@@ -105,7 +104,7 @@ public class IngestCoordinatorFactory {
                             .buildAcceptingRecords(),
                     DirectPartitionFileWriterFactory.from(
                             parquetConfiguration, filePathPrefix,
-                            parameters.getFileNameGenerator(), parameters.getFileUpdatedTimeSupplier()))
+                            parameters.getFileNameGenerator()))
                     .build();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/testutils/IngestCoordinatorTestParameters.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/testutils/IngestCoordinatorTestParameters.java
@@ -25,7 +25,6 @@ import sleeper.core.statestore.StateStore;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -42,7 +41,6 @@ public class IngestCoordinatorTestParameters {
     private final Configuration hadoopConfiguration;
     private final S3AsyncClient s3AsyncClient;
     private final List<String> fileNames;
-    private final Supplier<Instant> fileUpdatedTimes;
 
     private IngestCoordinatorTestParameters(Builder builder) {
         stateStore = builder.stateStore;
@@ -54,7 +52,6 @@ public class IngestCoordinatorTestParameters {
         hadoopConfiguration = builder.hadoopConfiguration;
         s3AsyncClient = builder.s3AsyncClient;
         fileNames = builder.fileNames;
-        fileUpdatedTimes = builder.fileUpdatedTimes;
     }
 
     public static Builder builder() {
@@ -101,10 +98,6 @@ public class IngestCoordinatorTestParameters {
         return fileNames.iterator()::next;
     }
 
-    public Supplier<Instant> getFileUpdatedTimeSupplier() {
-        return fileUpdatedTimes;
-    }
-
     public static final class Builder {
         private StateStore stateStore;
         private Schema schema;
@@ -115,7 +108,6 @@ public class IngestCoordinatorTestParameters {
         private Configuration hadoopConfiguration;
         private S3AsyncClient s3AsyncClient;
         private List<String> fileNames;
-        private Supplier<Instant> fileUpdatedTimes;
 
         private Builder() {
         }
@@ -170,15 +162,6 @@ public class IngestCoordinatorTestParameters {
 
         public Builder fileNames(List<String> fileNames) {
             this.fileNames = fileNames;
-            return this;
-        }
-
-        public Builder fileUpdatedTimes(List<Instant> fileUpdatedTimes) {
-            return fileUpdatedTimes(fileUpdatedTimes.iterator()::next);
-        }
-
-        public Builder fileUpdatedTimes(Supplier<Instant> fileUpdatedTimes) {
-            this.fileUpdatedTimes = fileUpdatedTimes;
             return this;
         }
 

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
@@ -104,12 +104,16 @@ class DynamoDBFileInfoStore implements FileInfoStore {
 
     @Override
     public void addFile(FileInfo fileInfo) throws StateStoreException {
+        addFile(fileInfo, clock.millis());
+    }
+
+    public void addFile(FileInfo fileInfo, long updateTime) throws StateStoreException {
         if (null == fileInfo.getFilename()
                 || null == fileInfo.getFileStatus()
                 || null == fileInfo.getPartitionId()) {
             throw new IllegalArgumentException("FileInfo needs non-null filename, status and partition: got " + fileInfo);
         }
-        Map<String, AttributeValue> itemValues = fileInfoFormat.createRecord(setLastUpdateTime(fileInfo));
+        Map<String, AttributeValue> itemValues = fileInfoFormat.createRecord(setLastUpdateTime(fileInfo, updateTime));
         try {
             String tableName = tableName(fileInfo);
             PutItemRequest putItemRequest = new PutItemRequest()
@@ -136,8 +140,9 @@ class DynamoDBFileInfoStore implements FileInfoStore {
 
     @Override
     public void addFiles(List<FileInfo> fileInfos) throws StateStoreException {
+        long updateTime = clock.millis();
         for (FileInfo fileInfo : fileInfos) {
-            addFile(fileInfo);
+            addFile(fileInfo, updateTime);
         }
     }
 
@@ -146,8 +151,9 @@ class DynamoDBFileInfoStore implements FileInfoStore {
             List<FileInfo> filesToBeMarkedReadyForGC,
             FileInfo newActiveFile) throws StateStoreException {
         // Delete record for file for current status
+        long updateTime = clock.millis();
         List<TransactWriteItem> writes = new ArrayList<>();
-        setLastUpdateTimes(filesToBeMarkedReadyForGC).forEach(fileInfo -> {
+        setLastUpdateTimes(filesToBeMarkedReadyForGC, updateTime).forEach(fileInfo -> {
             Delete delete = new Delete()
                     .withTableName(activeTableName)
                     .withKey(fileInfoFormat.createKey(fileInfo))
@@ -162,7 +168,7 @@ class DynamoDBFileInfoStore implements FileInfoStore {
         // Add record for file for new status
         Put put = new Put()
                 .withTableName(activeTableName)
-                .withItem(fileInfoFormat.createRecordWithStatus(setLastUpdateTime(newActiveFile), ACTIVE));
+                .withItem(fileInfoFormat.createRecordWithStatus(setLastUpdateTime(newActiveFile, updateTime), ACTIVE));
         writes.add(new TransactWriteItem().withPut(put));
         TransactWriteItemsRequest transactWriteItemsRequest = new TransactWriteItemsRequest()
                 .withTransactItems(writes)
@@ -184,8 +190,9 @@ class DynamoDBFileInfoStore implements FileInfoStore {
     public void atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(
             List<FileInfo> filesToBeMarkedReadyForGC, FileInfo leftFileInfo, FileInfo rightFileInfo) throws StateStoreException {
         // Delete record for file for current status
+        long updateTime = clock.millis();
         List<TransactWriteItem> writes = new ArrayList<>();
-        setLastUpdateTimes(filesToBeMarkedReadyForGC).forEach(fileInfo -> {
+        setLastUpdateTimes(filesToBeMarkedReadyForGC, updateTime).forEach(fileInfo -> {
             Delete delete = new Delete()
                     .withTableName(activeTableName)
                     .withKey(fileInfoFormat.createKey(fileInfo))
@@ -200,11 +207,11 @@ class DynamoDBFileInfoStore implements FileInfoStore {
         // Add record for file for new status
         Put put = new Put()
                 .withTableName(activeTableName)
-                .withItem(fileInfoFormat.createRecordWithStatus(setLastUpdateTime(leftFileInfo), ACTIVE));
+                .withItem(fileInfoFormat.createRecordWithStatus(setLastUpdateTime(leftFileInfo, updateTime), ACTIVE));
         writes.add(new TransactWriteItem().withPut(put));
         Put put2 = new Put()
                 .withTableName(activeTableName)
-                .withItem(fileInfoFormat.createRecordWithStatus(setLastUpdateTime(rightFileInfo), ACTIVE));
+                .withItem(fileInfoFormat.createRecordWithStatus(setLastUpdateTime(rightFileInfo, updateTime), ACTIVE));
         writes.add(new TransactWriteItem().withPut(put2));
         TransactWriteItemsRequest transactWriteItemsRequest = new TransactWriteItemsRequest()
                 .withTransactItems(writes)
@@ -232,7 +239,8 @@ class DynamoDBFileInfoStore implements FileInfoStore {
         List<TransactWriteItem> writes = new ArrayList<>();
         // TODO This should only be done for active files
         // Create Puts for each of the files, conditional on the compactionJob field being not present
-        setLastUpdateTimes(files).forEach(fileInfo -> {
+        long updateTime = clock.millis();
+        setLastUpdateTimes(files, updateTime).forEach(fileInfo -> {
             Put put = new Put()
                     .withTableName(activeTableName)
                     .withItem(fileInfoFormat.createRecordWithJobId(fileInfo, jobId))
@@ -437,12 +445,12 @@ class DynamoDBFileInfoStore implements FileInfoStore {
         clock = Clock.fixed(now, ZoneId.of("UTC"));
     }
 
-    private FileInfo setLastUpdateTime(FileInfo fileInfo) {
-        return fileInfo.toBuilder().lastStateStoreUpdateTime(clock.millis()).build();
+    private FileInfo setLastUpdateTime(FileInfo fileInfo, long updateTime) {
+        return fileInfo.toBuilder().lastStateStoreUpdateTime(updateTime).build();
     }
 
-    private Stream<FileInfo> setLastUpdateTimes(List<FileInfo> fileInfos) {
-        return fileInfos.stream().map(this::setLastUpdateTime);
+    private Stream<FileInfo> setLastUpdateTimes(List<FileInfo> fileInfos, long updateTime) {
+        return fileInfos.stream().map(fileInfo -> setLastUpdateTime(fileInfo, updateTime));
     }
 
     static final class Builder {

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
@@ -185,7 +185,7 @@ class DynamoDBFileInfoStore implements FileInfoStore {
             List<FileInfo> filesToBeMarkedReadyForGC, FileInfo leftFileInfo, FileInfo rightFileInfo) throws StateStoreException {
         // Delete record for file for current status
         List<TransactWriteItem> writes = new ArrayList<>();
-        for (FileInfo fileInfo : filesToBeMarkedReadyForGC) {
+        setLastUpdateTimes(filesToBeMarkedReadyForGC).forEach(fileInfo -> {
             Delete delete = new Delete()
                     .withTableName(activeTableName)
                     .withKey(fileInfoFormat.createKey(fileInfo))
@@ -196,7 +196,7 @@ class DynamoDBFileInfoStore implements FileInfoStore {
                     .withTableName(readyForGCTableName)
                     .withItem(fileInfoFormat.createRecordWithStatus(fileInfo, READY_FOR_GARBAGE_COLLECTION));
             writes.add(new TransactWriteItem().withPut(put));
-        }
+        });
         // Add record for file for new status
         Put put = new Put()
                 .withTableName(activeTableName)

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileInfoStore.java
@@ -23,7 +23,6 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sleeper.core.key.KeySerDe;
 import sleeper.core.record.Record;
 import sleeper.core.schema.Field;
 import sleeper.core.schema.Schema;
@@ -64,7 +63,6 @@ class S3FileInfoStore implements FileInfoStore {
 
     private final List<PrimitiveType> rowKeyTypes;
     private final int garbageCollectorDelayBeforeDeletionInMinutes;
-    private final KeySerDe keySerDe;
     private final String stateStorePath;
     private final Configuration conf;
     private final S3RevisionUtils s3RevisionUtils;
@@ -74,7 +72,6 @@ class S3FileInfoStore implements FileInfoStore {
         this.stateStorePath = Objects.requireNonNull(builder.stateStorePath, "stateStorePath must not be null");
         this.rowKeyTypes = builder.rowKeyTypes;
         this.garbageCollectorDelayBeforeDeletionInMinutes = builder.garbageCollectorDelayBeforeDeletionInMinutes;
-        this.keySerDe = new KeySerDe(rowKeyTypes);
         this.conf = Objects.requireNonNull(builder.conf, "hadoopConfiguration must not be null");
         this.s3RevisionUtils = Objects.requireNonNull(builder.s3RevisionUtils, "s3RevisionUtils must not be null");
     }
@@ -472,7 +469,7 @@ class S3FileInfoStore implements FileInfoStore {
         return record;
     }
 
-    private FileInfo getFileInfoFromRecord(Record record) throws IOException {
+    private FileInfo getFileInfoFromRecord(Record record) {
         String jobId = (String) record.get("jobId");
         return FileInfo.builder()
                 .filename((String) record.get("fileName"))

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreIT.java
@@ -138,8 +138,8 @@ public class DynamoDBStateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         dynamoDBStateStore.addFile(fileInfo);
@@ -164,8 +164,8 @@ public class DynamoDBStateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         dynamoDBStateStore.addFile(fileInfo);
@@ -190,8 +190,8 @@ public class DynamoDBStateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         dynamoDBStateStore.addFile(fileInfo);
@@ -216,8 +216,8 @@ public class DynamoDBStateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         dynamoDBStateStore.addFile(fileInfo);
@@ -237,6 +237,7 @@ public class DynamoDBStateStoreIT {
         // Given
         Schema schema = schemaWithSingleRowKeyType(new LongType());
         StateStore dynamoDBStateStore = getStateStore(schema);
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
         Set<FileInfo> expected = new HashSet<>();
         for (int i = 0; i < 10000; i++) { // 10,000 figure chosen to ensure results returned from Dynamo are paged
             FileInfo fileInfo = FileInfo.builder()
@@ -266,7 +267,6 @@ public class DynamoDBStateStoreIT {
                 .rowKeyTypes(new LongType())
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .build();
 
         // When / Then
@@ -283,7 +283,6 @@ public class DynamoDBStateStoreIT {
                 .rowKeyTypes(new LongType())
                 .filename("abc")
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .build();
 
         // When / Then
@@ -300,7 +299,6 @@ public class DynamoDBStateStoreIT {
                 .rowKeyTypes(new LongType())
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
-                .lastStateStoreUpdateTime(1_000_000L)
                 .build();
 
         // When / Then
@@ -328,6 +326,7 @@ public class DynamoDBStateStoreIT {
                 .numberOfRecords(100L)
                 .lastStateStoreUpdateTime(file1Time)
                 .build();
+        stateStore.fixTime(file1Time);
         stateStore.addFile(fileInfo1);
         //  - An active file which should not be garbage collected
         FileInfo fileInfo2 = FileInfo.builder()
@@ -338,6 +337,7 @@ public class DynamoDBStateStoreIT {
                 .numberOfRecords(100L)
                 .lastStateStoreUpdateTime(file2Time)
                 .build();
+        stateStore.fixTime(file2Time);
         stateStore.addFile(fileInfo2);
         //  - A file which is ready for garbage collection but which should not be garbage collected now as it has only
         //      just been marked as ready for GC
@@ -349,6 +349,7 @@ public class DynamoDBStateStoreIT {
                 .numberOfRecords(100L)
                 .lastStateStoreUpdateTime(file3Time)
                 .build();
+        stateStore.fixTime(file3Time);
         stateStore.addFile(fileInfo3);
 
         // When / Then 1
@@ -364,7 +365,7 @@ public class DynamoDBStateStoreIT {
     public void shouldReturnOnlyActiveFilesWithNoJobId() throws StateStoreException {
         // Given
         Schema schema = schemaWithKeyAndValueWithTypes(new LongType(), new StringType());
-        StateStore dynamoDBStateStore = getStateStore(schema);
+        DynamoDBStateStore dynamoDBStateStore = getStateStore(schema);
         FileInfo fileInfo1 = FileInfo.builder()
                 .rowKeyTypes(new LongType())
                 .filename("file1")
@@ -372,6 +373,7 @@ public class DynamoDBStateStoreIT {
                 .partitionId("1")
                 .lastStateStoreUpdateTime(1_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
         dynamoDBStateStore.addFile(fileInfo1);
         FileInfo fileInfo2 = FileInfo.builder()
                 .rowKeyTypes(new LongType())
@@ -380,6 +382,7 @@ public class DynamoDBStateStoreIT {
                 .partitionId("2")
                 .lastStateStoreUpdateTime(2_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(2_000_000L));
         dynamoDBStateStore.addFile(fileInfo2);
         FileInfo fileInfo3 = FileInfo.builder()
                 .rowKeyTypes(new LongType())
@@ -389,6 +392,7 @@ public class DynamoDBStateStoreIT {
                 .jobId("job1")
                 .lastStateStoreUpdateTime(3_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(3_000_000L));
         dynamoDBStateStore.addFile(fileInfo3);
 
         // When
@@ -412,6 +416,7 @@ public class DynamoDBStateStoreIT {
                     .partitionId("" + i)
                     .lastStateStoreUpdateTime((long) i * 1_000)
                     .build();
+            dynamoDBStateStore.fixTime(Instant.ofEpochMilli((long) i * 1_000));
             dynamoDBStateStore.addFile(fileInfo);
             expected.add(fileInfo);
         }
@@ -435,6 +440,7 @@ public class DynamoDBStateStoreIT {
                 .partitionId("4")
                 .lastStateStoreUpdateTime(1_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
         dynamoDBStateStore.addFile(fileInfo1);
         FileInfo fileInfo2 = FileInfo.builder()
                 .rowKeyTypes(new LongType())
@@ -443,6 +449,7 @@ public class DynamoDBStateStoreIT {
                 .partitionId("5")
                 .lastStateStoreUpdateTime(2_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(2_000_000L));
         dynamoDBStateStore.addFile(fileInfo2);
 
         // When
@@ -465,7 +472,6 @@ public class DynamoDBStateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("7")
-                    .lastStateStoreUpdateTime(i * 1_000_000L)
                     .build();
             filesToMoveToReadyForGC.add(fileInfo);
             dynamoDBStateStore.addFile(fileInfo);
@@ -475,14 +481,15 @@ public class DynamoDBStateStoreIT {
                 .filename("file-new")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("7")
-                .lastStateStoreUpdateTime(10_000_000L)
                 .build();
 
         // When
         dynamoDBStateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFile(filesToMoveToReadyForGC, newFileInfo);
 
         // Then
-        assertThat(dynamoDBStateStore.getActiveFiles()).containsExactly(newFileInfo);
+        assertThat(dynamoDBStateStore.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(newFileInfo);
         assertThat(dynamoDBStateStore.getReadyForGCFiles()).toIterable().hasSize(4);
     }
 
@@ -501,6 +508,7 @@ public class DynamoDBStateStoreIT {
                     .lastStateStoreUpdateTime(i * 1_000_000L)
                     .build();
             filesToMoveToReadyForGC.add(fileInfo);
+            dynamoDBStateStore.fixTime(Instant.ofEpochMilli(i * 1_000_000L));
             dynamoDBStateStore.addFile(fileInfo);
         }
         FileInfo newLeftFileInfo = FileInfo.builder()
@@ -517,6 +525,7 @@ public class DynamoDBStateStoreIT {
                 .partitionId("7")
                 .lastStateStoreUpdateTime(10_000_000L)
                 .build();
+        dynamoDBStateStore.fixTime(Instant.ofEpochMilli(10_000_000L));
 
         // When
         dynamoDBStateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(filesToMoveToReadyForGC, newLeftFileInfo, newRightFileInfo);
@@ -572,7 +581,6 @@ public class DynamoDBStateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("8")
-                    .lastStateStoreUpdateTime(i * 1_000_000L)
                     .build();
             files.add(fileInfo);
             dynamoDBStateStore.addFile(fileInfo);
@@ -584,7 +592,7 @@ public class DynamoDBStateStoreIT {
 
         // Then
         assertThat(dynamoDBStateStore.getActiveFiles())
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("jobId")
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("jobId", "lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrderElementsOf(files)
                 .extracting(FileInfo::getJobId).containsOnly(jobId);
         assertThat(dynamoDBStateStore.getReadyForGCFiles()).isExhausted();
@@ -606,6 +614,7 @@ public class DynamoDBStateStoreIT {
                     .lastStateStoreUpdateTime(i * 1_000_000L)
                     .build();
             files.add(fileInfo);
+            dynamoDBStateStore.fixTime(Instant.ofEpochMilli(i * 1_000_000L));
             dynamoDBStateStore.addFile(fileInfo);
         }
         String jobId = UUID.randomUUID().toString();
@@ -631,6 +640,7 @@ public class DynamoDBStateStoreIT {
                     .numberOfRecords(1000L)
                     .lastStateStoreUpdateTime(i * 1_000_000L)
                     .build();
+            dynamoDBStateStore.fixTime(Instant.ofEpochMilli(i * 1_000_000L));
             files.add(fileInfo);
         }
         String jobId = UUID.randomUUID().toString();
@@ -1029,7 +1039,6 @@ public class DynamoDBStateStoreIT {
         StateStore stateStore = getStateStore(schema, treeBefore.getAllPartitions());
         stateStore.addFile(FileInfoFactory.builder()
                 .schema(schema).partitionTree(treeBefore)
-                .lastStateStoreUpdate(Instant.now())
                 .build().leafFile(100L, 1L, 100L));
 
         // When / Then

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
@@ -92,8 +92,12 @@ public class DynamoDBStateStoreMultipleTablesIT {
         stateStore2.addFile(file2);
 
         // Then
-        assertThat(stateStore1.getActiveFiles()).containsExactly(file1);
-        assertThat(stateStore2.getActiveFiles()).containsExactly(file2);
+        assertThat(stateStore1.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file1);
+        assertThat(stateStore2.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file2);
     }
 
     @Test
@@ -128,7 +132,9 @@ public class DynamoDBStateStoreMultipleTablesIT {
 
         // Then
         assertThat(stateStore1.getActiveFiles()).isEmpty();
-        assertThat(stateStore2.getActiveFiles()).containsExactly(file2);
+        assertThat(stateStore2.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file2);
     }
 
     @Test
@@ -152,7 +158,9 @@ public class DynamoDBStateStoreMultipleTablesIT {
         assertThat(stateStore1.getAllPartitions()).isEmpty();
         assertThat(stateStore2.getAllPartitions()).containsExactly(tree2.getRootPartition());
         assertThat(stateStore1.getActiveFiles()).isEmpty();
-        assertThat(stateStore2.getActiveFiles()).containsExactly(file2);
+        assertThat(stateStore2.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file2);
     }
 
     private FileInfoFactory fileInfoFactory(PartitionTree tree) {

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreIT.java
@@ -867,7 +867,6 @@ public class S3StateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("" + (i % 5))
-                    .lastStateStoreUpdateTime(1_000_000L)
                     .numberOfRecords((long) i)
                     .build();
             files.add(fileInfo);

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreIT.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static sleeper.configuration.properties.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.configuration.properties.instance.CommonProperty.FILE_SYSTEM;
 import static sleeper.configuration.properties.instance.CommonProperty.MAXIMUM_CONNECTIONS_TO_S3;
@@ -157,9 +158,9 @@ public class S3StateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
+        stateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         stateStore.addFile(fileInfo);
@@ -184,9 +185,9 @@ public class S3StateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
+        stateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         stateStore.addFile(fileInfo);
@@ -211,9 +212,9 @@ public class S3StateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
+        stateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         stateStore.addFile(fileInfo);
@@ -238,9 +239,9 @@ public class S3StateStoreIT {
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
+        stateStore.fixTime(Instant.ofEpochMilli(1_000_000L));
 
         // When
         stateStore.addFile(fileInfo);
@@ -267,7 +268,6 @@ public class S3StateStoreIT {
                     .filename("file-" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("" + i)
-                    .lastStateStoreUpdateTime(1_000_000L)
                     .numberOfRecords(1L)
                     .build();
             expected.add(fileInfo);
@@ -278,7 +278,11 @@ public class S3StateStoreIT {
         List<FileInfo> fileInfos = stateStore.getActiveFiles();
 
         // Then
-        assertThat(fileInfos).hasSize(10000).containsExactlyInAnyOrderElementsOf(expected);
+        assertThat(fileInfos).hasSize(10000)
+                .extracting(FileInfo::getFilename, FileInfo::getPartitionId)
+                .containsExactlyInAnyOrderElementsOf(expected.stream()
+                        .map(fileInfo -> tuple(fileInfo.getFilename(), fileInfo.getPartitionId()))
+                        .collect(Collectors.toList()));
     }
 
     @Test
@@ -290,7 +294,6 @@ public class S3StateStoreIT {
                 .rowKeyTypes(new LongType())
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
 
@@ -308,7 +311,6 @@ public class S3StateStoreIT {
                 .rowKeyTypes(new LongType())
                 .filename("abc")
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
 
@@ -326,7 +328,6 @@ public class S3StateStoreIT {
                 .rowKeyTypes(new LongType())
                 .filename("abc")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
 
@@ -348,7 +349,6 @@ public class S3StateStoreIT {
                     .filename("file-" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("root")
-                    .lastStateStoreUpdateTime(1_000_000L)
                     .numberOfRecords(1L)
                     .build();
             files.add(fileInfo);
@@ -370,6 +370,7 @@ public class S3StateStoreIT {
         // Then
         assertThat(stateStore.getActiveFiles())
                 .hasSize(20)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrderElementsOf(files);
         executorService.shutdown();
     }
@@ -392,8 +393,8 @@ public class S3StateStoreIT {
                 .fileStatus(FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION)
                 .partitionId(partition.getId())
                 .numberOfRecords(100L)
-                .lastStateStoreUpdateTime(file1Time)
                 .build();
+        stateStore.fixTime(file1Time);
         stateStore.addFile(fileInfo1);
         //  - An active file which should not be garbage collected
         FileInfo fileInfo2 = FileInfo.builder()
@@ -402,8 +403,8 @@ public class S3StateStoreIT {
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId(partition.getId())
                 .numberOfRecords(100L)
-                .lastStateStoreUpdateTime(file2Time)
                 .build();
+        stateStore.fixTime(file2Time);
         stateStore.addFile(fileInfo2);
         //  - A file which is ready for garbage collection but which should not be garbage collected now as it has only
         //      just been marked as ready for GC
@@ -413,8 +414,8 @@ public class S3StateStoreIT {
                 .fileStatus(FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION)
                 .partitionId(partition.getId())
                 .numberOfRecords(100L)
-                .lastStateStoreUpdateTime(file3Time)
                 .build();
+        stateStore.fixTime(file3Time);
         stateStore.addFile(fileInfo3);
 
         // When 1
@@ -422,14 +423,18 @@ public class S3StateStoreIT {
         Iterator<FileInfo> readyForGCFilesIterator = stateStore.getReadyForGCFiles();
 
         // Then 1
-        assertThat(readyForGCFilesIterator).toIterable().containsExactly(fileInfo1);
+        assertThat(readyForGCFilesIterator).toIterable()
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(fileInfo1);
 
         // When 2
         stateStore.fixTime(file3GCTime);
         readyForGCFilesIterator = stateStore.getReadyForGCFiles();
 
         // Then 2
-        assertThat(readyForGCFilesIterator).toIterable().containsExactlyInAnyOrder(fileInfo1, fileInfo3);
+        assertThat(readyForGCFilesIterator).toIterable()
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactlyInAnyOrder(fileInfo1, fileInfo3);
     }
 
     @Test
@@ -442,7 +447,6 @@ public class S3StateStoreIT {
                 .filename("file1")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("1")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
         stateStore.addFile(fileInfo1);
@@ -451,7 +455,6 @@ public class S3StateStoreIT {
                 .filename("file2")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("2")
-                .lastStateStoreUpdateTime(2_000_000L)
                 .numberOfRecords(2L)
                 .build();
         stateStore.addFile(fileInfo2);
@@ -461,7 +464,6 @@ public class S3StateStoreIT {
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("3")
                 .jobId("job1")
-                .lastStateStoreUpdateTime(3_000_000L)
                 .numberOfRecords(3L)
                 .build();
         stateStore.addFile(fileInfo3);
@@ -470,7 +472,9 @@ public class S3StateStoreIT {
         List<FileInfo> fileInfos = stateStore.getActiveFilesWithNoJobId();
 
         // Then
-        assertThat(fileInfos).containsExactly(fileInfo1, fileInfo2);
+        assertThat(fileInfos)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(fileInfo1, fileInfo2);
     }
 
     @Test
@@ -483,7 +487,6 @@ public class S3StateStoreIT {
                 .filename("file1")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("4")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
         FileInfo fileInfo2 = FileInfo.builder()
@@ -491,7 +494,6 @@ public class S3StateStoreIT {
                 .filename("file2")
                 .fileStatus(FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION)
                 .partitionId("5")
-                .lastStateStoreUpdateTime(2_000_000L)
                 .numberOfRecords(2L)
                 .build();
         stateStore.addFiles(Arrays.asList(fileInfo1, fileInfo2));
@@ -500,7 +502,9 @@ public class S3StateStoreIT {
         stateStore.deleteReadyForGCFile(fileInfo2);
 
         // Then
-        assertThat(stateStore.getActiveFiles()).containsExactly(fileInfo1);
+        assertThat(stateStore.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(fileInfo1);
         assertThat(stateStore.getReadyForGCFiles()).isExhausted();
     }
 
@@ -514,7 +518,6 @@ public class S3StateStoreIT {
                 .filename("file1")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("4")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
         FileInfo fileInfo2 = FileInfo.builder()
@@ -522,7 +525,6 @@ public class S3StateStoreIT {
                 .filename("file2")
                 .fileStatus(FileInfo.FileStatus.READY_FOR_GARBAGE_COLLECTION)
                 .partitionId("5")
-                .lastStateStoreUpdateTime(2_000_000L)
                 .numberOfRecords(2L)
                 .build();
         stateStore.addFiles(Arrays.asList(fileInfo1, fileInfo2));
@@ -544,7 +546,6 @@ public class S3StateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("7")
-                    .lastStateStoreUpdateTime(i * 1_000_000L)
                     .numberOfRecords(1L)
                     .build();
             filesToMoveToReadyForGC.add(fileInfo);
@@ -555,7 +556,6 @@ public class S3StateStoreIT {
                 .filename("file-new")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("7")
-                .lastStateStoreUpdateTime(10_000_000L)
                 .numberOfRecords(4L)
                 .build();
 
@@ -563,7 +563,9 @@ public class S3StateStoreIT {
         stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFile(filesToMoveToReadyForGC, newFileInfo);
 
         // Then
-        assertThat(stateStore.getActiveFiles()).containsExactly(newFileInfo);
+        assertThat(stateStore.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(newFileInfo);
         assertThat(stateStore.getReadyForGCFiles()).toIterable().hasSize(4);
     }
 
@@ -579,7 +581,6 @@ public class S3StateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("7")
-                    .lastStateStoreUpdateTime(i * 1_000_000L)
                     .numberOfRecords((long) i)
                     .build();
             filesToMoveToReadyForGC.add(fileInfo);
@@ -590,7 +591,6 @@ public class S3StateStoreIT {
                 .filename("file-left-new")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("7")
-                .lastStateStoreUpdateTime(10_000_000L)
                 .numberOfRecords(5L)
                 .build();
         FileInfo newRightFileInfo = FileInfo.builder()
@@ -598,7 +598,6 @@ public class S3StateStoreIT {
                 .filename("file-right-new")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("7")
-                .lastStateStoreUpdateTime(10_000_000L)
                 .numberOfRecords(5L)
                 .build();
 
@@ -606,7 +605,9 @@ public class S3StateStoreIT {
         stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(filesToMoveToReadyForGC, newLeftFileInfo, newRightFileInfo);
 
         // Then
-        assertThat(stateStore.getActiveFiles()).containsExactlyInAnyOrder(newLeftFileInfo, newRightFileInfo);
+        assertThat(stateStore.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactlyInAnyOrder(newLeftFileInfo, newRightFileInfo);
         assertThat(stateStore.getReadyForGCFiles()).toIterable().hasSize(4);
     }
 
@@ -622,7 +623,6 @@ public class S3StateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("7")
-                    .lastStateStoreUpdateTime(1_000_000L)
                     .numberOfRecords(1L)
                     .build();
             filesToMoveToReadyForGC.add(fileInfo);
@@ -638,7 +638,6 @@ public class S3StateStoreIT {
                 .filename("file-new")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("7")
-                .lastStateStoreUpdateTime(1_000_000L)
                 .numberOfRecords(1L)
                 .build();
 
@@ -660,7 +659,6 @@ public class S3StateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("7")
-                    .lastStateStoreUpdateTime(i * 1_000_000L)
                     .numberOfRecords((long) i)
                     .build();
             filesToMoveToReadyForGC.add(fileInfo);
@@ -671,7 +669,6 @@ public class S3StateStoreIT {
                 .filename("file-left-new")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("7")
-                .lastStateStoreUpdateTime(10_000_000L)
                 .numberOfRecords(5L)
                 .build();
         FileInfo newRightFileInfo = FileInfo.builder()
@@ -679,7 +676,6 @@ public class S3StateStoreIT {
                 .filename("file-right-new")
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .partitionId("7")
-                .lastStateStoreUpdateTime(10_000_000L)
                 .numberOfRecords(5L)
                 .build();
         //  - One of the files is not active
@@ -707,7 +703,6 @@ public class S3StateStoreIT {
                     .filename("file" + i)
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("8")
-                    .lastStateStoreUpdateTime(i * 1_000_000L)
                     .numberOfRecords(1L)
                     .build();
             files.add(fileInfo);
@@ -720,7 +715,7 @@ public class S3StateStoreIT {
 
         // Then
         assertThat(stateStore.getActiveFiles()).hasSize(4)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("jobId")
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("jobId", "lastStateStoreUpdateTime")
                 .containsExactlyInAnyOrderElementsOf(files)
                 .extracting(FileInfo::getJobId).containsOnly(jobId);
         assertThat(stateStore.getReadyForGCFiles()).isExhausted();
@@ -739,7 +734,6 @@ public class S3StateStoreIT {
                     .fileStatus(FileInfo.FileStatus.ACTIVE)
                     .partitionId("9")
                     .jobId("compactionJob")
-                    .lastStateStoreUpdateTime(i * 1_000_000L)
                     .numberOfRecords(1L)
                     .build();
             files.add(fileInfo);
@@ -1216,24 +1210,5 @@ public class S3StateStoreIT {
         // Then
         assertThat(stateStore.getAllPartitions())
                 .containsExactlyInAnyOrderElementsOf(treeAfter.getAllPartitions());
-    }
-
-    @Test
-    void shouldStoreFileWhenMinAndMaxKeyAreNotSet() throws Exception {
-        // Given
-        Schema schema = schemaWithKey("key", new LongType());
-        StateStore stateStore = getStateStore(schema);
-        FileInfoFactory factory = FileInfoFactory.builder()
-                .schema(schema).partitions(stateStore.getAllPartitions())
-                .lastStateStoreUpdate(Instant.now())
-                .build();
-        FileInfo fileInfo = factory.leafFile(100L, null, null);
-
-        // When
-        stateStore.addFile(fileInfo);
-
-        // Then
-        assertThat(stateStore.getActiveFiles())
-                .containsExactly(fileInfo);
     }
 }

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
@@ -108,8 +108,12 @@ public class S3StateStoreMultipleTablesIT {
         stateStore2.addFile(file2);
 
         // Then
-        assertThat(stateStore1.getActiveFiles()).containsExactly(file1);
-        assertThat(stateStore2.getActiveFiles()).containsExactly(file2);
+        assertThat(stateStore1.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file1);
+        assertThat(stateStore2.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file2);
     }
 
     @Test
@@ -144,7 +148,9 @@ public class S3StateStoreMultipleTablesIT {
 
         // Then
         assertThat(stateStore1.getActiveFiles()).isEmpty();
-        assertThat(stateStore2.getActiveFiles()).containsExactly(file2);
+        assertThat(stateStore2.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file2);
     }
 
     @Test
@@ -168,7 +174,9 @@ public class S3StateStoreMultipleTablesIT {
         assertThat(stateStore1.getAllPartitions()).isEmpty();
         assertThat(stateStore2.getAllPartitions()).containsExactly(tree2.getRootPartition());
         assertThat(stateStore1.getActiveFiles()).isEmpty();
-        assertThat(stateStore2.getActiveFiles()).containsExactly(file2);
+        assertThat(stateStore2.getActiveFiles())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                .containsExactly(file2);
     }
 
     private FileInfoFactory fileInfoFactory(PartitionTree tree) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1381

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated existing tests
    - Ran system tests in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.