### PR TITLE
Issue 1465 - Use table ID in ingest status store

### DIFF
--- a/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
+++ b/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
@@ -15,6 +15,7 @@
  */
 package sleeper.bulkimport.job;
 
+import sleeper.core.table.TableIdentity;
 import sleeper.ingest.job.IngestJob;
 
 import java.util.HashMap;
@@ -152,6 +153,11 @@ public class BulkImportJob {
         public Builder tableId(String tableId) {
             this.tableId = tableId;
             return this;
+        }
+
+        public Builder tableId(TableIdentity tableId) {
+            return tableName(tableId.getTableName())
+                    .tableId(tableId.getTableUniqueId());
         }
 
         public Builder files(List<String> files) {

--- a/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
+++ b/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
@@ -15,15 +15,12 @@
  */
 package sleeper.bulkimport.job;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
 import sleeper.ingest.job.IngestJob;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * POJO containing information needed to run a bulk import job.
@@ -31,21 +28,23 @@ import java.util.Map;
 public class BulkImportJob {
     private final String id;
     private final String tableName;
+    private final String tableId;
     private final List<String> files;
     private final String className;
     private final Map<String, String> platformSpec;
     private final Map<String, String> sparkConf;
 
     private BulkImportJob(Builder builder) {
-        this.id = builder.id;
-        this.tableName = builder.tableName;
-        this.files = builder.files;
-        this.className = builder.className;
-        this.platformSpec = builder.platformSpec;
-        this.sparkConf = builder.sparkConf;
+        id = builder.id;
+        tableName = builder.tableName;
+        tableId = builder.tableId;
+        files = builder.files;
+        className = builder.className;
+        platformSpec = builder.platformSpec;
+        sparkConf = builder.sparkConf;
     }
 
-    public static BulkImportJob.Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 
@@ -55,6 +54,10 @@ public class BulkImportJob {
 
     public String getTableName() {
         return tableName;
+    }
+
+    public String getTableId() {
+        return tableId;
     }
 
     public List<String> getFiles() {
@@ -78,68 +81,92 @@ public class BulkImportJob {
     }
 
     public BulkImportJob applyIngestJobChanges(IngestJob job) {
-        return toBuilder().id(job.getId()).files(job.getFiles()).tableName(job.getTableName()).build();
+        return toBuilder()
+                .id(job.getId())
+                .tableName(job.getTableName())
+                .tableId(job.getTableId())
+                .files(job.getFiles())
+                .build();
     }
 
     public Builder toBuilder() {
-        return builder().id(id).files(files).tableName(tableName)
+        return builder().id(id).files(files).tableName(tableName).tableId(tableId)
                 .className(className).platformSpec(platformSpec).sparkConf(sparkConf);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object object) {
+        if (this == object) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (object == null || getClass() != object.getClass()) {
             return false;
         }
-
-        BulkImportJob that = (BulkImportJob) o;
-
-        return new EqualsBuilder()
-                .append(files, that.files)
-                .append(id, that.id)
-                .append(tableName, that.tableName)
-                .append(className, that.className)
-                .append(sparkConf, that.sparkConf)
-                .append(platformSpec, that.platformSpec)
-                .isEquals();
+        BulkImportJob that = (BulkImportJob) object;
+        return Objects.equals(id, that.id) && Objects.equals(tableName, that.tableName)
+                && Objects.equals(tableId, that.tableId) && Objects.equals(files, that.files)
+                && Objects.equals(className, that.className) && Objects.equals(platformSpec, that.platformSpec)
+                && Objects.equals(sparkConf, that.sparkConf);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37)
-                .append(files)
-                .append(id)
-                .append(tableName)
-                .append(className)
-                .append(sparkConf)
-                .append(platformSpec)
-                .toHashCode();
+        return Objects.hash(id, tableName, tableId, files, className, platformSpec, sparkConf);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .append("files", files)
-                .append("id", id)
-                .append("tableName", tableName)
-                .append("className", className)
-                .append("sparkConf", sparkConf)
-                .append("platformSpec", platformSpec)
-                .toString();
+        return "BulkImportJob{" +
+                "id='" + id + '\'' +
+                ", tableName='" + tableName + '\'' +
+                ", tableId='" + tableId + '\'' +
+                ", files=" + files +
+                ", className='" + className + '\'' +
+                ", platformSpec=" + platformSpec +
+                ", sparkConf=" + sparkConf +
+                '}';
     }
 
     public static final class Builder {
-        private Map<String, String> sparkConf;
-        private String className;
         private String id;
-        private List<String> files;
         private String tableName;
+        private String tableId;
+        private List<String> files;
+        private String className;
         private Map<String, String> platformSpec;
+        private Map<String, String> sparkConf;
 
         public Builder() {
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder tableId(String tableId) {
+            this.tableId = tableId;
+            return this;
+        }
+
+        public Builder files(List<String> files) {
+            this.files = files;
+            return this;
+        }
+
+        public Builder className(String className) {
+            this.className = className;
+            return this;
+        }
+
+        public Builder platformSpec(Map<String, String> platformSpec) {
+            this.platformSpec = platformSpec;
+            return this;
         }
 
         public Builder sparkConf(Map<String, String> sparkConf) {
@@ -153,31 +180,6 @@ public class BulkImportJob {
             }
             this.sparkConf.put(key, value);
 
-            return this;
-        }
-
-        public Builder tableName(String tableName) {
-            this.tableName = tableName;
-            return this;
-        }
-
-        public Builder className(String className) {
-            this.className = className;
-            return this;
-        }
-
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-
-        public Builder files(List<String> files) {
-            this.files = files;
-            return this;
-        }
-
-        public Builder platformSpec(Map<String, String> platformSpec) {
-            this.platformSpec = platformSpec;
             return this;
         }
 

--- a/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
+++ b/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
@@ -77,7 +77,7 @@ public class BulkImportJob {
     }
 
     public IngestJob toIngestJob() {
-        return IngestJob.builder().files(files).id(id).tableName(tableName).build();
+        return IngestJob.builder().files(files).id(id).tableName(tableName).tableId(tableId).build();
     }
 
     public BulkImportJob applyIngestJobChanges(IngestJob job) {

--- a/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
+++ b/java/bulk-import/bulk-import-common/src/main/java/sleeper/bulkimport/job/BulkImportJob.java
@@ -34,7 +34,7 @@ public class BulkImportJob {
     private final List<String> files;
     private final String className;
     private final Map<String, String> platformSpec;
-    private Map<String, String> sparkConf;
+    private final Map<String, String> sparkConf;
 
     private BulkImportJob(Builder builder) {
         this.id = builder.id;
@@ -73,17 +73,17 @@ public class BulkImportJob {
         return sparkConf;
     }
 
-    public void setSparkConf(Map<String, String> sparkConf) {
-        this.sparkConf = sparkConf;
-    }
-
     public IngestJob toIngestJob() {
         return IngestJob.builder().files(files).id(id).tableName(tableName).build();
     }
 
     public BulkImportJob applyIngestJobChanges(IngestJob job) {
-        return builder().id(job.getId()).files(job.getFiles()).tableName(job.getTableName())
-                .className(className).platformSpec(platformSpec).sparkConf(sparkConf).build();
+        return toBuilder().id(job.getId()).files(job.getFiles()).tableName(job.getTableName()).build();
+    }
+
+    public Builder toBuilder() {
+        return builder().id(id).files(files).tableName(tableName)
+                .className(className).platformSpec(platformSpec).sparkConf(sparkConf);
     }
 
     @Override

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
@@ -285,9 +285,9 @@ class BulkImportJobDriverIT {
         return createTable(instanceProperties, tableProperties, Collections.emptyList());
     }
 
-    private void runJob(BulkImportJobRunner runner, InstanceProperties properties, TableProperties tableProperties, BulkImportJob job) throws IOException {
+    private void runJob(BulkImportJobRunner runner, InstanceProperties properties, BulkImportJob job) throws IOException {
         String jobRunId = "test-run";
-        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), tableProperties.getId(), validationTime).jobRunId(jobRunId).build());
+        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), validationTime).jobRunId(jobRunId).build());
         BulkImportJobDriver driver = BulkImportJobDriver.from(runner, properties,
                 s3Client, dynamoDBClient, new Configuration(), statusStore,
                 List.of(startTime, endTime).iterator()::next);
@@ -312,7 +312,7 @@ class BulkImportJobDriverIT {
 
         // When
         BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
-        runJob(runner, instanceProperties, tableProperties, job);
+        runJob(runner, instanceProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();
@@ -359,7 +359,7 @@ class BulkImportJobDriverIT {
 
         // When
         BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
-        runJob(runner, instanceProperties, tableProperties, job);
+        runJob(runner, instanceProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();
@@ -406,7 +406,7 @@ class BulkImportJobDriverIT {
 
         // When
         BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
-        runJob(runner, instanceProperties, tableProperties, job);
+        runJob(runner, instanceProperties, job);
 
         // Then
         List<Record> leftPartition = records.stream()
@@ -446,7 +446,7 @@ class BulkImportJobDriverIT {
 
         // When
         BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
-        runJob(runner, instanceProperties, tableProperties, job);
+        runJob(runner, instanceProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();
@@ -518,7 +518,7 @@ class BulkImportJobDriverIT {
         // When
         BulkImportJob job = jobForTable(tableProperties).id("my-job")
                 .files(Lists.newArrayList(dataDir + "/import/")).build();
-        runJob(runner, instanceProperties, tableProperties, job);
+        runJob(runner, instanceProperties, job);
 
         // Then
         String expectedPartitionId = stateStore.getAllPartitions().get(0).getId();
@@ -552,7 +552,7 @@ class BulkImportJobDriverIT {
 
         // When
         BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
-        runJob(runner, instanceProperties, tableProperties, job);
+        runJob(runner, instanceProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
@@ -90,7 +90,6 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.CommonProperty.FILE_SYSTEM;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.STATESTORE_CLASSNAME;
-import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summary;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.finishedIngestJobWithValidation;
@@ -312,8 +311,7 @@ class BulkImportJobDriverIT {
         StateStore stateStore = createTable(instanceProperties, tableProperties);
 
         // When
-        BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
-                .tableName(tableProperties.get(TABLE_NAME)).build();
+        BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
         runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
@@ -360,8 +358,7 @@ class BulkImportJobDriverIT {
         StateStore stateStore = createTable(instanceProperties, tableProperties);
 
         // When
-        BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
-                .tableName(tableProperties.get(TABLE_NAME)).build();
+        BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
         runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
@@ -408,8 +405,7 @@ class BulkImportJobDriverIT {
         StateStore stateStore = createTable(instanceProperties, tableProperties, Collections.singletonList(50));
 
         // When
-        BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
-                .tableName(tableProperties.get(TABLE_NAME)).build();
+        BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
         runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
@@ -449,8 +445,7 @@ class BulkImportJobDriverIT {
         StateStore stateStore = createTable(instanceProperties, tableProperties, getSplitPointsForLotsOfRecords());
 
         // When
-        BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
-                .tableName(tableProperties.get(TABLE_NAME)).build();
+        BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
         runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
@@ -521,8 +516,8 @@ class BulkImportJobDriverIT {
         StateStore stateStore = createTable(instanceProperties, tableProperties);
 
         // When
-        BulkImportJob job = BulkImportJob.builder().id("my-job").files(Lists.newArrayList(dataDir + "/import/"))
-                .tableName(tableProperties.get(TABLE_NAME)).build();
+        BulkImportJob job = jobForTable(tableProperties).id("my-job")
+                .files(Lists.newArrayList(dataDir + "/import/")).build();
         runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
@@ -556,8 +551,7 @@ class BulkImportJobDriverIT {
         StateStore stateStore = createTable(instanceProperties, tableProperties);
 
         // When
-        BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
-                .tableName(tableProperties.get(TABLE_NAME)).build();
+        BulkImportJob job = jobForTable(tableProperties).id("my-job").files(inputFiles).build();
         runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
@@ -585,5 +579,10 @@ class BulkImportJobDriverIT {
         assertThat(statusStore.getAllJobs(tableProperties.getId())).containsExactly(
                 finishedIngestJobWithValidation(job.toIngestJob(), taskId, validationTime,
                         summary(startTime, endTime, records.size(), records.size())));
+    }
+
+    private BulkImportJob.Builder jobForTable(TableProperties tableProperties) {
+        return BulkImportJob.builder()
+                .tableId(tableProperties.getId());
     }
 }

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
@@ -338,7 +338,7 @@ class BulkImportJobDriverIT {
         sortRecords(expectedRecords);
         sortRecords(readRecords);
         assertThat(readRecords).isEqualTo(expectedRecords);
-        assertThat(statusStore.getAllJobs(tableProperties.get(TABLE_NAME))).containsExactly(
+        assertThat(statusStore.getAllJobs(tableProperties.getId())).containsExactly(
                 finishedIngestJobWithValidation(job.toIngestJob(), taskId, validationTime,
                         summary(startTime, endTime, records.size(), records.size())));
     }
@@ -386,7 +386,7 @@ class BulkImportJobDriverIT {
         sortRecords(expectedRecords);
         sortRecords(readRecords);
         assertThat(readRecords).isEqualTo(expectedRecords);
-        assertThat(statusStore.getAllJobs(tableProperties.get(TABLE_NAME))).containsExactly(
+        assertThat(statusStore.getAllJobs(tableProperties.getId())).containsExactly(
                 finishedIngestJobWithValidation(job.toIngestJob(), taskId, validationTime,
                         summary(startTime, endTime, records.size(), records.size())));
     }
@@ -427,7 +427,7 @@ class BulkImportJobDriverIT {
                 .containsExactlyInAnyOrder(
                         tuple(100L, leftPartition),
                         tuple(100L, rightPartition));
-        assertThat(statusStore.getAllJobs(tableProperties.get(TABLE_NAME))).containsExactly(
+        assertThat(statusStore.getAllJobs(tableProperties.getId())).containsExactly(
                 finishedIngestJobWithValidation(job.toIngestJob(), taskId, validationTime,
                         summary(startTime, endTime, records.size(), records.size())));
     }
@@ -497,7 +497,7 @@ class BulkImportJobDriverIT {
                     })
                     .forEach(read -> assertThat(read).isSortedAccordingTo(new RecordComparator(getSchema())));
         }
-        assertThat(statusStore.getAllJobs(tableProperties.get(TABLE_NAME))).containsExactly(
+        assertThat(statusStore.getAllJobs(tableProperties.getId())).containsExactly(
                 finishedIngestJobWithValidation(job.toIngestJob(), taskId, validationTime,
                         summary(startTime, endTime, records.size(), records.size())));
     }
@@ -532,7 +532,7 @@ class BulkImportJobDriverIT {
                 .extracting(FileInfo::getNumberOfRecords, FileInfo::getPartitionId,
                         file -> readRecords(file.getFilename(), schema))
                 .containsExactly(tuple(200L, expectedPartitionId, records));
-        assertThat(statusStore.getAllJobs(tableProperties.get(TABLE_NAME))).containsExactly(
+        assertThat(statusStore.getAllJobs(tableProperties.getId())).containsExactly(
                 finishedIngestJobWithValidation(job.toIngestJob(), taskId, validationTime,
                         summary(startTime, endTime, records.size(), records.size())));
     }
@@ -582,7 +582,7 @@ class BulkImportJobDriverIT {
         sortRecords(expectedRecords);
         sortRecords(readRecords);
         assertThat(readRecords).isEqualTo(expectedRecords);
-        assertThat(statusStore.getAllJobs(tableProperties.get(TABLE_NAME))).containsExactly(
+        assertThat(statusStore.getAllJobs(tableProperties.getId())).containsExactly(
                 finishedIngestJobWithValidation(job.toIngestJob(), taskId, validationTime,
                         summary(startTime, endTime, records.size(), records.size())));
     }

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
@@ -286,9 +286,9 @@ class BulkImportJobDriverIT {
         return createTable(instanceProperties, tableProperties, Collections.emptyList());
     }
 
-    private void runJob(BulkImportJobRunner runner, InstanceProperties properties, BulkImportJob job) throws IOException {
+    private void runJob(BulkImportJobRunner runner, InstanceProperties properties, TableProperties tableProperties, BulkImportJob job) throws IOException {
         String jobRunId = "test-run";
-        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), validationTime).jobRunId(jobRunId).build());
+        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), tableProperties.getId(), validationTime).jobRunId(jobRunId).build());
         BulkImportJobDriver driver = BulkImportJobDriver.from(runner, properties,
                 s3Client, dynamoDBClient, new Configuration(), statusStore,
                 List.of(startTime, endTime).iterator()::next);
@@ -314,7 +314,7 @@ class BulkImportJobDriverIT {
         // When
         BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
                 .tableName(tableProperties.get(TABLE_NAME)).build();
-        runJob(runner, instanceProperties, job);
+        runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();
@@ -362,7 +362,7 @@ class BulkImportJobDriverIT {
         // When
         BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
                 .tableName(tableProperties.get(TABLE_NAME)).build();
-        runJob(runner, instanceProperties, job);
+        runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();
@@ -410,7 +410,7 @@ class BulkImportJobDriverIT {
         // When
         BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
                 .tableName(tableProperties.get(TABLE_NAME)).build();
-        runJob(runner, instanceProperties, job);
+        runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
         List<Record> leftPartition = records.stream()
@@ -451,7 +451,7 @@ class BulkImportJobDriverIT {
         // When
         BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
                 .tableName(tableProperties.get(TABLE_NAME)).build();
-        runJob(runner, instanceProperties, job);
+        runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();
@@ -523,7 +523,7 @@ class BulkImportJobDriverIT {
         // When
         BulkImportJob job = BulkImportJob.builder().id("my-job").files(Lists.newArrayList(dataDir + "/import/"))
                 .tableName(tableProperties.get(TABLE_NAME)).build();
-        runJob(runner, instanceProperties, job);
+        runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
         String expectedPartitionId = stateStore.getAllPartitions().get(0).getId();
@@ -558,7 +558,7 @@ class BulkImportJobDriverIT {
         // When
         BulkImportJob job = BulkImportJob.builder().id("my-job").files(inputFiles)
                 .tableName(tableProperties.get(TABLE_NAME)).build();
-        runJob(runner, instanceProperties, job);
+        runJob(runner, instanceProperties, tableProperties, job);
 
         // Then
         List<FileInfo> activeFiles = stateStore.getActiveFiles();

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
@@ -177,7 +177,7 @@ class BulkImportJobDriverTest {
                         Instant startTime, Instant finishTime,
                         BulkImportJobDriver.SessionRunner sessionRunner,
                         StateStore stateStore) throws Exception {
-        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), tableProperties.getId(), validationTime).jobRunId(jobRunId).build());
+        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), validationTime).jobRunId(jobRunId).build());
         BulkImportJobDriver driver = new BulkImportJobDriver(sessionRunner,
                 new FixedTablePropertiesProvider(tableProperties),
                 new FixedStateStoreProvider(tableProperties, stateStore),

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
@@ -39,8 +39,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static sleeper.configuration.properties.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
+import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summary;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
@@ -111,17 +114,20 @@ class BulkImportJobDriverTest {
         StateStoreException jobFailure = new StateStoreException("Failed updating files");
         List<FileInfo> outputFiles = List.of(
                 defaultFileOnRootPartitionWithRecords("test-output.parquet", 100));
+        StateStore stateStore = mock(StateStore.class);
+        doThrow(jobFailure).when(stateStore).addFiles(outputFiles);
 
         // When
-        assertThatThrownBy(() -> runJobFailStateStoreUpdate(job, "test-run", "test-task",
-                validationTime, startTime, finishTime, outputFiles, jobFailure)
+        assertThatThrownBy(() -> runJob(job, "test-run", "test-task",
+                validationTime, startTime, finishTime, outputFiles, stateStore)
         ).isInstanceOf(RuntimeException.class).hasCauseReference(jobFailure);
 
         // Then
         assertThat(allJobsReported())
                 .containsExactly(finishedIngestJobWithValidation(job.toIngestJob(), "test-task",
                         validationTime, summary(startTime, finishTime, 0, 0)));
-        assertThat(stateStore.getActiveFiles()).isEmpty();
+        verify(stateStore).addFiles(outputFiles);
+        verifyNoMoreInteractions(stateStore);
     }
 
     @Test
@@ -134,30 +140,24 @@ class BulkImportJobDriverTest {
         RuntimeException jobFailure = new RuntimeException("Failed updating files");
         List<FileInfo> outputFiles = List.of(
                 defaultFileOnRootPartitionWithRecords("test-output.parquet", 100));
+        StateStore stateStore = mock(StateStore.class);
+        doThrow(jobFailure).when(stateStore).addFiles(outputFiles);
 
         // When
-        assertThatThrownBy(() -> runJobFailStateStoreUpdate(job, "test-run", "test-task",
-                validationTime, startTime, finishTime, outputFiles, jobFailure)
+        assertThatThrownBy(() -> runJob(job, "test-run", "test-task",
+                validationTime, startTime, finishTime, outputFiles, stateStore)
         ).isInstanceOf(RuntimeException.class).hasCauseReference(jobFailure);
 
         // Then
         assertThat(allJobsReported())
                 .containsExactly(finishedIngestJobWithValidation(job.toIngestJob(), "test-task",
                         validationTime, summary(startTime, finishTime, 0, 0)));
-        assertThat(stateStore.getActiveFiles()).isEmpty();
+        verify(stateStore).addFiles(outputFiles);
+        verifyNoMoreInteractions(stateStore);
     }
 
     private void runJob(BulkImportJob job, String jobRunId, String taskId, Instant validationTime,
                         Instant startTime, Instant finishTime, List<FileInfo> outputFiles) throws Exception {
-        runJob(job, jobRunId, taskId, validationTime, startTime, finishTime, outputFiles, stateStore);
-    }
-
-    private void runJobFailStateStoreUpdate(BulkImportJob job, String jobRunId, String taskId,
-                                            Instant validationTime, Instant startTime,
-                                            Instant finishTime, List<FileInfo> outputFiles,
-                                            Exception failure) throws Exception {
-        StateStore stateStore = mock(StateStore.class);
-        doThrow(failure).when(stateStore).addFiles(outputFiles);
         runJob(job, jobRunId, taskId, validationTime, startTime, finishTime, outputFiles, stateStore);
     }
 
@@ -191,6 +191,7 @@ class BulkImportJobDriverTest {
         return BulkImportJob.builder()
                 .id("test-job")
                 .tableName(tableProperties.get(TABLE_NAME))
+                .tableId(tableProperties.get(TABLE_ID))
                 .files(List.of("test.parquet")).build();
     }
 

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
@@ -43,8 +43,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static sleeper.configuration.properties.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
-import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
-import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summary;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 import static sleeper.core.statestore.FileInfoTestData.defaultFileOnRootPartitionWithRecords;
@@ -190,12 +188,11 @@ class BulkImportJobDriverTest {
     private BulkImportJob singleFileImportJob() {
         return BulkImportJob.builder()
                 .id("test-job")
-                .tableName(tableProperties.get(TABLE_NAME))
-                .tableId(tableProperties.get(TABLE_ID))
+                .tableId(tableProperties.getId())
                 .files(List.of("test.parquet")).build();
     }
 
     private List<IngestJobStatus> allJobsReported() {
-        return statusStore.getAllJobs(tableProperties.get(TABLE_NAME));
+        return statusStore.getAllJobs(tableProperties.getId());
     }
 }

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverTest.java
@@ -179,7 +179,7 @@ class BulkImportJobDriverTest {
                         Instant startTime, Instant finishTime,
                         BulkImportJobDriver.SessionRunner sessionRunner,
                         StateStore stateStore) throws Exception {
-        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), validationTime).jobRunId(jobRunId).build());
+        statusStore.jobValidated(ingestJobAccepted(job.toIngestJob(), tableProperties.getId(), validationTime).jobRunId(jobRunId).build());
         BulkImportJobDriver driver = new BulkImportJobDriver(sessionRunner,
                 new FixedTablePropertiesProvider(tableProperties),
                 new FixedStateStoreProvider(tableProperties, stateStore),

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/BulkImportStarterLambda.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/BulkImportStarterLambda.java
@@ -55,7 +55,6 @@ public class BulkImportStarterLambda implements RequestHandler<SQSEvent, Void> {
 
     private final PropertiesReloader propertiesReloader;
     private final BulkImportExecutor executor;
-    private final IngestJobStatusStore ingestJobStatusStore;
     private final IngestJobMessageHandler<BulkImportJob> ingestJobMessageHandler;
 
     public BulkImportStarterLambda() {
@@ -66,7 +65,7 @@ public class BulkImportStarterLambda implements RequestHandler<SQSEvent, Void> {
         PlatformExecutor platformExecutor = PlatformExecutor.fromEnvironment(
                 instanceProperties, tablePropertiesProvider);
         Configuration hadoopConfig = HadoopConfigurationProvider.getConfigurationForLambdas(instanceProperties);
-        ingestJobStatusStore = IngestJobStatusStoreFactory.getStatusStore(dynamo, instanceProperties);
+        IngestJobStatusStore ingestJobStatusStore = IngestJobStatusStoreFactory.getStatusStore(dynamo, instanceProperties);
         executor = new BulkImportExecutor(instanceProperties, tablePropertiesProvider,
                 new StateStoreProvider(dynamo, instanceProperties, hadoopConfig),
                 ingestJobStatusStore, s3, platformExecutor, Instant::now);
@@ -84,7 +83,6 @@ public class BulkImportStarterLambda implements RequestHandler<SQSEvent, Void> {
     public BulkImportStarterLambda(BulkImportExecutor executor, InstanceProperties properties, Configuration hadoopConfig,
                                    IngestJobStatusStore ingestJobStatusStore, Supplier<String> jobIdSupplier, Supplier<Instant> timeSupplier) {
         this.executor = executor;
-        this.ingestJobStatusStore = ingestJobStatusStore;
         this.propertiesReloader = PropertiesReloader.neverReload();
         this.ingestJobMessageHandler = messageHandler(
                 properties, hadoopConfig, ingestJobStatusStore,

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportExecutor.java
@@ -101,11 +101,7 @@ public class BulkImportExecutor {
             failedChecks.add("Job IDs are only allowed to be up to 63 characters long.");
         }
 
-        if (null == bulkImportJob.getTableName()) {
-            failedChecks.add("The table name must be set to a non-null value.");
-        } else if (!doesTableExist(bulkImportJob.getTableName())) {
-            failedChecks.add("Table does not exist.");
-        } else if (!hasMinimumPartitions(bulkImportJob)) {
+        if (!hasMinimumPartitions(bulkImportJob)) {
             failedChecks.add("The minimum partition count was not reached");
         }
 
@@ -124,17 +120,6 @@ public class BulkImportExecutor {
         } else {
             return true;
         }
-    }
-
-    private boolean doesTableExist(String tableName) {
-        try {
-            if (tablePropertiesProvider.getByName(tableName) != null) {
-                return true;
-            }
-        } catch (RuntimeException ep) {
-            LOGGER.warn("Could not find properties for table");
-        }
-        return false;
     }
 
     private boolean hasMinimumPartitions(BulkImportJob bulkImportJob) {

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutor.java
@@ -112,12 +112,11 @@ public class EmrServerlessPlatformExecutor implements PlatformExecutor {
 
         Map<String, String> jobSparkArgs = arguments.getBulkImportJob().getSparkConf();
         if (jobSparkArgs != null) {
-            jobSparkArgs = arguments.getBulkImportJob().getSparkConf().entrySet()
+            jobSparkArgs = jobSparkArgs.entrySet()
                     .stream().filter(prop -> prop.getKey().contains("sleeper.bulk.import.emr.serverless.spark"))
-                    .map(i -> {
-                        return Map.entry(i.getKey().split("sleeper\\.bulk\\.import\\.emr\\.serverless\\.")[1],
-                                i.getValue());
-                    })
+                    .map(i -> Map.entry(
+                            i.getKey().split("sleeper\\.bulk\\.import\\.emr\\.serverless\\.")[1],
+                            i.getValue()))
                     .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
             Map<String, String> sparkConf = Stream
@@ -125,9 +124,7 @@ public class EmrServerlessPlatformExecutor implements PlatformExecutor {
                     .flatMap(map -> map.entrySet().stream())
                     .collect(Collectors.toMap(Map.Entry::getKey,
                             Map.Entry::getValue, (m1, m2) -> m2, HashMap::new));
-            bulkImportJob.setSparkConf(sparkConf);
-        } else {
-            bulkImportJob.setSparkConf(instancePropertiesSparkConf);
+            bulkImportJob = bulkImportJob.toBuilder().sparkConf(sparkConf).build();
         }
 
         List<String> args = arguments.constructArgs(bulkImportJob, taskId);

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaIT.java
@@ -247,7 +247,8 @@ public class BulkImportStarterLambdaIT {
                         .jobIdSupplier(() -> "test-job")
                         .build());
         BulkImportJob job = BulkImportJob.builder()
-                .tableName("test-table").files(List.of("test-bucket/test-1.parquet"))
+                .tableName(TEST_TABLE).tableId(TEST_TABLE_ID)
+                .files(List.of("test-bucket/test-1.parquet"))
                 .build();
         SQSEvent event = getSqsEvent(job);
 
@@ -256,7 +257,8 @@ public class BulkImportStarterLambdaIT {
 
         // Then
         verify(executor, times(1)).runJob(BulkImportJob.builder()
-                .id("test-job").tableName("test-table")
+                .id("test-job")
+                .tableName(TEST_TABLE).tableId(TEST_TABLE_ID)
                 .files(List.of("test-bucket/test-1.parquet"))
                 .build());
     }
@@ -281,7 +283,10 @@ public class BulkImportStarterLambdaIT {
 
     private static BulkImportJob jobWithFiles(String... files) {
         return BulkImportJob.builder()
-                .id("id").files(List.of(files)).tableName("test-table").build();
+                .id("id")
+                .tableName(TEST_TABLE).tableId(TEST_TABLE_ID)
+                .files(List.of(files))
+                .build();
     }
 
     private static Configuration createHadoopConfiguration() {

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaIT.java
@@ -36,9 +36,14 @@ import sleeper.bulkimport.starter.executor.BulkImportExecutor;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.core.CommonTestConstants;
 import sleeper.core.record.process.status.ProcessRun;
+import sleeper.core.table.InMemoryTableIndex;
+import sleeper.core.table.TableIdentity;
+import sleeper.core.table.TableIndex;
+import sleeper.ingest.job.IngestJobMessageHandler;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.job.status.IngestJobStatusTestData;
 import sleeper.ingest.job.status.WriteToMemoryIngestJobStatusStore;
+import sleeper.utils.HadoopPathUtils;
 
 import java.time.Instant;
 import java.util.List;
@@ -53,6 +58,8 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
 
 @Testcontainers
 public class BulkImportStarterLambdaIT {
+    private static final String TEST_TABLE = "test-table";
+    private static final String TEST_TABLE_ID = "test-table-id";
     private static final String TEST_BUCKET = "test-bucket";
     @Container
     public static LocalStackContainer localStackContainer = new LocalStackContainer(DockerImageName.parse(CommonTestConstants.LOCALSTACK_DOCKER_IMAGE))
@@ -60,11 +67,15 @@ public class BulkImportStarterLambdaIT {
 
     private final AmazonS3 s3Client = createS3Client();
     private final BulkImportExecutor executor = mock(BulkImportExecutor.class);
+    private final TableIndex tableIndex = new InMemoryTableIndex();
     private final IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
     private final Instant validationTime = Instant.parse("2023-10-17T14:53:00Z");
-    private final BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor,
-            new InstanceProperties(), createHadoopConfiguration(), ingestJobStatusStore,
-            () -> "invalid-id", () -> validationTime);
+    private final Configuration hadoopConfig = createHadoopConfiguration();
+    private final BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(
+            executor, messageHandlerBuilder()
+            .jobIdSupplier(() -> "invalid-id")
+            .timeSupplier(() -> validationTime)
+            .build());
 
     private AmazonS3 createS3Client() {
         return buildAwsV1Client(localStackContainer, LocalStackContainer.Service.S3, AmazonS3ClientBuilder.standard());
@@ -73,6 +84,7 @@ public class BulkImportStarterLambdaIT {
     @BeforeEach
     void setup() {
         s3Client.createBucket(TEST_BUCKET);
+        tableIndex.create(TableIdentity.uniqueIdAndName(TEST_TABLE_ID, TEST_TABLE));
     }
 
     @AfterEach
@@ -80,6 +92,13 @@ public class BulkImportStarterLambdaIT {
         s3Client.listObjects(TEST_BUCKET).getObjectSummaries().forEach(s3ObjectSummary ->
                 s3Client.deleteObject(TEST_BUCKET, s3ObjectSummary.getKey()));
         s3Client.deleteBucket(TEST_BUCKET);
+    }
+
+    private IngestJobMessageHandler.Builder<BulkImportJob> messageHandlerBuilder() {
+        return BulkImportStarterLambda.messageHandlerBuilder()
+                .tableIndex(tableIndex)
+                .ingestJobStatusStore(ingestJobStatusStore)
+                .expandDirectories(files -> HadoopPathUtils.expandDirectories(files, hadoopConfig, new InstanceProperties()));
     }
 
     @Nested
@@ -206,8 +225,8 @@ public class BulkImportStarterLambdaIT {
         // Given
         uploadFileToS3("test-1.parquet");
         BulkImportExecutor executor = mock(BulkImportExecutor.class);
-        BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor,
-                new InstanceProperties(), createHadoopConfiguration(), new WriteToMemoryIngestJobStatusStore());
+        BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(
+                executor, messageHandlerBuilder().build());
         BulkImportJob job = jobWithFiles("test-bucket/test-1.parquet");
         SQSEvent event = getSqsEvent(job);
 
@@ -224,8 +243,9 @@ public class BulkImportStarterLambdaIT {
         uploadFileToS3("test-1.parquet");
         BulkImportExecutor executor = mock(BulkImportExecutor.class);
         BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor,
-                new InstanceProperties(), createHadoopConfiguration(), new WriteToMemoryIngestJobStatusStore(),
-                () -> "test-job", Instant::now);
+                messageHandlerBuilder()
+                        .jobIdSupplier(() -> "test-job")
+                        .build());
         BulkImportJob job = BulkImportJob.builder()
                 .tableName("test-table").files(List.of("test-bucket/test-1.parquet"))
                 .build();

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaTest.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaTest.java
@@ -18,12 +18,13 @@ package sleeper.bulkimport.starter;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import sleeper.bulkimport.job.BulkImportJob;
 import sleeper.bulkimport.starter.executor.BulkImportExecutor;
-import sleeper.configuration.properties.instance.InstanceProperties;
+import sleeper.core.table.InMemoryTableIndex;
+import sleeper.core.table.TableIndex;
+import sleeper.ingest.job.IngestJobMessageHandler;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.job.status.WriteToMemoryIngestJobStatusStore;
 
@@ -36,91 +37,102 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.rejectedRun;
 
 public class BulkImportStarterLambdaTest {
-    @Nested
-    @DisplayName("Report validation failures")
-    class ReportValidationFailures {
-        BulkImportExecutor executor = mock(BulkImportExecutor.class);
-        IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
+    BulkImportExecutor executor = mock(BulkImportExecutor.class);
+    TableIndex tableIndex = new InMemoryTableIndex();
+    IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
 
-        @Test
-        void shouldReportValidationFailureIfJsonInvalid() {
-            // Given
-            String json = "{";
-            SQSEvent event = getSqsEvent(json);
+    @Test
+    void shouldReportValidationFailureIfJsonInvalid() {
+        // Given
+        String json = "{";
+        SQSEvent event = getSqsEvent(json);
 
-            // When
-            Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, new InstanceProperties(),
-                    null, ingestJobStatusStore, () -> "test-job-id", () -> validationTime);
-            bulkImportStarter.handleRequest(event, mock(Context.class));
+        // When
+        Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
+        BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, messageHandlerBuilder()
+                .jobIdSupplier(() -> "test-job-id")
+                .timeSupplier(() -> validationTime)
+                .build());
+        bulkImportStarter.handleRequest(event, mock(Context.class));
 
-            // Then
-            assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Error parsing JSON. Reason: End of input at line 1 column 2 path $.")));
-        }
+        // Then
+        assertThat(ingestJobStatusStore.getInvalidJobs())
+                .containsExactly(jobStatus("test-job-id",
+                        rejectedRun("test-job-id", json, validationTime,
+                                "Error parsing JSON. Reason: End of input at line 1 column 2 path $.")));
+    }
 
-        @Test
-        void shouldReportModelValidationFailureIfTableNameNotProvided() {
-            // Given
-            String json = "{" +
-                    "\"files\":[]" +
-                    "}";
-            SQSEvent event = getSqsEvent(json);
+    @Test
+    void shouldReportModelValidationFailureIfTableNameNotProvided() {
+        // Given
+        String json = "{" +
+                "\"files\":[]" +
+                "}";
+        SQSEvent event = getSqsEvent(json);
 
-            // When
-            Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, new InstanceProperties(),
-                    null, ingestJobStatusStore, () -> "test-job-id", () -> validationTime);
-            bulkImportStarter.handleRequest(event, mock(Context.class));
+        // When
+        Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
+        BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, messageHandlerBuilder()
+                .jobIdSupplier(() -> "test-job-id")
+                .timeSupplier(() -> validationTime)
+                .build());
+        bulkImportStarter.handleRequest(event, mock(Context.class));
 
-            // Then
-            assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Model validation failed. Missing property \"tableName\"")));
-        }
+        // Then
+        assertThat(ingestJobStatusStore.getInvalidJobs())
+                .containsExactly(jobStatus("test-job-id",
+                        rejectedRun("test-job-id", json, validationTime,
+                                "Model validation failed. Missing property \"tableName\"")));
+    }
 
-        @Test
-        void shouldReportModelValidationFailureIfFilesNotProvided() {
-            // Given
-            String json = "{" +
-                    "\"tableName\":\"test-table\"" +
-                    "}";
-            SQSEvent event = getSqsEvent(json);
+    @Test
+    void shouldReportModelValidationFailureIfFilesNotProvided() {
+        // Given
+        String json = "{" +
+                "\"tableName\":\"test-table\"" +
+                "}";
+        SQSEvent event = getSqsEvent(json);
 
-            // When
-            Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, new InstanceProperties(),
-                    null, ingestJobStatusStore, () -> "test-job-id", () -> validationTime);
-            bulkImportStarter.handleRequest(event, mock(Context.class));
+        // When
+        Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
+        BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, messageHandlerBuilder()
+                .jobIdSupplier(() -> "test-job-id")
+                .timeSupplier(() -> validationTime)
+                .build());
+        bulkImportStarter.handleRequest(event, mock(Context.class));
 
-            // Then
-            assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Model validation failed. Missing property \"files\"")));
-        }
+        // Then
+        assertThat(ingestJobStatusStore.getInvalidJobs())
+                .containsExactly(jobStatus("test-job-id",
+                        rejectedRun("test-job-id", json, validationTime,
+                                "Model validation failed. Missing property \"files\"")));
+    }
 
-        @Test
-        void shouldReportMultipleModelValidationFailures() {
-            // Given
-            String json = "{}";
-            SQSEvent event = getSqsEvent(json);
+    @Test
+    void shouldReportMultipleModelValidationFailures() {
+        // Given
+        String json = "{}";
+        SQSEvent event = getSqsEvent(json);
 
-            // When
-            Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, new InstanceProperties(),
-                    null, ingestJobStatusStore, () -> "test-job-id", () -> validationTime);
-            bulkImportStarter.handleRequest(event, mock(Context.class));
+        // When
+        Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
+        BulkImportStarterLambda bulkImportStarter = new BulkImportStarterLambda(executor, messageHandlerBuilder()
+                .jobIdSupplier(() -> "test-job-id")
+                .timeSupplier(() -> validationTime)
+                .build());
+        bulkImportStarter.handleRequest(event, mock(Context.class));
 
-            // Then
-            assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Model validation failed. Missing property \"files\"",
-                                    "Model validation failed. Missing property \"tableName\"")));
-        }
+        // Then
+        assertThat(ingestJobStatusStore.getInvalidJobs())
+                .containsExactly(jobStatus("test-job-id",
+                        rejectedRun("test-job-id", json, validationTime,
+                                "Model validation failed. Missing property \"files\"",
+                                "Model validation failed. Missing property \"tableName\"")));
+    }
+
+    private IngestJobMessageHandler.Builder<BulkImportJob> messageHandlerBuilder() {
+        return BulkImportStarterLambda.messageHandlerBuilder()
+                .tableIndex(tableIndex)
+                .ingestJobStatusStore(ingestJobStatusStore);
     }
 }

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportExecutorIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportExecutorIT.java
@@ -40,6 +40,7 @@ import sleeper.core.CommonTestConstants;
 import sleeper.core.schema.Field;
 import sleeper.core.schema.Schema;
 import sleeper.core.schema.type.StringType;
+import sleeper.core.table.TableIdentity;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.status.store.job.DynamoDBIngestJobStatusStore;
 import sleeper.ingest.status.store.job.DynamoDBIngestJobStatusStoreCreator;
@@ -58,7 +59,6 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.BULK_IMPORT_MIN_LEAF_PARTITION_COUNT;
-import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRun;
@@ -88,7 +88,7 @@ class BulkImportExecutorIT {
     private final InstanceProperties instanceProperties = createTestInstanceProperties();
     private final TableProperties tableProperties = createTestTableProperties(instanceProperties, SCHEMA);
     private final String bucketName = UUID.randomUUID().toString();
-    private final String tableName = "myTable";
+    private final TableIdentity tableId = tableProperties.getId();
     private final IngestJobStatusStore ingestJobStatusStore = IngestJobStatusStoreFactory.getStatusStore(dynamoDB, instanceProperties);
 
     @BeforeEach
@@ -96,8 +96,6 @@ class BulkImportExecutorIT {
         DynamoDBIngestJobStatusStoreCreator.create(instanceProperties, dynamoDB);
         instanceProperties.set(BULK_IMPORT_BUCKET, bucketName);
         s3.createBucket(bucketName);
-        tableProperties.set(TABLE_NAME, tableName);
-        tableProperties.setSchema(SCHEMA);
         tableProperties.set(BULK_IMPORT_MIN_LEAF_PARTITION_COUNT, "1");
     }
 
@@ -114,7 +112,7 @@ class BulkImportExecutorIT {
         void shouldFailValidationIfFileListIsEmpty() {
             // Given
             BulkImportJob importJob = new BulkImportJob.Builder()
-                    .tableName(tableName)
+                    .tableId(tableId)
                     .id("my-job")
                     .files(Lists.newArrayList())
                     .build();
@@ -125,7 +123,7 @@ class BulkImportExecutorIT {
 
             // Then
             assertThat(fakeExecutor.getJobsRun()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs(tableName))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                     .containsExactly(jobStatus(importJob.toIngestJob(),
                             rejectedRun(importJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"),
@@ -133,53 +131,11 @@ class BulkImportExecutorIT {
         }
 
         @Test
-        void shouldFailValidationIfJobPointsAtNonExistentTable() {
-            // Given
-            BulkImportJob importJob = new BulkImportJob.Builder()
-                    .tableName("table-that-does-not-exist")
-                    .id("my-job")
-                    .files(Lists.newArrayList("file1.parquet"))
-                    .build();
-            FakeExecutor fakeExecutor = buildExecutorWithValidationTime(Instant.parse("2023-06-02T15:41:00Z"));
-
-            // When
-            fakeExecutor.runJob(importJob);
-
-            // Then
-            assertThat(fakeExecutor.getJobsRun()).isEmpty();
-            assertThat(ingestJobStatusStore.getJob("my-job")).isPresent().get()
-                    .usingRecursiveComparison(IGNORE_UPDATE_TIMES)
-                    .isEqualTo(jobStatus(importJob.toIngestJob(),
-                            rejectedRun(importJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"),
-                                    "Table does not exist.")));
-        }
-
-        @Test
-        void shouldFailValidationIfTableNameIsNull() {
-            // Given
-            BulkImportJob importJob = new BulkImportJob.Builder()
-                    .id("my-job")
-                    .files(Lists.newArrayList("file1.parquet"))
-                    .build();
-            FakeExecutor fakeExecutor = buildExecutorWithValidationTime(Instant.parse("2023-06-02T15:41:00Z"));
-            // When
-            fakeExecutor.runJob(importJob);
-
-            // Then
-            assertThat(fakeExecutor.getJobsRun()).isEmpty();
-            assertThat(ingestJobStatusStore.getJob("my-job")).isPresent().get()
-                    .usingRecursiveComparison(IGNORE_UPDATE_TIMES)
-                    .isEqualTo(jobStatus(importJob.toIngestJob(),
-                            rejectedRun(importJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"),
-                                    "The table name must be set to a non-null value.")));
-        }
-
-        @Test
         void shouldFailValidationIfJobIdContainsMoreThan63Characters() {
             // Given
             String invalidId = UUID.randomUUID().toString() + UUID.randomUUID();
             BulkImportJob importJob = new BulkImportJob.Builder()
-                    .tableName(tableName)
+                    .tableId(tableId)
                     .files(Lists.newArrayList("file1.parquet"))
                     .id(invalidId)
                     .build();
@@ -189,7 +145,7 @@ class BulkImportExecutorIT {
 
             // Then
             assertThat(fakeExecutor.getJobsRun()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs(tableName))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                     .containsExactly(jobStatus(importJob.toIngestJob(),
                             rejectedRun(importJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"),
@@ -200,7 +156,7 @@ class BulkImportExecutorIT {
         void shouldFailValidationIfJobIdContainsUppercaseLetters() {
             // Given
             BulkImportJob importJob = new BulkImportJob.Builder()
-                    .tableName(tableName)
+                    .tableId(tableId)
                     .id("importJob")
                     .files(Lists.newArrayList("file1.parquet"))
                     .build();
@@ -211,7 +167,7 @@ class BulkImportExecutorIT {
 
             // Then
             assertThat(fakeExecutor.getJobsRun()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs("myTable"))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                     .containsExactly(jobStatus(importJob.toIngestJob(),
                             rejectedRun(importJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"),
@@ -226,7 +182,7 @@ class BulkImportExecutorIT {
         s3.putObject(bucketName, "file2.parquet", "");
         s3.putObject(bucketName, "directory/file3.parquet", "");
         BulkImportJob importJob = new BulkImportJob.Builder()
-                .tableName(tableName)
+                .tableId(tableId)
                 .id("my-job")
                 .files(List.of(
                         bucketName + "/file1.parquet",
@@ -241,7 +197,7 @@ class BulkImportExecutorIT {
         // Then
         assertThat(fakeExecutor.getJobsRun()).containsExactly(importJob);
         assertThat(fakeExecutor.getJobRunIdsOfJobsRun()).containsExactly("job-run-id");
-        assertThat(ingestJobStatusStore.getAllJobs("myTable"))
+        assertThat(ingestJobStatusStore.getAllJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(jobStatus(importJob.toIngestJob(),
                         acceptedRun(importJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"))));
@@ -252,7 +208,7 @@ class BulkImportExecutorIT {
         // Given
         s3.putObject(bucketName, "directory/file1.parquet", "");
         BulkImportJob importJob = new BulkImportJob.Builder()
-                .tableName(tableName)
+                .tableId(tableId)
                 .id("my-job")
                 .files(List.of(bucketName + "/directory", bucketName + "/directory/"))
                 .build();
@@ -264,7 +220,7 @@ class BulkImportExecutorIT {
         // Then
         assertThat(fakeExecutor.getJobsRun()).containsExactly(importJob);
         assertThat(fakeExecutor.getJobRunIdsOfJobsRun()).containsExactly("job-run-id");
-        assertThat(ingestJobStatusStore.getAllJobs("myTable"))
+        assertThat(ingestJobStatusStore.getAllJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(jobStatus(importJob.toIngestJob(),
                         acceptedRun(importJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"))));

--- a/java/clients/src/main/java/sleeper/clients/docker/SendFilesToIngest.java
+++ b/java/clients/src/main/java/sleeper/clients/docker/SendFilesToIngest.java
@@ -74,7 +74,7 @@ public class SendFilesToIngest {
                 .files(filePaths.stream()
                         .map(filePath -> properties.get(INGEST_SOURCE_BUCKET) + "/ingest/" + filePath.getFileName().toString())
                         .collect(Collectors.toList()))
-                .tableName("system-test")
+                .tableName(tableName)
                 .build();
         sqsClient.sendMessage(properties.get(INGEST_JOB_QUEUE_URL), new IngestJobSerDe().toJson(job));
     }

--- a/java/clients/src/main/java/sleeper/clients/status/report/job/query/AllJobsQuery.java
+++ b/java/clients/src/main/java/sleeper/clients/status/report/job/query/AllJobsQuery.java
@@ -37,7 +37,7 @@ public class AllJobsQuery implements JobQuery {
 
     @Override
     public List<IngestJobStatus> run(IngestJobStatusStore statusStore) {
-        return statusStore.getAllJobs(tableId.getTableName());
+        return statusStore.getAllJobs(tableId);
     }
 
     @Override

--- a/java/clients/src/main/java/sleeper/clients/status/report/job/query/RangeJobsQuery.java
+++ b/java/clients/src/main/java/sleeper/clients/status/report/job/query/RangeJobsQuery.java
@@ -55,7 +55,7 @@ public class RangeJobsQuery implements JobQuery {
 
     @Override
     public List<IngestJobStatus> run(IngestJobStatusStore statusStore) {
-        return statusStore.getJobsInTimePeriod(tableId.getTableName(), start, end);
+        return statusStore.getJobsInTimePeriod(tableId, start, end);
     }
 
     @Override

--- a/java/clients/src/main/java/sleeper/clients/status/report/job/query/UnfinishedJobsQuery.java
+++ b/java/clients/src/main/java/sleeper/clients/status/report/job/query/UnfinishedJobsQuery.java
@@ -37,7 +37,7 @@ public class UnfinishedJobsQuery implements JobQuery {
 
     @Override
     public List<IngestJobStatus> run(IngestJobStatusStore statusStore) {
-        return statusStore.getUnfinishedJobs(tableId.getTableName());
+        return statusStore.getUnfinishedJobs(tableId);
     }
 
     @Override

--- a/java/clients/src/test/java/sleeper/clients/admin/IngestStatusReportScreenTest.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/IngestStatusReportScreenTest.java
@@ -75,7 +75,7 @@ class IngestStatusReportScreenTest extends AdminClientMockStoreBase {
         @Test
         void shouldRunReportWithQueryTypeAll() throws Exception {
             // Given
-            when(ingestJobStatusStore.getAllJobs("test-table"))
+            when(ingestJobStatusStore.getAllJobs(tableProperties.getId()))
                     .thenReturn(oneStartedJobStatus());
 
             // When/Then
@@ -99,7 +99,7 @@ class IngestStatusReportScreenTest extends AdminClientMockStoreBase {
         @Test
         void shouldRunReportWithQueryTypeUnfinished() throws Exception {
             // Given
-            when(ingestJobStatusStore.getUnfinishedJobs("test-table"))
+            when(ingestJobStatusStore.getUnfinishedJobs(tableProperties.getId()))
                     .thenReturn(oneStartedJobStatus());
 
             // When/Then
@@ -144,7 +144,7 @@ class IngestStatusReportScreenTest extends AdminClientMockStoreBase {
         @Test
         void shouldRunReportWithQueryTypeRange() throws Exception {
             // Given
-            when(ingestJobStatusStore.getJobsInTimePeriod("test-table",
+            when(ingestJobStatusStore.getJobsInTimePeriod(tableProperties.getId(),
                     Instant.parse("2023-03-15T14:00:00Z"), Instant.parse("2023-03-15T18:00:00Z")))
                     .thenReturn(oneStartedJobStatus());
 

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TablePropertiesProvider.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TablePropertiesProvider.java
@@ -105,7 +105,7 @@ public class TablePropertiesProvider {
 
     public Stream<TableProperties> streamAllTables() {
         return propertiesStore.streamAllTableIds()
-                .map(id -> getByName(id.getTableName()));
+                .map(this::get);
     }
 
     public void clearCache() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJob.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJob.java
@@ -21,13 +21,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class IngestJob {
-    private final String tableName;
     private final String id;
+    private final String tableName;
+    private final String tableId;
     private final List<String> files;
 
     private IngestJob(Builder builder) {
-        tableName = builder.tableName;
         id = builder.id;
+        tableName = builder.tableName;
+        tableId = builder.tableId;
         files = builder.files;
     }
 
@@ -35,12 +37,16 @@ public class IngestJob {
         return new Builder();
     }
 
+    public String getId() {
+        return id;
+    }
+
     public String getTableName() {
         return tableName;
     }
 
-    public String getId() {
-        return id;
+    public String getTableId() {
+        return tableId;
     }
 
     public List<String> getFiles() {
@@ -56,22 +62,21 @@ public class IngestJob {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object object) {
+        if (this == object) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        IngestJob ingestJob = (IngestJob) o;
-        return Objects.equals(id, ingestJob.id) &&
-                Objects.equals(tableName, ingestJob.tableName) &&
-                Objects.equals(files, ingestJob.files);
+        IngestJob ingestJob = (IngestJob) object;
+        return Objects.equals(id, ingestJob.id) && Objects.equals(tableName, ingestJob.tableName)
+                && Objects.equals(tableId, ingestJob.tableId) && Objects.equals(files, ingestJob.files);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, tableName, files);
+        return Objects.hash(id, tableName, tableId, files);
     }
 
     @Override
@@ -79,16 +84,23 @@ public class IngestJob {
         return "IngestJob{" +
                 "id='" + id + '\'' +
                 ", tableName='" + tableName + '\'' +
+                ", tableId='" + tableId + '\'' +
                 ", files=" + files +
                 '}';
     }
 
     public static final class Builder {
-        private String tableName;
         private String id;
+        private String tableName;
+        private String tableId;
         private List<String> files;
 
         private Builder() {
+        }
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
         }
 
         public Builder tableName(String tableName) {
@@ -96,8 +108,8 @@ public class IngestJob {
             return this;
         }
 
-        public Builder id(String id) {
-            this.id = id;
+        public Builder tableId(String tableId) {
+            this.tableId = tableId;
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJob.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJob.java
@@ -15,7 +15,6 @@
  */
 package sleeper.ingest.job;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -34,19 +33,6 @@ public class IngestJob {
 
     public static Builder builder() {
         return new Builder();
-    }
-
-    public List<String> getValidationFailures() {
-        List<String> validationFailures = new ArrayList<>();
-        if (files == null) {
-            validationFailures.add("Missing property \"files\"");
-        } else if (files.contains(null)) {
-            validationFailures.add("One of the files was null");
-        }
-        if (tableName == null) {
-            validationFailures.add("Missing property \"tableName\"");
-        }
-        return validationFailures;
     }
 
     public String getTableName() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
@@ -27,6 +27,7 @@ import sleeper.ingest.job.status.IngestJobValidatedEvent;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.BiFunction;
@@ -48,14 +49,14 @@ public class IngestJobMessageHandler<T> {
     private final Supplier<Instant> timeSupplier;
 
     private IngestJobMessageHandler(Builder<T> builder) {
-        tableIndex = builder.tableIndex;
-        ingestJobStatusStore = builder.ingestJobStatusStore;
-        deserialiser = builder.deserialiser;
-        toIngestJob = builder.toIngestJob;
-        applyIngestJobChanges = builder.applyIngestJobChanges;
-        expandDirectories = builder.expandDirectories;
-        jobIdSupplier = builder.jobIdSupplier;
-        timeSupplier = builder.timeSupplier;
+        tableIndex = Objects.requireNonNull(builder.tableIndex, "tableIndex must not be null");
+        ingestJobStatusStore = Objects.requireNonNull(builder.ingestJobStatusStore, "ingestJobStatusStore must not be null");
+        deserialiser = Objects.requireNonNull(builder.deserialiser, "deserialiser must not be null");
+        toIngestJob = Objects.requireNonNull(builder.toIngestJob, "toIngestJob must not be null");
+        applyIngestJobChanges = Objects.requireNonNull(builder.applyIngestJobChanges, "applyIngestJobChanges must not be null");
+        expandDirectories = Objects.requireNonNull(builder.expandDirectories, "expandDirectories must not be null");
+        jobIdSupplier = Objects.requireNonNull(builder.jobIdSupplier, "jobIdSupplier must not be null");
+        timeSupplier = Objects.requireNonNull(builder.timeSupplier, "timeSupplier must not be null");
     }
 
     public static Builder<IngestJob> forIngestJob() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
@@ -19,6 +19,7 @@ package sleeper.ingest.job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import sleeper.core.table.TableIndex;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.job.status.IngestJobValidatedEvent;
 
@@ -36,6 +37,7 @@ import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobRejecte
 
 public class IngestJobMessageHandler<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(IngestJobMessageHandler.class);
+    private final TableIndex tableIndex;
     private final IngestJobStatusStore ingestJobStatusStore;
     private final Function<String, T> deserialiser;
     private final Function<T, IngestJob> toIngestJob;
@@ -45,6 +47,7 @@ public class IngestJobMessageHandler<T> {
     private final Supplier<Instant> timeSupplier;
 
     private IngestJobMessageHandler(Builder<T> builder) {
+        tableIndex = builder.tableIndex;
         ingestJobStatusStore = builder.ingestJobStatusStore;
         deserialiser = builder.deserialiser;
         toIngestJob = builder.toIngestJob;
@@ -131,6 +134,7 @@ public class IngestJobMessageHandler<T> {
     }
 
     public static final class Builder<T> {
+        private TableIndex tableIndex;
         private IngestJobStatusStore ingestJobStatusStore;
         private Function<String, T> deserialiser;
         private Function<T, IngestJob> toIngestJob;
@@ -140,6 +144,11 @@ public class IngestJobMessageHandler<T> {
         private Supplier<Instant> timeSupplier = Instant::now;
 
         private Builder() {
+        }
+
+        public Builder<T> tableIndex(TableIndex tableIndex) {
+            this.tableIndex = tableIndex;
+            return this;
         }
 
         public Builder<T> ingestJobStatusStore(IngestJobStatusStore ingestJobStatusStore) {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
@@ -114,7 +114,12 @@ public class IngestJobMessageHandler<T> {
         if (expandedFiles.isEmpty()) {
             LOGGER.warn("Could not find one or more files for job: {}", job);
             ingestJobStatusStore.jobValidated(
-                    ingestJobRejected(jobId, message, timeSupplier.get(), "Could not find one or more files"));
+                    refusedEventBuilder()
+                            .jobId(jobId)
+                            .tableName(ingestJob.getTableName())
+                            .jsonMessage(message)
+                            .reasons("Could not find one or more files")
+                            .build());
             return Optional.empty();
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/IngestJobMessageHandler.java
@@ -78,12 +78,10 @@ public class IngestJobMessageHandler<T> {
             return Optional.empty();
         }
         IngestJob ingestJob = toIngestJob.apply(job);
-        IngestJob.Builder ingestJobBuilder = ingestJob.toBuilder();
         String jobId = ingestJob.getId();
         if (jobId == null || jobId.isBlank()) {
             jobId = jobIdSupplier.get();
             LOGGER.info("Null or blank id provided. Generated new id: {}", jobId);
-            ingestJobBuilder.id(jobId);
         }
 
         List<String> files = ingestJob.getFiles();

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 public class IngestJobFinishedEvent {
     private final String jobId;
     private final String tableName;
+    private final String tableId;
     private final RecordsProcessedSummary summary;
     private final String jobRunId;
     private final String taskId;
@@ -31,6 +32,7 @@ public class IngestJobFinishedEvent {
     private IngestJobFinishedEvent(Builder builder) {
         jobId = Objects.requireNonNull(builder.jobId, "jobId must not be null");
         tableName = Objects.requireNonNull(builder.tableName, "tableName must not be null");
+        tableId = Objects.requireNonNull(builder.tableId, "tableId must not be null");
         summary = Objects.requireNonNull(builder.summary, "summary must not be null");
         jobRunId = builder.jobRunId;
         taskId = Objects.requireNonNull(builder.taskId, "taskId must not be null");
@@ -54,6 +56,10 @@ public class IngestJobFinishedEvent {
 
     public String getTableName() {
         return tableName;
+    }
+
+    public String getTableId() {
+        return tableId;
     }
 
     public RecordsProcessedSummary getSummary() {
@@ -99,6 +105,7 @@ public class IngestJobFinishedEvent {
     public static final class Builder {
         private String jobId;
         private String tableName;
+        private String tableId;
         private RecordsProcessedSummary summary;
         private String jobRunId;
         private String taskId;
@@ -108,7 +115,8 @@ public class IngestJobFinishedEvent {
 
         public Builder job(IngestJob job) {
             return jobId(job.getId())
-                    .tableName(job.getTableName());
+                    .tableName(job.getTableName())
+                    .tableId(job.getTableId());
         }
 
         public Builder jobId(String jobId) {
@@ -118,6 +126,11 @@ public class IngestJobFinishedEvent {
 
         public Builder tableName(String tableName) {
             this.tableName = tableName;
+            return this;
+        }
+
+        public Builder tableId(String tableId) {
+            this.tableId = tableId;
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
@@ -22,13 +22,15 @@ import sleeper.ingest.job.IngestJob;
 import java.util.Objects;
 
 public class IngestJobFinishedEvent {
-    private final IngestJob job;
+    private final String jobId;
+    private final String tableName;
     private final RecordsProcessedSummary summary;
     private final String jobRunId;
     private final String taskId;
 
     private IngestJobFinishedEvent(Builder builder) {
-        job = Objects.requireNonNull(builder.job, "job must not be null");
+        jobId = Objects.requireNonNull(builder.jobId, "jobId must not be null");
+        tableName = Objects.requireNonNull(builder.tableName, "tableName must not be null");
         summary = Objects.requireNonNull(builder.summary, "summary must not be null");
         jobRunId = builder.jobRunId;
         taskId = Objects.requireNonNull(builder.taskId, "taskId must not be null");
@@ -47,11 +49,11 @@ public class IngestJobFinishedEvent {
     }
 
     public String getJobId() {
-        return job.getId();
+        return jobId;
     }
 
     public String getTableName() {
-        return job.getTableName();
+        return tableName;
     }
 
     public RecordsProcessedSummary getSummary() {
@@ -75,18 +77,19 @@ public class IngestJobFinishedEvent {
             return false;
         }
         IngestJobFinishedEvent that = (IngestJobFinishedEvent) o;
-        return Objects.equals(job, that.job) && Objects.equals(summary, that.summary) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId);
+        return Objects.equals(jobId, that.jobId) && Objects.equals(tableName, that.tableName) && Objects.equals(summary, that.summary) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(job, summary, jobRunId, taskId);
+        return Objects.hash(jobId, tableName, summary, jobRunId, taskId);
     }
 
     @Override
     public String toString() {
         return "IngestJobFinishedEvent{" +
-                "job=" + job +
+                "jobId='" + jobId + '\'' +
+                ", tableName='" + tableName + '\'' +
                 ", summary=" + summary +
                 ", jobRunId='" + jobRunId + '\'' +
                 ", taskId='" + taskId + '\'' +
@@ -94,7 +97,8 @@ public class IngestJobFinishedEvent {
     }
 
     public static final class Builder {
-        private IngestJob job;
+        private String jobId;
+        private String tableName;
         private RecordsProcessedSummary summary;
         private String jobRunId;
         private String taskId;
@@ -103,7 +107,17 @@ public class IngestJobFinishedEvent {
         }
 
         public Builder job(IngestJob job) {
-            this.job = job;
+            return jobId(job.getId())
+                    .tableName(job.getTableName());
+        }
+
+        public Builder jobId(String jobId) {
+            this.jobId = jobId;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
@@ -75,20 +75,22 @@ public class IngestJobFinishedEvent {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object object) {
+        if (this == object) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        IngestJobFinishedEvent that = (IngestJobFinishedEvent) o;
-        return Objects.equals(jobId, that.jobId) && Objects.equals(tableName, that.tableName) && Objects.equals(summary, that.summary) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId);
+        IngestJobFinishedEvent that = (IngestJobFinishedEvent) object;
+        return Objects.equals(jobId, that.jobId) && Objects.equals(tableName, that.tableName)
+                && Objects.equals(tableId, that.tableId) && Objects.equals(summary, that.summary)
+                && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobId, tableName, summary, jobRunId, taskId);
+        return Objects.hash(jobId, tableName, tableId, summary, jobRunId, taskId);
     }
 
     @Override
@@ -96,6 +98,7 @@ public class IngestJobFinishedEvent {
         return "IngestJobFinishedEvent{" +
                 "jobId='" + jobId + '\'' +
                 ", tableName='" + tableName + '\'' +
+                ", tableId='" + tableId + '\'' +
                 ", summary=" + summary +
                 ", jobRunId='" + jobRunId + '\'' +
                 ", taskId='" + taskId + '\'' +

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobFinishedEvent.java
@@ -46,8 +46,12 @@ public class IngestJobFinishedEvent {
         return builder().job(job).summary(summary);
     }
 
-    public IngestJob getJob() {
-        return job;
+    public String getJobId() {
+        return job.getId();
+    }
+
+    public String getTableName() {
+        return job.getTableName();
     }
 
     public RecordsProcessedSummary getSummary() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
@@ -22,14 +22,18 @@ import java.time.Instant;
 import java.util.Objects;
 
 public class IngestJobStartedEvent {
-    private final IngestJob job;
+    private final String jobId;
+    private final String tableName;
+    private final int fileCount;
     private final String jobRunId;
     private final String taskId;
     private final Instant startTime;
     private final boolean startOfRun;
 
     private IngestJobStartedEvent(Builder builder) {
-        job = Objects.requireNonNull(builder.job, "job must not be null");
+        jobId = builder.jobId;
+        tableName = builder.tableName;
+        fileCount = builder.fileCount;
         jobRunId = builder.jobRunId;
         taskId = Objects.requireNonNull(builder.taskId, "taskId must not be null");
         startTime = Objects.requireNonNull(builder.startTime, "startTime must not be null");
@@ -51,7 +55,7 @@ public class IngestJobStartedEvent {
                 .startOfRun(true);
     }
 
-    public static IngestJobStartedEvent.Builder validatedIngestJobStarted(IngestJob job, Instant startTime) {
+    public static Builder validatedIngestJobStarted(IngestJob job, Instant startTime) {
         return builder()
                 .job(job)
                 .startTime(startTime)
@@ -59,15 +63,15 @@ public class IngestJobStartedEvent {
     }
 
     public String getJobId() {
-        return job.getId();
+        return jobId;
     }
 
     public String getTableName() {
-        return job.getTableName();
+        return tableName;
     }
 
     public int getFileCount() {
-        return job.getFileCount();
+        return fileCount;
     }
 
     public String getJobRunId() {
@@ -95,18 +99,20 @@ public class IngestJobStartedEvent {
             return false;
         }
         IngestJobStartedEvent that = (IngestJobStartedEvent) o;
-        return startOfRun == that.startOfRun && Objects.equals(job, that.job) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId) && Objects.equals(startTime, that.startTime);
+        return fileCount == that.fileCount && startOfRun == that.startOfRun && Objects.equals(jobId, that.jobId) && Objects.equals(tableName, that.tableName) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId) && Objects.equals(startTime, that.startTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(job, jobRunId, taskId, startTime, startOfRun);
+        return Objects.hash(jobId, tableName, fileCount, jobRunId, taskId, startTime, startOfRun);
     }
 
     @Override
     public String toString() {
         return "IngestJobStartedEvent{" +
-                "job=" + job +
+                "jobId='" + jobId + '\'' +
+                ", tableName='" + tableName + '\'' +
+                ", fileCount=" + fileCount +
                 ", jobRunId='" + jobRunId + '\'' +
                 ", taskId='" + taskId + '\'' +
                 ", startTime=" + startTime +
@@ -115,7 +121,9 @@ public class IngestJobStartedEvent {
     }
 
     public static final class Builder {
-        private IngestJob job;
+        private String jobId;
+        private String tableName;
+        private int fileCount;
         private String jobRunId;
         private String taskId;
         private Instant startTime;
@@ -125,7 +133,23 @@ public class IngestJobStartedEvent {
         }
 
         public Builder job(IngestJob job) {
-            this.job = job;
+            return jobId(job.getId())
+                    .tableName(job.getTableName())
+                    .fileCount(job.getFileCount());
+        }
+
+        public Builder jobId(String jobId) {
+            this.jobId = jobId;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder fileCount(int fileCount) {
+            this.fileCount = fileCount;
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
@@ -32,9 +32,9 @@ public class IngestJobStartedEvent {
     private final boolean startOfRun;
 
     private IngestJobStartedEvent(Builder builder) {
-        jobId = builder.jobId;
-        tableName = builder.tableName;
-        tableId = builder.tableId;
+        jobId = Objects.requireNonNull(builder.jobId, "jobId must not be null");
+        tableName = Objects.requireNonNull(builder.tableName, "tableName must not be null");
+        tableId = Objects.requireNonNull(builder.tableId, "tableId must not be null");
         fileCount = builder.fileCount;
         jobRunId = builder.jobRunId;
         taskId = Objects.requireNonNull(builder.taskId, "taskId must not be null");

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
@@ -97,20 +97,23 @@ public class IngestJobStartedEvent {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object object) {
+        if (this == object) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        IngestJobStartedEvent that = (IngestJobStartedEvent) o;
-        return fileCount == that.fileCount && startOfRun == that.startOfRun && Objects.equals(jobId, that.jobId) && Objects.equals(tableName, that.tableName) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId) && Objects.equals(startTime, that.startTime);
+        IngestJobStartedEvent that = (IngestJobStartedEvent) object;
+        return fileCount == that.fileCount && startOfRun == that.startOfRun && Objects.equals(jobId, that.jobId)
+                && Objects.equals(tableName, that.tableName) && Objects.equals(tableId, that.tableId)
+                && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId)
+                && Objects.equals(startTime, that.startTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobId, tableName, fileCount, jobRunId, taskId, startTime, startOfRun);
+        return Objects.hash(jobId, tableName, tableId, fileCount, jobRunId, taskId, startTime, startOfRun);
     }
 
     @Override
@@ -118,6 +121,7 @@ public class IngestJobStartedEvent {
         return "IngestJobStartedEvent{" +
                 "jobId='" + jobId + '\'' +
                 ", tableName='" + tableName + '\'' +
+                ", tableId='" + tableId + '\'' +
                 ", fileCount=" + fileCount +
                 ", jobRunId='" + jobRunId + '\'' +
                 ", taskId='" + taskId + '\'' +

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 public class IngestJobStartedEvent {
     private final String jobId;
     private final String tableName;
+    private final String tableId;
     private final int fileCount;
     private final String jobRunId;
     private final String taskId;
@@ -33,6 +34,7 @@ public class IngestJobStartedEvent {
     private IngestJobStartedEvent(Builder builder) {
         jobId = builder.jobId;
         tableName = builder.tableName;
+        tableId = builder.tableId;
         fileCount = builder.fileCount;
         jobRunId = builder.jobRunId;
         taskId = Objects.requireNonNull(builder.taskId, "taskId must not be null");
@@ -68,6 +70,10 @@ public class IngestJobStartedEvent {
 
     public String getTableName() {
         return tableName;
+    }
+
+    public String getTableId() {
+        return tableId;
     }
 
     public int getFileCount() {
@@ -123,6 +129,7 @@ public class IngestJobStartedEvent {
     public static final class Builder {
         private String jobId;
         private String tableName;
+        private String tableId;
         private int fileCount;
         private String jobRunId;
         private String taskId;
@@ -135,6 +142,7 @@ public class IngestJobStartedEvent {
         public Builder job(IngestJob job) {
             return jobId(job.getId())
                     .tableName(job.getTableName())
+                    .tableId(job.getTableId())
                     .fileCount(job.getFileCount());
         }
 
@@ -145,6 +153,11 @@ public class IngestJobStartedEvent {
 
         public Builder tableName(String tableName) {
             this.tableName = tableName;
+            return this;
+        }
+
+        public Builder tableId(String tableId) {
+            this.tableId = tableId;
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStartedEvent.java
@@ -58,8 +58,16 @@ public class IngestJobStartedEvent {
                 .startOfRun(false);
     }
 
-    public IngestJob getJob() {
-        return job;
+    public String getJobId() {
+        return job.getId();
+    }
+
+    public String getTableName() {
+        return job.getTableName();
+    }
+
+    public int getFileCount() {
+        return job.getFileCount();
     }
 
     public String getJobRunId() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStatusStore.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStatusStore.java
@@ -16,6 +16,8 @@
 
 package sleeper.ingest.job.status;
 
+import sleeper.core.table.TableIdentity;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -37,12 +39,24 @@ public interface IngestJobStatusStore {
         throw new UnsupportedOperationException("Instance has no ingest job status store");
     }
 
+    default List<IngestJobStatus> getJobsInTimePeriod(TableIdentity tableId, Instant start, Instant end) {
+        return getJobsInTimePeriod(tableId.getTableName(), start, end);
+    }
+
     default List<IngestJobStatus> getAllJobs(String tableName) {
         throw new UnsupportedOperationException("Instance has no ingest job status store");
     }
 
+    default List<IngestJobStatus> getAllJobs(TableIdentity tableId) {
+        return getAllJobs(tableId.getTableName());
+    }
+
     default List<IngestJobStatus> getUnfinishedJobs(String tableName) {
         throw new UnsupportedOperationException("Instance has no ingest job status store");
+    }
+
+    default List<IngestJobStatus> getUnfinishedJobs(TableIdentity tableId) {
+        return getUnfinishedJobs(tableId.getTableName());
     }
 
     default Optional<IngestJobStatus> getJob(String jobId) {
@@ -51,6 +65,10 @@ public interface IngestJobStatusStore {
 
     default List<IngestJobStatus> getJobsByTaskId(String tableName, String taskId) {
         throw new UnsupportedOperationException("Instance has no ingest job status store");
+    }
+
+    default List<IngestJobStatus> getJobsByTaskId(TableIdentity tableId, String taskId) {
+        return getJobsByTaskId(tableId.getTableName(), taskId);
     }
 
     default List<IngestJobStatus> getInvalidJobs() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStatusStore.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobStatusStore.java
@@ -35,40 +35,24 @@ public interface IngestJobStatusStore {
     default void jobFinished(IngestJobFinishedEvent event) {
     }
 
-    default List<IngestJobStatus> getJobsInTimePeriod(String tableName, Instant start, Instant end) {
-        throw new UnsupportedOperationException("Instance has no ingest job status store");
-    }
-
     default List<IngestJobStatus> getJobsInTimePeriod(TableIdentity tableId, Instant start, Instant end) {
-        return getJobsInTimePeriod(tableId.getTableName(), start, end);
-    }
-
-    default List<IngestJobStatus> getAllJobs(String tableName) {
         throw new UnsupportedOperationException("Instance has no ingest job status store");
     }
 
     default List<IngestJobStatus> getAllJobs(TableIdentity tableId) {
-        return getAllJobs(tableId.getTableName());
-    }
-
-    default List<IngestJobStatus> getUnfinishedJobs(String tableName) {
         throw new UnsupportedOperationException("Instance has no ingest job status store");
     }
 
     default List<IngestJobStatus> getUnfinishedJobs(TableIdentity tableId) {
-        return getUnfinishedJobs(tableId.getTableName());
+        throw new UnsupportedOperationException("Instance has no ingest job status store");
     }
 
     default Optional<IngestJobStatus> getJob(String jobId) {
         throw new UnsupportedOperationException("Instance has no ingest job status store");
     }
 
-    default List<IngestJobStatus> getJobsByTaskId(String tableName, String taskId) {
-        throw new UnsupportedOperationException("Instance has no ingest job status store");
-    }
-
     default List<IngestJobStatus> getJobsByTaskId(TableIdentity tableId, String taskId) {
-        return getJobsByTaskId(tableId.getTableName(), taskId);
+        throw new UnsupportedOperationException("Instance has no ingest job status store");
     }
 
     default List<IngestJobStatus> getInvalidJobs() {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -64,6 +64,20 @@ public class IngestJobValidatedEvent {
         return new Builder();
     }
 
+    public IngestJobValidatedStatus toStatusUpdate(Instant updateTime) {
+        if (isAccepted()) {
+            return IngestJobAcceptedStatus.from(
+                    job, validationTime, updateTime);
+        } else {
+            return IngestJobRejectedStatus.builder()
+                    .job(job)
+                    .validationTime(validationTime)
+                    .updateTime(updateTime)
+                    .reasons(reasons)
+                    .jsonMessage(jsonMessage).build();
+        }
+    }
+
     public IngestJob getJob() {
         return job;
     }

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -16,7 +16,6 @@
 
 package sleeper.ingest.job.status;
 
-import sleeper.core.table.TableIdentity;
 import sleeper.ingest.job.IngestJob;
 
 import java.time.Instant;
@@ -48,16 +47,6 @@ public class IngestJobValidatedEvent {
 
     public static Builder ingestJobAccepted(IngestJob job, Instant validationTime) {
         return builder().job(job).validationTime(validationTime).reasons(List.of());
-    }
-
-    public static Builder ingestJobAccepted(IngestJob job, TableIdentity tableId, Instant validationTime) {
-        return builder()
-                .jobId(job.getId())
-                .tableName(tableId.getTableName())
-                .tableId(tableId.getTableUniqueId())
-                .fileCount(job.getFileCount())
-                .validationTime(validationTime)
-                .reasons(List.of());
     }
 
     public static IngestJobValidatedEvent ingestJobRejected(String jobId, String jsonMessage, Instant validationTime, String... reasons) {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -16,6 +16,7 @@
 
 package sleeper.ingest.job.status;
 
+import sleeper.core.table.TableId;
 import sleeper.ingest.job.IngestJob;
 
 import java.time.Instant;
@@ -45,6 +46,15 @@ public class IngestJobValidatedEvent {
 
     public static Builder ingestJobAccepted(IngestJob job, Instant validationTime) {
         return builder().job(job).validationTime(validationTime).reasons(List.of());
+    }
+
+    public static Builder ingestJobAccepted(IngestJob job, TableId tableId, Instant validationTime) {
+        return builder()
+                .jobId(job.getId())
+                .tableName(job.getTableName())
+                .tableId(tableId.getTableUniqueId())
+                .validationTime(validationTime)
+                .reasons(List.of());
     }
 
     public static IngestJobValidatedEvent ingestJobRejected(String jobId, String jsonMessage, Instant validationTime, String... reasons) {
@@ -175,6 +185,10 @@ public class IngestJobValidatedEvent {
 
         public Builder tableName(String tableName) {
             this.tableName = tableName;
+            return this;
+        }
+
+        public Builder tableId(String tableId) {
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -68,6 +68,18 @@ public class IngestJobValidatedEvent {
         return job;
     }
 
+    public String getJobId() {
+        return job.getId();
+    }
+
+    public String getTableName() {
+        return job.getTableName();
+    }
+
+    public int getFileCount() {
+        return job.getFileCount();
+    }
+
     public String getJobRunId() {
         return jobRunId;
     }

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -51,8 +51,9 @@ public class IngestJobValidatedEvent {
     public static Builder ingestJobAccepted(IngestJob job, TableId tableId, Instant validationTime) {
         return builder()
                 .jobId(job.getId())
-                .tableName(job.getTableName())
+                .tableName(tableId.getTableName())
                 .tableId(tableId.getTableUniqueId())
+                .fileCount(job.getFileCount())
                 .validationTime(validationTime)
                 .reasons(List.of());
     }

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -188,6 +188,7 @@ public class IngestJobValidatedEvent {
         public Builder job(IngestJob job) {
             return jobId(job.getId())
                     .tableName(job.getTableName())
+                    .tableId(job.getTableId())
                     .fileCount(job.getFileCount());
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -36,8 +36,8 @@ public class IngestJobValidatedEvent {
 
     private IngestJobValidatedEvent(Builder builder) {
         jobId = Objects.requireNonNull(builder.jobId, "jobId must not be null");
-        tableName = Objects.requireNonNull(builder.tableName, "tableName must not be null");
-        tableId = Objects.requireNonNull(builder.tableId, "tableId must not be null");
+        tableName = builder.tableName;
+        tableId = builder.tableId;
         fileCount = builder.fileCount;
         validationTime = Objects.requireNonNull(builder.validationTime, "validationTime must not be null");
         reasons = Objects.requireNonNull(builder.reasons, "reasons must not be null");

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -67,10 +67,10 @@ public class IngestJobValidatedEvent {
     public IngestJobValidatedStatus toStatusUpdate(Instant updateTime) {
         if (isAccepted()) {
             return IngestJobAcceptedStatus.from(
-                    job, validationTime, updateTime);
+                    getFileCount(), validationTime, updateTime);
         } else {
             return IngestJobRejectedStatus.builder()
-                    .job(job)
+                    .inputFileCount(getFileCount())
                     .validationTime(validationTime)
                     .updateTime(updateTime)
                     .reasons(reasons)

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 public class IngestJobValidatedEvent {
     private final String jobId;
     private final String tableName;
+    private final String tableId;
     private final int fileCount;
     private final Instant validationTime;
     private final List<String> reasons;
@@ -35,7 +36,8 @@ public class IngestJobValidatedEvent {
 
     private IngestJobValidatedEvent(Builder builder) {
         jobId = Objects.requireNonNull(builder.jobId, "jobId must not be null");
-        tableName = builder.tableName;
+        tableName = Objects.requireNonNull(builder.tableName, "tableName must not be null");
+        tableId = Objects.requireNonNull(builder.tableId, "tableId must not be null");
         fileCount = builder.fileCount;
         validationTime = Objects.requireNonNull(builder.validationTime, "validationTime must not be null");
         reasons = Objects.requireNonNull(builder.reasons, "reasons must not be null");
@@ -101,6 +103,10 @@ public class IngestJobValidatedEvent {
         return tableName;
     }
 
+    public String getTableId() {
+        return tableId;
+    }
+
     public int getFileCount() {
         return fileCount;
     }
@@ -163,6 +169,7 @@ public class IngestJobValidatedEvent {
     public static final class Builder {
         private String jobId;
         private String tableName;
+        private String tableId;
         private int fileCount;
         private Instant validationTime;
         private List<String> reasons;
@@ -190,6 +197,7 @@ public class IngestJobValidatedEvent {
         }
 
         public Builder tableId(String tableId) {
+            this.tableId = tableId;
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -50,12 +50,12 @@ public class IngestJobValidatedEvent {
     }
 
     public static IngestJobValidatedEvent ingestJobRejected(String jobId, String jsonMessage, Instant validationTime, String... reasons) {
-        return ingestJobRejected(jobId, jsonMessage, validationTime, List.of(reasons));
-    }
-
-    public static IngestJobValidatedEvent ingestJobRejected(String jobId, String jsonMessage, Instant validationTime, List<String> reasons) {
-        return builder().job(IngestJob.builder().id(jobId).build()).validationTime(validationTime)
-                .jsonMessage(jsonMessage).reasons(reasons).build();
+        return builder()
+                .jobId(jobId)
+                .validationTime(validationTime)
+                .reasons(reasons)
+                .jsonMessage(jsonMessage)
+                .build();
     }
 
     public static IngestJobValidatedEvent ingestJobRejected(IngestJob job, Instant validationTime, String... reasons) {

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -136,20 +136,24 @@ public class IngestJobValidatedEvent {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object object) {
+        if (this == object) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (object == null || getClass() != object.getClass()) {
             return false;
         }
-        IngestJobValidatedEvent that = (IngestJobValidatedEvent) o;
-        return fileCount == that.fileCount && Objects.equals(jobId, that.jobId) && Objects.equals(tableName, that.tableName) && Objects.equals(validationTime, that.validationTime) && Objects.equals(reasons, that.reasons) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId) && Objects.equals(jsonMessage, that.jsonMessage);
+        IngestJobValidatedEvent that = (IngestJobValidatedEvent) object;
+        return fileCount == that.fileCount && Objects.equals(jobId, that.jobId)
+                && Objects.equals(tableName, that.tableName) && Objects.equals(tableId, that.tableId)
+                && Objects.equals(validationTime, that.validationTime) && Objects.equals(reasons, that.reasons)
+                && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId)
+                && Objects.equals(jsonMessage, that.jsonMessage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobId, tableName, fileCount, validationTime, reasons, jobRunId, taskId, jsonMessage);
+        return Objects.hash(jobId, tableName, tableId, fileCount, validationTime, reasons, jobRunId, taskId, jsonMessage);
     }
 
     @Override
@@ -157,6 +161,7 @@ public class IngestJobValidatedEvent {
         return "IngestJobValidatedEvent{" +
                 "jobId='" + jobId + '\'' +
                 ", tableName='" + tableName + '\'' +
+                ", tableId='" + tableId + '\'' +
                 ", fileCount=" + fileCount +
                 ", validationTime=" + validationTime +
                 ", reasons=" + reasons +

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Objects;
 
 public class IngestJobValidatedEvent {
-    private final IngestJob job;
+    private final String jobId;
+    private final String tableName;
+    private final int fileCount;
     private final Instant validationTime;
     private final List<String> reasons;
     private final String jobRunId;
@@ -31,7 +33,9 @@ public class IngestJobValidatedEvent {
     private final String jsonMessage;
 
     private IngestJobValidatedEvent(Builder builder) {
-        job = Objects.requireNonNull(builder.job, "job must not be null");
+        jobId = Objects.requireNonNull(builder.jobId, "jobId must not be null");
+        tableName = Objects.requireNonNull(builder.tableName, "tableName must not be null");
+        fileCount = Objects.requireNonNull(builder.fileCount, "fileCount must not be null");
         validationTime = Objects.requireNonNull(builder.validationTime, "validationTime must not be null");
         reasons = Objects.requireNonNull(builder.reasons, "reasons must not be null");
         jobRunId = builder.jobRunId;
@@ -78,20 +82,16 @@ public class IngestJobValidatedEvent {
         }
     }
 
-    public IngestJob getJob() {
-        return job;
-    }
-
     public String getJobId() {
-        return job.getId();
+        return jobId;
     }
 
     public String getTableName() {
-        return job.getTableName();
+        return tableName;
     }
 
     public int getFileCount() {
-        return job.getFileCount();
+        return fileCount;
     }
 
     public String getJobRunId() {
@@ -127,23 +127,20 @@ public class IngestJobValidatedEvent {
             return false;
         }
         IngestJobValidatedEvent that = (IngestJobValidatedEvent) o;
-        return Objects.equals(job, that.job)
-                && Objects.equals(validationTime, that.validationTime)
-                && Objects.equals(reasons, that.reasons)
-                && Objects.equals(jobRunId, that.jobRunId)
-                && Objects.equals(taskId, that.taskId)
-                && Objects.equals(jsonMessage, that.jsonMessage);
+        return fileCount == that.fileCount && Objects.equals(jobId, that.jobId) && Objects.equals(tableName, that.tableName) && Objects.equals(validationTime, that.validationTime) && Objects.equals(reasons, that.reasons) && Objects.equals(jobRunId, that.jobRunId) && Objects.equals(taskId, that.taskId) && Objects.equals(jsonMessage, that.jsonMessage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(job, validationTime, reasons, jobRunId, taskId, jsonMessage);
+        return Objects.hash(jobId, tableName, fileCount, validationTime, reasons, jobRunId, taskId, jsonMessage);
     }
 
     @Override
     public String toString() {
         return "IngestJobValidatedEvent{" +
-                "job=" + job +
+                "jobId='" + jobId + '\'' +
+                ", tableName='" + tableName + '\'' +
+                ", fileCount=" + fileCount +
                 ", validationTime=" + validationTime +
                 ", reasons=" + reasons +
                 ", jobRunId='" + jobRunId + '\'' +
@@ -153,7 +150,9 @@ public class IngestJobValidatedEvent {
     }
 
     public static final class Builder {
-        private IngestJob job;
+        private String jobId;
+        private String tableName;
+        private int fileCount;
         private Instant validationTime;
         private List<String> reasons;
         private String jobRunId;
@@ -164,7 +163,23 @@ public class IngestJobValidatedEvent {
         }
 
         public Builder job(IngestJob job) {
-            this.job = job;
+            return jobId(job.getId())
+                    .tableName(job.getTableName())
+                    .fileCount(job.getFileCount());
+        }
+
+        public Builder jobId(String jobId) {
+            this.jobId = jobId;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder fileCount(int fileCount) {
+            this.fileCount = fileCount;
             return this;
         }
 

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -16,7 +16,7 @@
 
 package sleeper.ingest.job.status;
 
-import sleeper.core.table.TableId;
+import sleeper.core.table.TableIdentity;
 import sleeper.ingest.job.IngestJob;
 
 import java.time.Instant;
@@ -48,7 +48,7 @@ public class IngestJobValidatedEvent {
         return builder().job(job).validationTime(validationTime).reasons(List.of());
     }
 
-    public static Builder ingestJobAccepted(IngestJob job, TableId tableId, Instant validationTime) {
+    public static Builder ingestJobAccepted(IngestJob job, TableIdentity tableId, Instant validationTime) {
         return builder()
                 .jobId(job.getId())
                 .tableName(tableId.getTableName())

--- a/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
+++ b/java/ingest/ingest-core/src/main/java/sleeper/ingest/job/status/IngestJobValidatedEvent.java
@@ -34,8 +34,8 @@ public class IngestJobValidatedEvent {
 
     private IngestJobValidatedEvent(Builder builder) {
         jobId = Objects.requireNonNull(builder.jobId, "jobId must not be null");
-        tableName = Objects.requireNonNull(builder.tableName, "tableName must not be null");
-        fileCount = Objects.requireNonNull(builder.fileCount, "fileCount must not be null");
+        tableName = builder.tableName;
+        fileCount = builder.fileCount;
         validationTime = Objects.requireNonNull(builder.validationTime, "validationTime must not be null");
         reasons = Objects.requireNonNull(builder.reasons, "reasons must not be null");
         jobRunId = builder.jobRunId;

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import sleeper.ingest.job.status.IngestJobStatus;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.job.status.WriteToMemoryIngestJobStatusStore;
 
@@ -205,6 +206,8 @@ public class IngestJobMessageHandlerTest {
                     .containsExactly(jobStatus("test-job-id",
                             rejectedRun("test-job-id", json, validationTime,
                                     "Error parsing JSON. Reason: End of input at line 1 column 2 path $.")));
+            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+                    .isEmpty();
         }
 
         @Test
@@ -226,6 +229,8 @@ public class IngestJobMessageHandlerTest {
                     .containsExactly(jobStatus("test-job-id",
                             rejectedRun("test-job-id", json, validationTime,
                                     "Model validation failed. Missing property \"tableName\"")));
+            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+                    .isEmpty();
         }
 
         @Test
@@ -242,11 +247,14 @@ public class IngestJobMessageHandlerTest {
                     "}";
 
             // When / Then
+            IngestJobStatus expected = jobStatus("test-job-id",
+                    rejectedRun("test-job-id", json, validationTime,
+                            "Model validation failed. Missing property \"files\""));
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Model validation failed. Missing property \"files\"")));
+                    .containsExactly(expected);
+            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+                    .containsExactly(expected);
         }
 
         @Test
@@ -267,6 +275,8 @@ public class IngestJobMessageHandlerTest {
                             rejectedRun("test-job-id", json, validationTime,
                                     "Model validation failed. Missing property \"files\"",
                                     "Model validation failed. Missing property \"tableName\"")));
+            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+                    .isEmpty();
         }
 
         @Test
@@ -284,11 +294,14 @@ public class IngestJobMessageHandlerTest {
                     "}";
 
             // When / Then
+            IngestJobStatus expected = jobStatus("invalid-job-1",
+                    rejectedRun("invalid-job-1", json, validationTime,
+                            "Model validation failed. One of the files was null"));
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("invalid-job-1",
-                            rejectedRun("invalid-job-1", json, validationTime,
-                                    "Model validation failed. One of the files was null")));
+                    .containsExactly(expected);
+            assertThat(ingestJobStatusStore.getAllJobs("system-test"))
+                    .containsExactly(expected);
         }
     }
 

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
@@ -338,6 +338,27 @@ public class IngestJobMessageHandlerTest {
         }
 
         @Test
+        void shouldReportMultipleModelValidationFailures() {
+            // Given
+            Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
+                    .jobIdSupplier(() -> "test-job-id")
+                    .timeSupplier(() -> validationTime)
+                    .build();
+            String json = "{}";
+
+            // When / Then
+            assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
+            assertThat(ingestJobStatusStore.getInvalidJobs())
+                    .containsExactly(jobStatus("test-job-id",
+                            rejectedRun("test-job-id", json, validationTime,
+                                    "Missing property \"files\"",
+                                    "Table not found")));
+            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+                    .isEmpty();
+        }
+
+        @Test
         void shouldReportValidationFailureIfFileIsNull() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
@@ -259,7 +259,7 @@ public class IngestJobMessageHandlerTest {
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(jobStatus("test-job-id",
                             rejectedRun("test-job-id", json, validationTime,
-                                    "Model validation failed. Missing property \"tableName\"")));
+                                    "Table not found")));
             assertThat(ingestJobStatusStore.getAllJobs("test-table"))
                     .isEmpty();
         }
@@ -279,33 +279,12 @@ public class IngestJobMessageHandlerTest {
             // When / Then
             IngestJobStatus expected = jobStatus("test-job-id",
                     rejectedRun("test-job-id", json, validationTime,
-                            "Model validation failed. Missing property \"files\""));
+                            "Missing property \"files\""));
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expected);
             assertThat(ingestJobStatusStore.getAllJobs("test-table"))
                     .containsExactly(expected);
-        }
-
-        @Test
-        void shouldReportMultipleModelValidationFailures() {
-            // Given
-            Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
-                    .jobIdSupplier(() -> "test-job-id")
-                    .timeSupplier(() -> validationTime)
-                    .build();
-            String json = "{}";
-
-            // When / Then
-            assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
-            assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Model validation failed. Missing property \"files\"",
-                                    "Model validation failed. Missing property \"tableName\"")));
-            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
-                    .isEmpty();
         }
 
         @Test
@@ -330,7 +309,7 @@ public class IngestJobMessageHandlerTest {
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expectedStatus);
             assertThat(ingestJobStatusStore.getAllJobs("non-existent-table"))
-                    .containsExactly(expectedStatus);
+                    .isEmpty();
         }
 
         @Test
@@ -367,18 +346,18 @@ public class IngestJobMessageHandlerTest {
                     .build();
             String json = "{" +
                     "\"id\": \"invalid-job-1\"," +
-                    "\"tableName\": \"system-test\"," +
+                    "\"tableName\": \"test-table\"," +
                     "\"files\": [,]" +
                     "}";
 
             // When / Then
             IngestJobStatus expected = jobStatus("invalid-job-1",
                     rejectedRun("invalid-job-1", json, validationTime,
-                            "Model validation failed. One of the files was null"));
+                            "One of the files was null"));
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expected);
-            assertThat(ingestJobStatusStore.getAllJobs("system-test"))
+            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
                     .containsExactly(expected);
         }
     }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import sleeper.core.table.InMemoryTableIndex;
+import sleeper.core.table.TableIndex;
 import sleeper.ingest.job.status.IngestJobStatus;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.job.status.WriteToMemoryIngestJobStatusStore;
@@ -37,6 +39,9 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.rejectedRun;
 
 public class IngestJobMessageHandlerTest {
 
+    private final TableIndex tableIndex = new InMemoryTableIndex();
+    private final IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
+
     @Nested
     @DisplayName("Read job")
     class ReadJob {
@@ -44,8 +49,7 @@ public class IngestJobMessageHandlerTest {
         @Test
         void shouldReadJob() {
             // Given
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore).build();
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler().build();
             String json = "{" +
                     "\"id\":\"test-job-id\"," +
                     "\"tableName\":\"test-table\"," +
@@ -66,8 +70,7 @@ public class IngestJobMessageHandlerTest {
         @Test
         void shouldGenerateId() {
             // Given
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore)
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
                     .jobIdSupplier(() -> "test-job-id")
                     .build();
             String json = "{" +
@@ -89,8 +92,7 @@ public class IngestJobMessageHandlerTest {
         @Test
         void shouldGenerateIdWhenEmpty() {
             // Given
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore)
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
                     .jobIdSupplier(() -> "test-job-id")
                     .build();
             String json = "{" +
@@ -118,8 +120,7 @@ public class IngestJobMessageHandlerTest {
         @Test
         void shouldExpandDirectories() {
             // Given
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandlerWithDirectories(ingestJobStatusStore,
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandlerWithDirectories(
                     Map.of("dir1", List.of("file1a.parquet", "file1b.parquet"),
                             "dir2", List.of("file2.parquet")))
                     .build();
@@ -141,8 +142,7 @@ public class IngestJobMessageHandlerTest {
         void shouldFailValidationWhenDirectoryIsEmpty() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandlerWithDirectories(ingestJobStatusStore,
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandlerWithDirectories(
                     Map.of("dir", List.of()))
                     .timeSupplier(() -> validationTime)
                     .build();
@@ -167,8 +167,7 @@ public class IngestJobMessageHandlerTest {
         void shouldFailValidationWhenDirectoryIsEmptyAndIdIsGenerated() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandlerWithDirectories(ingestJobStatusStore,
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandlerWithDirectories(
                     Map.of("dir", List.of()))
                     .jobIdSupplier(() -> "test-job-id")
                     .timeSupplier(() -> validationTime)
@@ -195,8 +194,7 @@ public class IngestJobMessageHandlerTest {
         void shouldReportValidationFailureIfJsonInvalid() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore)
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
                     .jobIdSupplier(() -> "test-job-id")
                     .timeSupplier(() -> validationTime)
                     .build();
@@ -216,8 +214,7 @@ public class IngestJobMessageHandlerTest {
         void shouldReportModelValidationFailureIfTableNameNotProvided() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore)
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
                     .jobIdSupplier(() -> "test-job-id")
                     .timeSupplier(() -> validationTime)
                     .build();
@@ -239,8 +236,7 @@ public class IngestJobMessageHandlerTest {
         void shouldReportModelValidationFailureIfFilesNotProvided() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore)
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
                     .jobIdSupplier(() -> "test-job-id")
                     .timeSupplier(() -> validationTime)
                     .build();
@@ -263,8 +259,7 @@ public class IngestJobMessageHandlerTest {
         void shouldReportMultipleModelValidationFailures() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore)
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
                     .jobIdSupplier(() -> "test-job-id")
                     .timeSupplier(() -> validationTime)
                     .build();
@@ -285,8 +280,7 @@ public class IngestJobMessageHandlerTest {
         void shouldReportValidationFailureIfFileIsNull() {
             // Given
             Instant validationTime = Instant.parse("2023-07-03T16:14:00Z");
-            IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
-            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler(ingestJobStatusStore)
+            IngestJobMessageHandler<IngestJob> ingestJobMessageHandler = messageHandler()
                     .timeSupplier(() -> validationTime)
                     .build();
             String json = "{" +
@@ -307,14 +301,14 @@ public class IngestJobMessageHandlerTest {
         }
     }
 
-    private IngestJobMessageHandler.Builder<IngestJob> messageHandler(IngestJobStatusStore ingestJobStatusStore) {
-        return messageHandlerWithDirectories(ingestJobStatusStore, Map.of());
+    private IngestJobMessageHandler.Builder<IngestJob> messageHandler() {
+        return messageHandlerWithDirectories(Map.of());
     }
 
-    private IngestJobMessageHandler.Builder<IngestJob> messageHandlerWithDirectories(
-            IngestJobStatusStore ingestJobStatusStore, Map<String, List<String>> directoryContents) {
+    private IngestJobMessageHandler.Builder<IngestJob> messageHandlerWithDirectories(Map<String, List<String>> directoryContents) {
 
         return IngestJobMessageHandler.forIngestJob()
+                .tableIndex(tableIndex)
                 .ingestJobStatusStore(ingestJobStatusStore)
                 .expandDirectories(files -> expandDirFiles(files, directoryContents));
     }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
@@ -43,10 +43,11 @@ public class IngestJobMessageHandlerTest {
 
     private final TableIndex tableIndex = new InMemoryTableIndex();
     private final IngestJobStatusStore ingestJobStatusStore = new WriteToMemoryIngestJobStatusStore();
+    private final TableIdentity tableId = TableIdentity.uniqueIdAndName("test-table-id", "test-table");
 
     @BeforeEach
     void setUp() {
-        tableIndex.create(TableIdentity.uniqueIdAndName("test-table-id", "test-table"));
+        tableIndex.create(tableId);
     }
 
     @Nested
@@ -72,7 +73,7 @@ public class IngestJobMessageHandlerTest {
                             .files("file1.parquet", "file2.parquet")
                             .build());
             assertThat(ingestJobStatusStore.getInvalidJobs()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).isEmpty();
+            assertThat(ingestJobStatusStore.getAllJobs(tableId)).isEmpty();
         }
 
         @Test
@@ -95,7 +96,7 @@ public class IngestJobMessageHandlerTest {
                             .files("file1.parquet", "file2.parquet")
                             .build());
             assertThat(ingestJobStatusStore.getInvalidJobs()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).isEmpty();
+            assertThat(ingestJobStatusStore.getAllJobs(tableId)).isEmpty();
         }
 
         @Test
@@ -119,7 +120,7 @@ public class IngestJobMessageHandlerTest {
                             .files("file1.parquet", "file2.parquet")
                             .build());
             assertThat(ingestJobStatusStore.getInvalidJobs()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).isEmpty();
+            assertThat(ingestJobStatusStore.getAllJobs(tableId)).isEmpty();
         }
 
         @Test
@@ -141,7 +142,7 @@ public class IngestJobMessageHandlerTest {
                             .files("file1.parquet", "file2.parquet")
                             .build());
             assertThat(ingestJobStatusStore.getInvalidJobs()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).isEmpty();
+            assertThat(ingestJobStatusStore.getAllJobs(tableId)).isEmpty();
         }
     }
 
@@ -167,7 +168,7 @@ public class IngestJobMessageHandlerTest {
                     .get().extracting(IngestJob::getTableName, IngestJob::getFiles)
                     .containsExactly("test-table", List.of("dir1/file1a.parquet", "dir1/file1b.parquet", "dir2/file2.parquet"));
             assertThat(ingestJobStatusStore.getInvalidJobs()).isEmpty();
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).isEmpty();
+            assertThat(ingestJobStatusStore.getAllJobs(tableId)).isEmpty();
         }
 
         @Test
@@ -191,7 +192,7 @@ public class IngestJobMessageHandlerTest {
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expected);
-            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .containsExactly(expected);
         }
 
@@ -215,7 +216,7 @@ public class IngestJobMessageHandlerTest {
                             "Could not find one or more files"));
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs()).containsExactly(expected);
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).containsExactly(expected);
+            assertThat(ingestJobStatusStore.getAllJobs(tableId)).containsExactly(expected);
         }
     }
 
@@ -238,7 +239,7 @@ public class IngestJobMessageHandlerTest {
                     .containsExactly(jobStatus("test-job-id",
                             rejectedRun("test-job-id", json, validationTime,
                                     "Error parsing JSON. Reason: End of input at line 1 column 2 path $.")));
-            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .isEmpty();
         }
 
@@ -260,7 +261,7 @@ public class IngestJobMessageHandlerTest {
                     .containsExactly(jobStatus("test-job-id",
                             rejectedRun("test-job-id", json, validationTime,
                                     "Table not found")));
-            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .isEmpty();
         }
 
@@ -283,7 +284,7 @@ public class IngestJobMessageHandlerTest {
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expected);
-            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .containsExactly(expected);
         }
 
@@ -308,8 +309,6 @@ public class IngestJobMessageHandlerTest {
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expectedStatus);
-            assertThat(ingestJobStatusStore.getAllJobs("non-existent-table"))
-                    .isEmpty();
         }
 
         @Test
@@ -333,8 +332,6 @@ public class IngestJobMessageHandlerTest {
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expectedStatus);
-            assertThat(ingestJobStatusStore.getAllJobs("non-existent-table"))
-                    .isEmpty();
         }
 
         @Test
@@ -354,7 +351,7 @@ public class IngestJobMessageHandlerTest {
                             rejectedRun("test-job-id", json, validationTime,
                                     "Missing property \"files\"",
                                     "Table not found")));
-            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .isEmpty();
         }
 
@@ -378,7 +375,7 @@ public class IngestJobMessageHandlerTest {
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
                     .containsExactly(expected);
-            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+            assertThat(ingestJobStatusStore.getAllJobs(tableId))
                     .containsExactly(expected);
         }
     }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerTest.java
@@ -153,12 +153,14 @@ public class IngestJobMessageHandlerTest {
                     "}";
 
             // When / Then
+            IngestJobStatus expected = jobStatus("test-job-id",
+                    rejectedRun("test-job-id", json, validationTime,
+                            "Could not find one or more files"));
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
             assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Could not find one or more files")));
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).isEmpty();
+                    .containsExactly(expected);
+            assertThat(ingestJobStatusStore.getAllJobs("test-table"))
+                    .containsExactly(expected);
         }
 
         @Test
@@ -177,12 +179,12 @@ public class IngestJobMessageHandlerTest {
                     "}";
 
             // When / Then
+            IngestJobStatus expected = jobStatus("test-job-id",
+                    rejectedRun("test-job-id", json, validationTime,
+                            "Could not find one or more files"));
             assertThat(ingestJobMessageHandler.deserialiseAndValidate(json)).isEmpty();
-            assertThat(ingestJobStatusStore.getInvalidJobs())
-                    .containsExactly(jobStatus("test-job-id",
-                            rejectedRun("test-job-id", json, validationTime,
-                                    "Could not find one or more files")));
-            assertThat(ingestJobStatusStore.getAllJobs("test-table")).isEmpty();
+            assertThat(ingestJobStatusStore.getInvalidJobs()).containsExactly(expected);
+            assertThat(ingestJobStatusStore.getAllJobs("test-table")).containsExactly(expected);
         }
     }
 

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobTestData.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobTestData.java
@@ -16,29 +16,32 @@
 
 package sleeper.ingest.job;
 
-import java.util.Arrays;
+import sleeper.core.table.TableIdentity;
+
 import java.util.List;
 
 public class IngestJobTestData {
 
-    public static final String DEFAULT_TABLE_NAME = "test-table";
+    public static final TableIdentity DEFAULT_TABLE = TableIdentity.uniqueIdAndName("test-table-id", "test-table");
+    public static final String DEFAULT_TABLE_NAME = DEFAULT_TABLE.getTableName();
 
     private IngestJobTestData() {
     }
 
-    public static IngestJob createJobWithTableAndFiles(String jobId, String tableName, List<String> filenames) {
+    public static IngestJob createJobWithTableAndFiles(String jobId, TableIdentity table, List<String> filenames) {
         return IngestJob.builder()
                 .id(jobId)
                 .files(filenames)
-                .tableName(tableName)
+                .tableName(table.getTableName())
+                .tableId(table.getTableUniqueId())
                 .build();
     }
 
-    public static IngestJob createJobWithTableAndFiles(String jobId, String tableName, String... filenames) {
-        return createJobWithTableAndFiles(jobId, tableName, Arrays.asList(filenames));
+    public static IngestJob createJobWithTableAndFiles(String jobId, TableIdentity table, String... filenames) {
+        return createJobWithTableAndFiles(jobId, table, List.of(filenames));
     }
 
     public static IngestJob createJobInDefaultTable(String jobId, String... filenames) {
-        return createJobWithTableAndFiles(jobId, DEFAULT_TABLE_NAME, filenames);
+        return createJobWithTableAndFiles(jobId, DEFAULT_TABLE, filenames);
     }
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobTestData.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/IngestJobTestData.java
@@ -23,7 +23,6 @@ import java.util.List;
 public class IngestJobTestData {
 
     public static final TableIdentity DEFAULT_TABLE = TableIdentity.uniqueIdAndName("test-table-id", "test-table");
-    public static final String DEFAULT_TABLE_NAME = DEFAULT_TABLE.getTableName();
 
     private IngestJobTestData() {
     }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStore.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStore.java
@@ -40,26 +40,11 @@ public class WriteToMemoryIngestJobStatusStore implements IngestJobStatusStore {
                 .jobIdToUpdateRecords.computeIfAbsent(event.getJobId(), jobId -> new ArrayList<>())
                 .add(ProcessStatusUpdateRecord.builder()
                         .jobId(event.getJobId())
-                        .statusUpdate(validatedStatus(event))
+                        .statusUpdate(event.toStatusUpdate(
+                                defaultUpdateTime(event.getValidationTime())))
                         .jobRunId(event.getJobRunId())
                         .taskId(event.getTaskId())
                         .build());
-    }
-
-    private static IngestJobValidatedStatus validatedStatus(IngestJobValidatedEvent event) {
-        if (event.isAccepted()) {
-            return IngestJobAcceptedStatus.from(
-                    event.getJob(),
-                    event.getValidationTime(),
-                    defaultUpdateTime(event.getValidationTime()));
-        } else {
-            return IngestJobRejectedStatus.builder()
-                    .job(event.getJob())
-                    .validationTime(event.getValidationTime())
-                    .updateTime(defaultUpdateTime(event.getValidationTime()))
-                    .reasons(event.getReasons())
-                    .jsonMessage(event.getJsonMessage()).build();
-        }
     }
 
     @Override

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStore.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStore.java
@@ -18,6 +18,7 @@ package sleeper.ingest.job.status;
 import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.record.process.status.ProcessFinishedStatus;
 import sleeper.core.record.process.status.ProcessStatusUpdateRecord;
+import sleeper.core.table.TableIdentity;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -100,6 +101,10 @@ public class WriteToMemoryIngestJobStatusStore implements IngestJobStatusStore {
     public Stream<IngestJobStatus> streamAllJobs() {
         return IngestJobStatus.streamFrom(tableNameToJobs.values().stream()
                 .flatMap(TableJobs::streamAllRecords));
+    }
+
+    public Stream<ProcessStatusUpdateRecord> streamTableRecords(TableIdentity tableId) {
+        return streamTableRecords(tableId.getTableName());
     }
 
     public Stream<ProcessStatusUpdateRecord> streamTableRecords(String tableName) {

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
@@ -64,7 +64,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         public void shouldReturnOneStartedJobWithNoFiles() {
             String taskId = "test-task";
             Instant startTime = Instant.parse("2022-09-22T12:00:14.000Z");
-            IngestJob job = createJobWithTableAndFiles("test-job", tableName);
+            IngestJob job = createJobWithTableAndFiles("test-job", tableId);
 
             store.jobStarted(ingestJobStarted(taskId, job, startTime));
             assertThat(store.getAllJobs(tableName)).containsExactly(
@@ -75,7 +75,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         public void shouldReturnOneStartedJobWithFiles() {
             String taskId = "test-task";
             Instant startTime = Instant.parse("2022-09-22T12:00:14.000Z");
-            IngestJob job = createJobWithTableAndFiles("test-job", tableName, "test-file-1.parquet", "test-file-2.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job", tableId, "test-file-1.parquet", "test-file-2.parquet");
 
             store.jobStarted(ingestJobStarted(taskId, job, startTime));
             assertThat(store.getAllJobs(tableName)).containsExactly(
@@ -87,7 +87,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
             String taskId = "test-task";
             Instant startTime = Instant.parse("2022-09-22T12:00:14.000Z");
             Instant finishTime = Instant.parse("2022-09-22T12:00:44.000Z");
-            IngestJob job = createJobWithTableAndFiles("test-job", tableName, "test-file-1.parquet", "test-file-2.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job", tableId, "test-file-1.parquet", "test-file-2.parquet");
             RecordsProcessedSummary summary = new RecordsProcessedSummary(
                     new RecordsProcessed(200L, 200L), startTime, finishTime);
 
@@ -102,7 +102,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
             String taskId = "test-task";
             Instant startTime = Instant.parse("2022-09-22T12:00:14.000Z");
             Instant finishTime = Instant.parse("2022-09-22T12:00:44.000Z");
-            IngestJob job = createJobWithTableAndFiles("test-job", tableName, "test-file-1.parquet", "test-file-2.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job", tableId, "test-file-1.parquet", "test-file-2.parquet");
             RecordsProcessedSummary summary = new RecordsProcessedSummary(
                     new RecordsProcessed(200L, 200L), startTime, finishTime);
 
@@ -113,7 +113,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         public void shouldReturnTwoRunsOnSameJob() {
             String taskId = "test-task";
-            IngestJob job = createJobWithTableAndFiles("test-job", tableName, "test-file-1.parquet", "test-file-2.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job", tableId, "test-file-1.parquet", "test-file-2.parquet");
             Instant startTime1 = Instant.parse("2022-09-22T12:00:15.000Z");
             Instant startTime2 = Instant.parse("2022-09-22T12:00:31.000Z");
             RecordsProcessedSummary summary1 = new RecordsProcessedSummary(
@@ -135,8 +135,8 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         public void shouldReturnTwoJobs() {
             String taskId = "test-task";
-            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet", "test-file-2.parquet");
-            IngestJob job2 = createJobWithTableAndFiles("test-job-2", tableName, "test-file-3.parquet");
+            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet", "test-file-2.parquet");
+            IngestJob job2 = createJobWithTableAndFiles("test-job-2", tableId, "test-file-3.parquet");
             Instant startTime1 = Instant.parse("2022-09-22T12:00:15.000Z");
             Instant startTime2 = Instant.parse("2022-09-22T12:00:31.000Z");
             RecordsProcessedSummary summary1 = new RecordsProcessedSummary(
@@ -157,11 +157,11 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         public void shouldReturnJobsWithCorrectTableName() {
             // Given
-            String tableName1 = createTable("test-table-1").getTableName();
-            String tableName2 = createTable("test-table-2").getTableName();
+            TableIdentity table1 = createTable("test-table-1");
+            TableIdentity table2 = createTable("test-table-2");
             String taskId = "test-task";
-            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableName1, "test-file-1.parquet", "test-file-2.parquet");
-            IngestJob job2 = createJobWithTableAndFiles("test-job-2", tableName2, "test-file-3.parquet");
+            IngestJob job1 = createJobWithTableAndFiles("test-job-1", table1, "test-file-1.parquet", "test-file-2.parquet");
+            IngestJob job2 = createJobWithTableAndFiles("test-job-2", table2, "test-file-3.parquet");
             Instant startTime1 = Instant.parse("2022-09-22T12:00:15.000Z");
             Instant startTime2 = Instant.parse("2022-09-22T12:00:31.000Z");
             RecordsProcessedSummary summary1 = new RecordsProcessedSummary(
@@ -176,9 +176,9 @@ public class WriteToMemoryIngestJobStatusStoreTest {
             store.jobFinished(ingestJobFinished(taskId, job2, summary2));
 
             // Then
-            assertThat(store.getAllJobs(tableName2)).containsExactly(
+            assertThat(store.getAllJobs(table2.getTableName())).containsExactly(
                     jobStatus(job2, finishedIngestRun(job2, taskId, summary2)));
-            assertThat(store.getAllJobs(tableName1)).containsExactly(
+            assertThat(store.getAllJobs(table1.getTableName())).containsExactly(
                     jobStatus(job1, finishedIngestRun(job1, taskId, summary1)));
         }
 
@@ -189,11 +189,11 @@ public class WriteToMemoryIngestJobStatusStoreTest {
 
         @Test
         public void shouldReturnJobsWithSameIdOnDifferentTables() {
-            String tableName1 = createTable("test-table-1").getTableName();
-            String tableName2 = createTable("test-table-2").getTableName();
+            TableIdentity table1 = createTable("test-table-1");
+            TableIdentity table2 = createTable("test-table-2");
             String taskId = "test-task";
-            IngestJob job1 = createJobWithTableAndFiles("test-job", tableName1, "test-file-1.parquet", "test-file-2.parquet");
-            IngestJob job2 = createJobWithTableAndFiles("test-job", tableName2, "test-file-3.parquet");
+            IngestJob job1 = createJobWithTableAndFiles("test-job", table1, "test-file-1.parquet", "test-file-2.parquet");
+            IngestJob job2 = createJobWithTableAndFiles("test-job", table2, "test-file-3.parquet");
             Instant startTime1 = Instant.parse("2022-09-22T12:00:15.000Z");
             Instant startTime2 = Instant.parse("2022-09-22T12:00:31.000Z");
 
@@ -202,9 +202,9 @@ public class WriteToMemoryIngestJobStatusStoreTest {
             store.jobStarted(ingestJobStarted(taskId, job2, startTime2));
 
             // Then
-            assertThat(store.getAllJobs(tableName2)).containsExactly(
+            assertThat(store.getAllJobs(table2.getTableName())).containsExactly(
                     jobStatus(job2, startedIngestRun(job2, taskId, startTime2)));
-            assertThat(store.getAllJobs(tableName1)).containsExactly(
+            assertThat(store.getAllJobs(table1.getTableName())).containsExactly(
                     jobStatus(job1, startedIngestRun(job1, taskId, startTime1)));
         }
     }
@@ -215,7 +215,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         void shouldGetInvalidJobsWithOneRejectedJob() {
             // Given
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
             // When
@@ -230,8 +230,8 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         void shouldGetOneInvalidJobWithOneRejectedJobAndOneAcceptedJob() {
             // Given
-            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
-            IngestJob job2 = createJobWithTableAndFiles("test-job-2", tableName, "test-file-2.parquet");
+            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
+            IngestJob job2 = createJobWithTableAndFiles("test-job-2", tableId, "test-file-2.parquet");
 
             Instant validationTime1 = Instant.parse("2022-09-22T12:00:10.000Z");
             Instant validationTime2 = Instant.parse("2022-09-22T12:02:10.000Z");
@@ -248,10 +248,10 @@ public class WriteToMemoryIngestJobStatusStoreTest {
 
         @Test
         void shouldGetInvalidJobsAcrossMultipleTables() {
-            String tableName1 = createTable("test-table-1").getTableName();
-            String tableName2 = createTable("test-table-2").getTableName();
-            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableName1, "test-file-1.parquet");
-            IngestJob job2 = createJobWithTableAndFiles("test-job-2", tableName2, "test-file-2.parquet");
+            TableIdentity table1 = createTable("test-table-1");
+            TableIdentity table2 = createTable("test-table-2");
+            IngestJob job1 = createJobWithTableAndFiles("test-job-1", table1, "test-file-1.parquet");
+            IngestJob job2 = createJobWithTableAndFiles("test-job-2", table2, "test-file-2.parquet");
             Instant validationTime1 = Instant.parse("2022-09-22T12:00:15.000Z");
             Instant validationTime2 = Instant.parse("2022-09-22T12:00:31.000Z");
 
@@ -268,7 +268,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         void shouldNotGetJobThatWasRejectedThenAccepted() {
             // Given
-            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job1 = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
 
             Instant validationTime1 = Instant.parse("2022-09-22T12:00:10.000Z");
             Instant validationTime2 = Instant.parse("2022-09-22T12:02:10.000Z");
@@ -303,7 +303,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         void shouldReportUnstartedJobWithNoValidationFailures() {
             // Given
             String taskId = "some-task";
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
             // When
@@ -318,7 +318,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         void shouldReportStartedJobWithNoValidationFailures() {
             // Given
             String taskId = "test-task";
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
             Instant startTime = Instant.parse("2022-09-22T12:00:15.000Z");
 
@@ -335,7 +335,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         void shouldReportJobWithOneValidationFailure() {
             // Given
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
             // When
@@ -350,7 +350,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         void shouldReportJobWithMultipleValidationFailures() {
             // Given
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
             // When
@@ -370,7 +370,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         @Test
         void shouldReportAcceptedJob() {
             // Given
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
             // When
@@ -389,7 +389,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
             // Given
             String jobRunId = "test-run";
             String taskId = "test-task";
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
             Instant startTime = Instant.parse("2022-09-22T12:00:15.000Z");
 
@@ -411,7 +411,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
             // Given
             String jobRunId = "test-run";
             String taskId = "test-task";
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
             Instant startTime = Instant.parse("2022-09-22T12:00:15.000Z");
             RecordsProcessedSummary summary = summary(startTime, Duration.ofMinutes(10), 100L, 100L);
@@ -435,7 +435,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
             // Given
             String jobRunId = "test-run";
             String taskId = "test-task";
-            IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+            IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
             Instant startTime = Instant.parse("2022-09-22T12:00:15.000Z");
             RecordsProcessedSummary summary = summary(startTime, Duration.ofMinutes(10), 100L, 100L);
 

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
@@ -22,10 +22,8 @@ import org.junit.jupiter.api.Test;
 import sleeper.core.record.process.RecordsProcessed;
 import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.record.process.status.ProcessStatusUpdateRecord;
-import sleeper.core.table.InMemoryTableIndex;
 import sleeper.core.table.TableIdGenerator;
 import sleeper.core.table.TableIdentity;
-import sleeper.core.table.TableIndex;
 import sleeper.ingest.job.IngestJob;
 
 import java.time.Duration;
@@ -54,7 +52,6 @@ import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobRejecte
 public class WriteToMemoryIngestJobStatusStoreTest {
 
     private final WriteToMemoryIngestJobStatusStore store = new WriteToMemoryIngestJobStatusStore();
-    private final TableIndex tableIndex = new InMemoryTableIndex();
     private final TableIdentity tableId = createTable("test-table");
 
     @Nested
@@ -455,9 +452,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
     }
 
     private TableIdentity createTable(String tableName) {
-        TableIdentity tableId = TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
-        tableIndex.create(tableId);
-        return tableId;
+        return TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
     }
 
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
@@ -48,6 +48,7 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.finishedIngestRu
 import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.rejectedRun;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.startedIngestRun;
+import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
 import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobRejected;
 
 public class WriteToMemoryIngestJobStatusStoreTest {
@@ -459,7 +460,4 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         return tableId;
     }
 
-    private IngestJobValidatedEvent.Builder ingestJobAccepted(IngestJob job, Instant validationTime) {
-        return IngestJobValidatedEvent.ingestJobAccepted(job, tableIndex.getTableByName(job.getTableName()).orElseThrow(), validationTime);
-    }
 }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/job/status/WriteToMemoryIngestJobStatusStoreTest.java
@@ -23,8 +23,8 @@ import sleeper.core.record.process.RecordsProcessed;
 import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.record.process.status.ProcessStatusUpdateRecord;
 import sleeper.core.table.InMemoryTableIndex;
-import sleeper.core.table.TableId;
 import sleeper.core.table.TableIdGenerator;
+import sleeper.core.table.TableIdentity;
 import sleeper.core.table.TableIndex;
 import sleeper.ingest.job.IngestJob;
 
@@ -54,7 +54,7 @@ public class WriteToMemoryIngestJobStatusStoreTest {
 
     private final WriteToMemoryIngestJobStatusStore store = new WriteToMemoryIngestJobStatusStore();
     private final TableIndex tableIndex = new InMemoryTableIndex();
-    private final TableId tableId = createTable("test-table");
+    private final TableIdentity tableId = createTable("test-table");
     private final String tableName = tableId.getTableName();
 
     @Nested
@@ -452,8 +452,8 @@ public class WriteToMemoryIngestJobStatusStoreTest {
         }
     }
 
-    private TableId createTable(String tableName) {
-        TableId tableId = TableId.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
+    private TableIdentity createTable(String tableName) {
+        TableIdentity tableId = TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
         tableIndex.create(tableId);
         return tableId;
     }

--- a/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskTest.java
+++ b/java/ingest/ingest-core/src/test/java/sleeper/ingest/task/IngestTaskTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
 import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summary;
 import static sleeper.core.statestore.FileInfoTestData.DEFAULT_NUMBER_OF_RECORDS;
 import static sleeper.ingest.IngestResultTestData.defaultFileIngestResultReadAndWritten;
-import static sleeper.ingest.job.IngestJobTestData.DEFAULT_TABLE_NAME;
+import static sleeper.ingest.job.IngestJobTestData.DEFAULT_TABLE;
 import static sleeper.ingest.job.IngestJobTestData.createJobInDefaultTable;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.finishedIngestJob;
 import static sleeper.ingest.task.IngestTaskStatusTestData.finishedMultipleJobs;
@@ -73,7 +73,7 @@ public class IngestTaskTest {
         // Then
         assertThat(taskStatusStore.getAllTasks()).containsExactly(finishedNoJobs(taskId, startTime, finishTime));
         assertThat(jobs.getIngestResults()).isEmpty();
-        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE_NAME)).isEmpty();
+        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE)).isEmpty();
     }
 
     @Test
@@ -98,7 +98,7 @@ public class IngestTaskTest {
         assertThat(taskStatusStore.getAllTasks()).containsExactly(
                 finishedOneJobNoFiles(taskId, startTaskTime, finishTaskTime, startJobTime, finishJobTime));
         assertThat(jobs.getIngestResults()).containsExactly(IngestResult.noFiles());
-        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE_NAME)).containsExactly(
+        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE)).containsExactly(
                 finishedIngestJob(job, taskId, summary(startJobTime, finishJobTime, 0, 0)));
     }
 
@@ -125,7 +125,7 @@ public class IngestTaskTest {
                 finishedOneJobOneFile(taskId, startTaskTime, finishTaskTime, startJobTime, finishJobTime));
         assertThat(jobs.getIngestResults())
                 .containsExactly(IngestResultTestData.defaultFileIngestResult("test.parquet"));
-        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE_NAME)).containsExactly(
+        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE)).containsExactly(
                 finishedIngestJob(job, taskId, defaultSummary(startJobTime, finishJobTime)));
     }
 
@@ -157,7 +157,7 @@ public class IngestTaskTest {
         assertThat(jobs.getIngestResults()).containsExactly(
                 IngestResultTestData.defaultFileIngestResult("test1.parquet"),
                 IngestResultTestData.defaultFileIngestResult("test2.parquet"));
-        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE_NAME)).containsExactly(
+        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE)).containsExactly(
                 finishedIngestJob(job2, taskId, defaultSummary(startJob2Time, finishJob2Time)),
                 finishedIngestJob(job1, taskId, defaultSummary(startJob1Time, finishJob1Time)));
     }
@@ -185,7 +185,7 @@ public class IngestTaskTest {
         // Then
         assertThat(taskStatusStore.getAllTasks()).containsExactly(
                 finishedOneJob(taskId, startTaskTime, finishTaskTime, startJobTime, finishJobTime, 200, 100));
-        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE_NAME)).containsExactly(
+        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE)).containsExactly(
                 finishedIngestJob(job, taskId, summary(startJobTime, finishJobTime, 200, 100)));
     }
 
@@ -216,7 +216,7 @@ public class IngestTaskTest {
         assertThatThrownBy(() -> runTask(mockJobs, taskId, times)).isSameAs(failure);
         assertThat(taskStatusStore.getAllTasks()).containsExactly(
                 finishedOneJobOneFile(taskId, startTaskTime, finishTaskTime, startJob1Time, finishJob1Time));
-        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE_NAME)).containsExactly(
+        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE)).containsExactly(
                 finishedIngestJob(job1, taskId, defaultSummary(startJob1Time, finishJob1Time)));
     }
 
@@ -253,7 +253,7 @@ public class IngestTaskTest {
                         summary(startJob2Time, finishJob2Time, 0, 0)));
         assertThat(jobs.getIngestResults()).containsExactly(
                 IngestResultTestData.defaultFileIngestResult("test1.parquet"));
-        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE_NAME)).containsExactly(
+        assertThat(jobStatusStore.getAllJobs(DEFAULT_TABLE)).containsExactly(
                 finishedIngestJob(job2, taskId, summary(startJob2Time, finishJob2Time, 0, 0)),
                 finishedIngestJob(job1, taskId, defaultSummary(startJob1Time, finishJob1Time)));
     }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/ECSIngestTask.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/ECSIngestTask.java
@@ -33,6 +33,7 @@ import sleeper.configuration.jars.ObjectFactoryException;
 import sleeper.configuration.properties.PropertiesReloader;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
+import sleeper.configuration.table.index.DynamoDBTableIndex;
 import sleeper.core.iterator.IteratorException;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.ingest.impl.partitionfilewriter.AsyncS3PartitionFileWriterFactory;
@@ -119,7 +120,8 @@ public class ECSIngestTask {
                 s3AsyncClient,
                 hadoopConfiguration);
         IngestJobQueueConsumer queueConsumer = new IngestJobQueueConsumer(
-                sqsClient, cloudWatchClient, instanceProperties, hadoopConfiguration, jobStore);
+                sqsClient, cloudWatchClient, instanceProperties, hadoopConfiguration,
+                new DynamoDBTableIndex(instanceProperties, dynamoDBClient), jobStore);
         return new IngestTask(
                 queueConsumer, taskId, taskStore, jobStore, ingestJobRunner);
     }

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobQueueConsumer.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobQueueConsumer.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.core.iterator.IteratorException;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.core.table.TableIndex;
 import sleeper.ingest.IngestResult;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.job.common.action.ActionException;
@@ -68,6 +69,7 @@ public class IngestJobQueueConsumer implements IngestJobSource {
                                   AmazonCloudWatch cloudWatchClient,
                                   InstanceProperties instanceProperties,
                                   Configuration configuration,
+                                  TableIndex tableIndex,
                                   IngestJobStatusStore ingestJobStatusStore) {
         this.sqsClient = sqsClient;
         this.cloudWatchClient = cloudWatchClient;
@@ -75,14 +77,16 @@ public class IngestJobQueueConsumer implements IngestJobSource {
         this.sqsJobQueueUrl = instanceProperties.get(INGEST_JOB_QUEUE_URL);
         this.keepAlivePeriod = instanceProperties.getInt(INGEST_KEEP_ALIVE_PERIOD_IN_SECONDS);
         this.visibilityTimeoutInSeconds = instanceProperties.getInt(QUEUE_VISIBILITY_TIMEOUT_IN_SECONDS);
-        this.ingestJobMessageHandler = messageHandler(instanceProperties, configuration, ingestJobStatusStore).build();
+        this.ingestJobMessageHandler = messageHandler(instanceProperties, configuration, tableIndex, ingestJobStatusStore).build();
     }
 
     public static IngestJobMessageHandler.Builder<IngestJob> messageHandler(
             InstanceProperties instanceProperties,
             Configuration configuration,
+            TableIndex tableIndex,
             IngestJobStatusStore ingestJobStatusStore) {
         return IngestJobMessageHandler.forIngestJob()
+                .tableIndex(tableIndex)
                 .ingestJobStatusStore(ingestJobStatusStore)
                 .expandDirectories(files -> HadoopPathUtils.expandDirectories(files, configuration, instanceProperties));
     }

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/ECSIngestTaskIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/ECSIngestTaskIT.java
@@ -74,7 +74,7 @@ public class ECSIngestTaskIT extends IngestJobQueueConsumerTestBase {
                 .flatMap(List::stream).collect(Collectors.toList());
         String localDir = createTempDirectory(temporaryFolder, null).toString();
         StateStore stateStore = createTable(recordListAndSchema.sleeperSchema);
-        sendJobs(List.of(createJobWithTableAndFiles("job", tableName, files)));
+        sendJobs(List.of(createJobWithTableAndFiles("job", tableProperties.getId(), files)));
 
         // When
         runTask(localDir, "task");

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobMessageHandlerIT.java
@@ -175,7 +175,7 @@ public class IngestJobMessageHandlerIT {
             // Given
             String json = "{" +
                     "\"id\": \"id\"," +
-                    "\"tableName\": \"system-test\"," +
+                    "\"tableName\": \"test-table\"," +
                     "\"files\": [" +
                     "    \"test-bucket/not-a-file\"" +
                     "]}";
@@ -196,7 +196,7 @@ public class IngestJobMessageHandlerIT {
             uploadFileToS3("test-file.parquet");
             String json = "{" +
                     "\"id\": \"id\"," +
-                    "\"tableName\": \"system-test\"," +
+                    "\"tableName\": \"test-table\"," +
                     "\"files\": [" +
                     "    \"test-bucket/test-file.parquet\"," +
                     "    \"test-bucket/not-a-file\"" +
@@ -219,7 +219,9 @@ public class IngestJobMessageHandlerIT {
 
     private static IngestJob jobWithFiles(String... files) {
         return IngestJob.builder()
-                .id("id").tableName(TEST_TABLE).files(List.of(files)).build();
+                .id("id")
+                .tableName(TEST_TABLE).tableId(TEST_TABLE_ID)
+                .files(List.of(files)).build();
     }
 
     private static Configuration createHadoopConfiguration() {

--- a/java/ingest/ingest-status-store/pom.xml
+++ b/java/ingest/ingest-status-store/pom.xml
@@ -64,6 +64,13 @@
         </dependency>
         <dependency>
             <groupId>sleeper</groupId>
+            <artifactId>configuration</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>sleeper</groupId>
             <artifactId>statestore</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>

--- a/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusFormat.java
+++ b/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusFormat.java
@@ -27,7 +27,6 @@ import sleeper.core.record.process.status.ProcessStatusUpdate;
 import sleeper.core.record.process.status.ProcessStatusUpdateRecord;
 import sleeper.dynamodb.tools.DynamoDBAttributes;
 import sleeper.dynamodb.tools.DynamoDBRecordBuilder;
-import sleeper.ingest.job.IngestJob;
 import sleeper.ingest.job.status.IngestJobAcceptedStatus;
 import sleeper.ingest.job.status.IngestJobFinishedEvent;
 import sleeper.ingest.job.status.IngestJobRejectedStatus;
@@ -84,32 +83,38 @@ public class DynamoDBIngestJobStatusFormat {
     }
 
     public Map<String, AttributeValue> createJobValidatedRecord(IngestJobValidatedEvent event) {
-        return createJobRecord(event.getJob(), UPDATE_TYPE_VALIDATED)
+        return createRecord(UPDATE_TYPE_VALIDATED)
+                .string(JOB_ID, event.getJobId())
+                .string(TABLE_NAME, event.getTableName())
                 .number(VALIDATION_TIME, event.getValidationTime().toEpochMilli())
                 .bool(VALIDATION_RESULT, event.isAccepted())
                 .list(VALIDATION_REASONS, event.getReasons().stream()
                         .map(DynamoDBAttributes::createStringAttribute)
                         .collect(Collectors.toList()))
                 .string(JSON_MESSAGE, event.getJsonMessage())
-                .number(INPUT_FILES_COUNT, event.getJob().getFileCount())
+                .number(INPUT_FILES_COUNT, event.getFileCount())
                 .string(JOB_RUN_ID, event.getJobRunId())
                 .string(TASK_ID, event.getTaskId())
                 .build();
     }
 
     public Map<String, AttributeValue> createJobStartedRecord(IngestJobStartedEvent event) {
-        return createJobRecord(event.getJob(), UPDATE_TYPE_STARTED)
+        return createRecord(UPDATE_TYPE_STARTED)
+                .string(JOB_ID, event.getJobId())
+                .string(TABLE_NAME, event.getTableName())
                 .number(START_TIME, event.getStartTime().toEpochMilli())
                 .string(JOB_RUN_ID, event.getJobRunId())
                 .string(TASK_ID, event.getTaskId())
-                .number(INPUT_FILES_COUNT, event.getJob().getFileCount())
+                .number(INPUT_FILES_COUNT, event.getFileCount())
                 .bool(START_OF_RUN, event.isStartOfRun())
                 .build();
     }
 
     public Map<String, AttributeValue> createJobFinishedRecord(IngestJobFinishedEvent event) {
         RecordsProcessedSummary summary = event.getSummary();
-        return createJobRecord(event.getJob(), UPDATE_TYPE_FINISHED)
+        return createRecord(UPDATE_TYPE_FINISHED)
+                .string(JOB_ID, event.getJobId())
+                .string(TABLE_NAME, event.getTableName())
                 .number(START_TIME, summary.getStartTime().toEpochMilli())
                 .string(JOB_RUN_ID, event.getJobRunId())
                 .string(TASK_ID, event.getTaskId())
@@ -119,11 +124,9 @@ public class DynamoDBIngestJobStatusFormat {
                 .build();
     }
 
-    private DynamoDBRecordBuilder createJobRecord(IngestJob job, String updateType) {
+    private DynamoDBRecordBuilder createRecord(String updateType) {
         Instant timeNow = getTimeNow.get();
         return new DynamoDBRecordBuilder()
-                .string(JOB_ID, job.getId())
-                .string(TABLE_NAME, job.getTableName())
                 .number(UPDATE_TIME, timeNow.toEpochMilli())
                 .string(UPDATE_TYPE, updateType)
                 .number(EXPIRY_DATE, timeNow.getEpochSecond() + timeToLiveInSeconds);

--- a/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusFormat.java
+++ b/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusFormat.java
@@ -59,8 +59,8 @@ public class DynamoDBIngestJobStatusFormat {
     public static final String VALIDATION_RESULT = "Result";
     public static final String VALIDATION_REASONS = "ValidationReasons";
     public static final String JSON_MESSAGE = "JsonMessage";
-
     public static final String TABLE_NAME = "TableName";
+    public static final String TABLE_ID = "TableId";
     public static final String INPUT_FILES_COUNT = "InputFilesCount";
     public static final String START_OF_RUN = "StartOfRun";
     public static final String START_TIME = "StartTime";
@@ -86,6 +86,7 @@ public class DynamoDBIngestJobStatusFormat {
         return createRecord(UPDATE_TYPE_VALIDATED)
                 .string(JOB_ID, event.getJobId())
                 .string(TABLE_NAME, event.getTableName())
+                .string(TABLE_ID, event.getTableId())
                 .number(VALIDATION_TIME, event.getValidationTime().toEpochMilli())
                 .bool(VALIDATION_RESULT, event.isAccepted())
                 .list(VALIDATION_REASONS, event.getReasons().stream()
@@ -102,6 +103,7 @@ public class DynamoDBIngestJobStatusFormat {
         return createRecord(UPDATE_TYPE_STARTED)
                 .string(JOB_ID, event.getJobId())
                 .string(TABLE_NAME, event.getTableName())
+                .string(TABLE_ID, event.getTableId())
                 .number(START_TIME, event.getStartTime().toEpochMilli())
                 .string(JOB_RUN_ID, event.getJobRunId())
                 .string(TASK_ID, event.getTaskId())
@@ -115,6 +117,7 @@ public class DynamoDBIngestJobStatusFormat {
         return createRecord(UPDATE_TYPE_FINISHED)
                 .string(JOB_ID, event.getJobId())
                 .string(TABLE_NAME, event.getTableName())
+                .string(TABLE_ID, event.getTableId())
                 .number(START_TIME, summary.getStartTime().toEpochMilli())
                 .string(JOB_RUN_ID, event.getJobRunId())
                 .string(TASK_ID, event.getTaskId())

--- a/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusStore.java
+++ b/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusStore.java
@@ -171,8 +171,8 @@ public class DynamoDBIngestJobStatusStore implements IngestJobStatusStore {
 
     private ScanRequest createScanRequestByTable(TableIdentity tableId) {
         return createScanRequest()
-                .addScanFilterEntry(DynamoDBIngestJobStatusFormat.TABLE_NAME, new Condition()
-                        .withAttributeValueList(createStringAttribute(tableId.getTableName()))
+                .addScanFilterEntry(DynamoDBIngestJobStatusFormat.TABLE_ID, new Condition()
+                        .withAttributeValueList(createStringAttribute(tableId.getTableUniqueId()))
                         .withComparisonOperator(ComparisonOperator.EQ));
     }
 }

--- a/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusStore.java
+++ b/java/ingest/ingest-status-store/src/main/java/sleeper/ingest/status/store/job/DynamoDBIngestJobStatusStore.java
@@ -75,9 +75,9 @@ public class DynamoDBIngestJobStatusStore implements IngestJobStatusStore {
         try {
             PutItemResult result = putItem(format.createJobValidatedRecord(event));
             LOGGER.info("Put validated event for job {} to table {}, capacity consumed = {}",
-                    event.getJob().getId(), statusTableName, result.getConsumedCapacity().getCapacityUnits());
+                    event.getJobId(), statusTableName, result.getConsumedCapacity().getCapacityUnits());
         } catch (RuntimeException e) {
-            throw new IngestStatusStoreException("Failed putItem in jobValidated for job " + event.getJob().getId(), e);
+            throw new IngestStatusStoreException("Failed putItem in jobValidated for job " + event.getJobId(), e);
         }
     }
 
@@ -86,9 +86,9 @@ public class DynamoDBIngestJobStatusStore implements IngestJobStatusStore {
         try {
             PutItemResult result = putItem(format.createJobStartedRecord(event));
             LOGGER.info("Put started event for job {} to table {}, capacity consumed = {}",
-                    event.getJob().getId(), statusTableName, result.getConsumedCapacity().getCapacityUnits());
+                    event.getJobId(), statusTableName, result.getConsumedCapacity().getCapacityUnits());
         } catch (RuntimeException e) {
-            throw new IngestStatusStoreException("Failed putItem in jobStarted for job " + event.getJob().getId(), e);
+            throw new IngestStatusStoreException("Failed putItem in jobStarted for job " + event.getJobId(), e);
         }
     }
 
@@ -97,9 +97,9 @@ public class DynamoDBIngestJobStatusStore implements IngestJobStatusStore {
         try {
             PutItemResult result = putItem(format.createJobFinishedRecord(event));
             LOGGER.info("Put finished event for job {} to table {}, capacity consumed = {}",
-                    event.getJob().getId(), statusTableName, result.getConsumedCapacity().getCapacityUnits());
+                    event.getJobId(), statusTableName, result.getConsumedCapacity().getCapacityUnits());
         } catch (RuntimeException e) {
-            throw new IngestStatusStoreException("Failed putItem in jobFinished for job " + event.getJob().getId(), e);
+            throw new IngestStatusStoreException("Failed putItem in jobFinished for job " + event.getJobId(), e);
         }
     }
 

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryAllIngestJobsIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryAllIngestJobsIT.java
@@ -42,7 +42,7 @@ public class QueryAllIngestJobsIT extends DynamoDBIngestJobStatusStoreTestBase {
         store.jobStarted(defaultJobStartedEvent(job3, startedTime3));
 
         // Then
-        assertThat(store.getAllJobs(tableName))
+        assertThat(store.getAllJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(
                         defaultJobStartedStatus(job3, startedTime3),
@@ -63,7 +63,7 @@ public class QueryAllIngestJobsIT extends DynamoDBIngestJobStatusStoreTestBase {
         store.jobStarted(defaultJobStartedEvent(job2, startedTime2));
 
         // Then
-        assertThat(store.getAllJobs(tableName))
+        assertThat(store.getAllJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(defaultJobStartedStatus(job1, startedTime1));
     }
@@ -72,6 +72,6 @@ public class QueryAllIngestJobsIT extends DynamoDBIngestJobStatusStoreTestBase {
     public void shouldReturnNoIngestJobs() {
 
         // When / Then
-        assertThat(store.getAllJobs(tableName)).isEmpty();
+        assertThat(store.getAllJobs(tableId)).isEmpty();
     }
 }

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryIngestJobStatusByPeriodIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryIngestJobStatusByPeriodIT.java
@@ -47,7 +47,7 @@ public class QueryIngestJobStatusByPeriodIT extends DynamoDBIngestJobStatusStore
         // Then
         Instant epochStart = Instant.ofEpochMilli(0);
         Instant farFuture = epochStart.plus(Period.ofDays(999999999));
-        assertThat(store.getJobsInTimePeriod(tableName, epochStart, farFuture))
+        assertThat(store.getJobsInTimePeriod(tableId, epochStart, farFuture))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_EXPIRY_DATE)
                 .containsExactly(
                         defaultJobStartedStatus(job2, startedTime2),
@@ -68,7 +68,7 @@ public class QueryIngestJobStatusByPeriodIT extends DynamoDBIngestJobStatusStore
         store.jobStarted(defaultJobStartedEvent(job, startedTime));
 
         // Then
-        assertThat(store.getJobsInTimePeriod(tableName, periodStart, periodEnd)).isEmpty();
+        assertThat(store.getJobsInTimePeriod(tableId, periodStart, periodEnd)).isEmpty();
     }
 
     @Test
@@ -89,7 +89,7 @@ public class QueryIngestJobStatusByPeriodIT extends DynamoDBIngestJobStatusStore
         // Then
         Instant epochStart = Instant.ofEpochMilli(0);
         Instant farFuture = epochStart.plus(Period.ofDays(999999999));
-        assertThat(store.getJobsInTimePeriod(tableName, epochStart, farFuture))
+        assertThat(store.getJobsInTimePeriod(tableId, epochStart, farFuture))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_EXPIRY_DATE)
                 .containsExactly(defaultJobStartedStatus(job1, startedTime1));
     }
@@ -111,7 +111,7 @@ public class QueryIngestJobStatusByPeriodIT extends DynamoDBIngestJobStatusStore
         store.jobFinished(defaultJobFinishedEvent(job, startedTime, finishedTime));
 
         // Then
-        assertThat(store.getJobsInTimePeriod(tableName, periodStart, periodEnd))
+        assertThat(store.getJobsInTimePeriod(tableId, periodStart, periodEnd))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_EXPIRY_DATE)
                 .containsExactly(defaultJobFinishedStatus(job, startedTime, finishedTime));
     }
@@ -130,7 +130,7 @@ public class QueryIngestJobStatusByPeriodIT extends DynamoDBIngestJobStatusStore
         store.jobValidated(ingestJobRejected(job, rejectedTime, "Test reason"));
 
         // Then
-        assertThat(store.getJobsInTimePeriod(tableName, periodStart, periodEnd))
+        assertThat(store.getJobsInTimePeriod(tableId, periodStart, periodEnd))
                 .isEmpty();
     }
 }

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryIngestJobStatusByTaskIdIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryIngestJobStatusByTaskIdIT.java
@@ -44,7 +44,7 @@ public class QueryIngestJobStatusByTaskIdIT extends DynamoDBIngestJobStatusStore
         store.jobStarted(ingestJobStarted("another-task", job2, startedTime2));
 
         // Then
-        assertThat(store.getJobsByTaskId(tableName, searchingTaskId))
+        assertThat(store.getJobsByTaskId(tableId, searchingTaskId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(startedIngestJob(job1, searchingTaskId, startedTime1));
     }
@@ -66,7 +66,7 @@ public class QueryIngestJobStatusByTaskIdIT extends DynamoDBIngestJobStatusStore
         store.jobStarted(ingestJobStarted(taskId3, job, startedTime3));
 
         // Then
-        assertThat(store.getJobsByTaskId(tableName, searchingTaskId))
+        assertThat(store.getJobsByTaskId(tableId, searchingTaskId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(jobStatus(job,
                         startedIngestRun(job, taskId3, startedTime3),
@@ -77,6 +77,6 @@ public class QueryIngestJobStatusByTaskIdIT extends DynamoDBIngestJobStatusStore
     @Test
     public void shouldReturnNoIngestJobsByTaskId() {
         // When / Then
-        assertThat(store.getJobsByTaskId(tableName, "not-present")).isNullOrEmpty();
+        assertThat(store.getJobsByTaskId(tableId, "not-present")).isNullOrEmpty();
     }
 }

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryIngestJobStatusUnfinishedIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/QueryIngestJobStatusUnfinishedIT.java
@@ -40,7 +40,7 @@ public class QueryIngestJobStatusUnfinishedIT extends DynamoDBIngestJobStatusSto
         store.jobStarted(defaultJobStartedEvent(job2, startedTime2));
 
         // Then
-        assertThat(store.getUnfinishedJobs(tableName))
+        assertThat(store.getUnfinishedJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(
                         defaultJobStartedStatus(job2, startedTime2),
@@ -62,7 +62,7 @@ public class QueryIngestJobStatusUnfinishedIT extends DynamoDBIngestJobStatusSto
         store.jobStarted(defaultJobStartedEvent(job2, startedTime2));
 
         // Then
-        assertThat(store.getUnfinishedJobs(tableName))
+        assertThat(store.getUnfinishedJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(defaultJobStartedStatus(job2, startedTime2));
     }
@@ -80,7 +80,7 @@ public class QueryIngestJobStatusUnfinishedIT extends DynamoDBIngestJobStatusSto
         store.jobStarted(defaultJobStartedEvent(job2, startedTime2));
 
         // Then
-        assertThat(store.getUnfinishedJobs(tableName))
+        assertThat(store.getUnfinishedJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(defaultJobStartedStatus(job1, startedTime1));
     }
@@ -99,7 +99,7 @@ public class QueryIngestJobStatusUnfinishedIT extends DynamoDBIngestJobStatusSto
         store.jobStarted(defaultJobStartedEvent(job, startedTime2));
 
         // Then
-        assertThat(store.getUnfinishedJobs(tableName))
+        assertThat(store.getUnfinishedJobs(tableId))
                 .usingRecursiveFieldByFieldElementComparator(IGNORE_UPDATE_TIMES)
                 .containsExactly(jobStatus(job,
                         defaultJobStartedRun(job, startedTime2),

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobRunIdIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobRunIdIT.java
@@ -33,6 +33,7 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRun;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunWhichFinished;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunWhichStarted;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
+import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
 
 public class StoreIngestJobRunIdIT extends DynamoDBIngestJobStatusStoreTestBase {
     @Test

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobRunIdIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobRunIdIT.java
@@ -33,14 +33,12 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRun;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunWhichFinished;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunWhichStarted;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
-import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
 
 public class StoreIngestJobRunIdIT extends DynamoDBIngestJobStatusStoreTestBase {
     @Test
     void shouldReportAcceptedJob() {
         // Given
-        String tableName = "test-table";
-        IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+        IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
         Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
         // When
@@ -55,10 +53,9 @@ public class StoreIngestJobRunIdIT extends DynamoDBIngestJobStatusStoreTestBase 
     @Test
     void shouldReportStartedJob() {
         // Given
-        String tableName = "test-table";
         String jobRunId = "test-run";
         String taskId = "test-task";
-        IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+        IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
         Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
         Instant startTime = Instant.parse("2022-09-22T12:00:15.000Z");
 
@@ -76,10 +73,9 @@ public class StoreIngestJobRunIdIT extends DynamoDBIngestJobStatusStoreTestBase 
     @Test
     void shouldReportFinishedJob() {
         // Given
-        String tableName = "test-table";
         String jobRunId = "test-run";
         String taskId = "test-task";
-        IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+        IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
         Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
         Instant startTime = Instant.parse("2022-09-22T12:00:15.000Z");
         RecordsProcessedSummary summary = summary(startTime, Duration.ofMinutes(10), 100L, 100L);

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobValidatedIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobValidatedIT.java
@@ -31,16 +31,14 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunOnTas
 import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunWhichStarted;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.rejectedRun;
-import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
 import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobRejected;
 
 public class StoreIngestJobValidatedIT extends DynamoDBIngestJobStatusStoreTestBase {
     @Test
     void shouldReportUnstartedJobWithNoValidationFailures() {
         // Given
-        String tableName = "test-table";
         String taskId = "some-task";
-        IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+        IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
         Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
         // When
@@ -55,9 +53,8 @@ public class StoreIngestJobValidatedIT extends DynamoDBIngestJobStatusStoreTestB
     @Test
     void shouldReportStartedJobWithNoValidationFailures() {
         // Given
-        String tableName = "test-table";
         String taskId = "some-task";
-        IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+        IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
         Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
         Instant startTime = Instant.parse("2022-09-22T12:00:15.000Z");
 
@@ -75,8 +72,7 @@ public class StoreIngestJobValidatedIT extends DynamoDBIngestJobStatusStoreTestB
     @Test
     void shouldReportJobWithOneValidationFailure() {
         // Given
-        String tableName = "test-table";
-        IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+        IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
         Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
         // When
@@ -92,8 +88,7 @@ public class StoreIngestJobValidatedIT extends DynamoDBIngestJobStatusStoreTestB
     @Test
     void shouldReportJobWithMultipleValidationFailures() {
         // Given
-        String tableName = "test-table";
-        IngestJob job = createJobWithTableAndFiles("test-job-1", tableName, "test-file-1.parquet");
+        IngestJob job = createJobWithTableAndFiles("test-job-1", tableId, "test-file-1.parquet");
         Instant validationTime = Instant.parse("2022-09-22T12:00:10.000Z");
 
         // When

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobValidatedIT.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/job/StoreIngestJobValidatedIT.java
@@ -31,6 +31,7 @@ import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunOnTas
 import static sleeper.ingest.job.status.IngestJobStatusTestData.acceptedRunWhichStarted;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.rejectedRun;
+import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
 import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobRejected;
 
 public class StoreIngestJobValidatedIT extends DynamoDBIngestJobStatusStoreTestBase {

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
@@ -155,7 +155,7 @@ public class DynamoDBIngestJobStatusStoreTestBase extends DynamoDBTestBase {
     }
 
     protected IngestJob jobWithFiles(String... filenames) {
-        return jobWithTableAndFiles(tableName, filenames);
+        return IngestJobTestData.createJobWithTableAndFiles(UUID.randomUUID().toString(), tableName, filenames);
     }
 
     protected IngestJob jobWithTableAndFiles(String tableName, String... filenames) {

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
@@ -152,7 +152,7 @@ public class DynamoDBIngestJobStatusStoreTestBase extends DynamoDBTestBase {
     }
 
     protected List<IngestJobStatus> getAllJobStatuses() {
-        return store.getAllJobs(tableName);
+        return store.getAllJobs(tableId);
     }
 
     protected IngestJob jobWithFiles(String... filenames) {

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
@@ -75,6 +75,7 @@ public class DynamoDBIngestJobStatusStoreTestBase extends DynamoDBTestBase {
     private final TableIndex tableIndex = new InMemoryTableIndex();
 
     protected final String tableName = tableProperties.get(TABLE_NAME);
+    protected final TableIdentity tableId = tableProperties.getId();
     protected final IngestJobStatusStore store = IngestJobStatusStoreFactory.getStatusStore(dynamoDBClient, instanceProperties);
 
     @BeforeEach
@@ -155,16 +156,18 @@ public class DynamoDBIngestJobStatusStoreTestBase extends DynamoDBTestBase {
     }
 
     protected IngestJob jobWithFiles(String... filenames) {
-        return IngestJobTestData.createJobWithTableAndFiles(UUID.randomUUID().toString(), tableName, filenames);
+        return IngestJobTestData.createJobWithTableAndFiles(UUID.randomUUID().toString(), tableId, filenames);
     }
 
     protected IngestJob jobWithTableAndFiles(String tableName, String... filenames) {
-        createTable(tableName);
-        return IngestJobTestData.createJobWithTableAndFiles(UUID.randomUUID().toString(), tableName, filenames);
+        TableIdentity table = createTable(tableName);
+        return IngestJobTestData.createJobWithTableAndFiles(UUID.randomUUID().toString(), table, filenames);
     }
 
-    private void createTable(String tableName) {
-        tableIndex.create(TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName));
+    private TableIdentity createTable(String tableName) {
+        TableIdentity id = TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
+        tableIndex.create(id);
+        return id;
     }
 
     protected IngestJobValidatedEvent.Builder ingestJobAccepted(IngestJob job, Instant validationTime) {

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/DynamoDBIngestJobStatusStoreTestBase.java
@@ -26,8 +26,8 @@ import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.record.process.status.ProcessRun;
 import sleeper.core.schema.Schema;
 import sleeper.core.table.InMemoryTableIndex;
-import sleeper.core.table.TableId;
 import sleeper.core.table.TableIdGenerator;
+import sleeper.core.table.TableIdentity;
 import sleeper.core.table.TableIndex;
 import sleeper.dynamodb.tools.DynamoDBTestBase;
 import sleeper.ingest.job.IngestJob;
@@ -164,14 +164,14 @@ public class DynamoDBIngestJobStatusStoreTestBase extends DynamoDBTestBase {
     }
 
     private void createTable(String tableName) {
-        tableIndex.create(TableId.uniqueIdAndName(new TableIdGenerator().generateString(), tableName));
+        tableIndex.create(TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName));
     }
 
     protected IngestJobValidatedEvent.Builder ingestJobAccepted(IngestJob job, Instant validationTime) {
         return IngestJobValidatedEvent.ingestJobAccepted(job, tableId(job), validationTime);
     }
 
-    private TableId tableId(IngestJob job) {
+    private TableIdentity tableId(IngestJob job) {
         return tableIndex.getTableByName(job.getTableName()).orElseThrow();
     }
 }

--- a/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/IngestStatusStoreTestUtils.java
+++ b/java/ingest/ingest-status-store/src/test/java/sleeper/ingest/status/store/testutils/IngestStatusStoreTestUtils.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.instance.CommonProperty.FILE_SYSTEM;
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
+import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
 public class IngestStatusStoreTestUtils {
@@ -47,9 +48,8 @@ public class IngestStatusStoreTestUtils {
     }
 
     public static TableProperties createTableProperties(Schema schema, InstanceProperties instanceProperties) {
-        TableProperties tableProperties = new TableProperties(instanceProperties);
+        TableProperties tableProperties = createTestTableProperties(instanceProperties, schema);
         tableProperties.set(TABLE_NAME, "test-table");
-        tableProperties.setSchema(schema);
         return tableProperties;
     }
 }

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/util/WaitForJobsStatusTest.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/util/WaitForJobsStatusTest.java
@@ -20,13 +20,9 @@ import org.junit.jupiter.api.Test;
 
 import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.testutils.CompactionJobStatusStoreInMemory;
-import sleeper.core.table.InMemoryTableIndex;
-import sleeper.core.table.TableIdGenerator;
 import sleeper.core.table.TableIdentity;
-import sleeper.core.table.TableIndex;
 import sleeper.ingest.job.IngestJob;
 import sleeper.ingest.job.status.IngestJobStatusStore;
-import sleeper.ingest.job.status.IngestJobValidatedEvent;
 import sleeper.ingest.job.status.WriteToMemoryIngestJobStatusStore;
 
 import java.time.Duration;
@@ -38,11 +34,11 @@ import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summar
 import static sleeper.ingest.job.IngestJobTestData.createJobWithTableAndFiles;
 import static sleeper.ingest.job.status.IngestJobFinishedEvent.ingestJobFinished;
 import static sleeper.ingest.job.status.IngestJobStartedEvent.validatedIngestJobStarted;
+import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
 
 public class WaitForJobsStatusTest {
 
-    private final TableIndex tableIndex = new InMemoryTableIndex();
-    private final TableIdentity tableId = createTable("test-table");
+    private final TableIdentity tableId = TableIdentity.uniqueIdAndName("test-table-id", "test-table");
 
     @Test
     void shouldReportSeveralBulkImportJobs() {
@@ -119,15 +115,5 @@ public class WaitForJobsStatusTest {
                 .outputFile(id + "/outputFile")
                 .isSplittingJob(false)
                 .partitionId(id + "-partition").build();
-    }
-
-    private TableIdentity createTable(String tableName) {
-        TableIdentity tableId = TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
-        tableIndex.create(tableId);
-        return tableId;
-    }
-
-    private IngestJobValidatedEvent.Builder ingestJobAccepted(IngestJob job, Instant validationTime) {
-        return IngestJobValidatedEvent.ingestJobAccepted(job, tableIndex.getTableByName(job.getTableName()).orElseThrow(), validationTime);
     }
 }

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/util/WaitForJobsStatusTest.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/util/WaitForJobsStatusTest.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.Test;
 import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.testutils.CompactionJobStatusStoreInMemory;
 import sleeper.core.table.InMemoryTableIndex;
-import sleeper.core.table.TableId;
 import sleeper.core.table.TableIdGenerator;
+import sleeper.core.table.TableIdentity;
 import sleeper.core.table.TableIndex;
 import sleeper.ingest.job.IngestJob;
 import sleeper.ingest.job.status.IngestJobStatusStore;
@@ -42,7 +42,7 @@ import static sleeper.ingest.job.status.IngestJobStartedEvent.validatedIngestJob
 public class WaitForJobsStatusTest {
 
     private final TableIndex tableIndex = new InMemoryTableIndex();
-    private final TableId tableId = createTable("test-table");
+    private final TableIdentity tableId = createTable("test-table");
     private final String tableName = tableId.getTableName();
 
     @Test
@@ -122,8 +122,8 @@ public class WaitForJobsStatusTest {
                 .partitionId(id + "-partition").build();
     }
 
-    private TableId createTable(String tableName) {
-        TableId tableId = TableId.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
+    private TableIdentity createTable(String tableName) {
+        TableIdentity tableId = TableIdentity.uniqueIdAndName(new TableIdGenerator().generateString(), tableName);
         tableIndex.create(tableId);
         return tableId;
     }

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/util/WaitForJobsStatusTest.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/util/WaitForJobsStatusTest.java
@@ -43,15 +43,14 @@ public class WaitForJobsStatusTest {
 
     private final TableIndex tableIndex = new InMemoryTableIndex();
     private final TableIdentity tableId = createTable("test-table");
-    private final String tableName = tableId.getTableName();
 
     @Test
     void shouldReportSeveralBulkImportJobs() {
         // Given
         IngestJobStatusStore store = new WriteToMemoryIngestJobStatusStore();
-        IngestJob acceptedJob = createJobWithTableAndFiles("accepted-job", tableName, "test.parquet", "test2.parquet");
-        IngestJob startedJob = createJobWithTableAndFiles("started-job", tableName, "test3.parquet", "test4.parquet");
-        IngestJob finishedJob = createJobWithTableAndFiles("finished-job", tableName, "test3.parquet", "test4.parquet");
+        IngestJob acceptedJob = createJobWithTableAndFiles("accepted-job", tableId, "test.parquet", "test2.parquet");
+        IngestJob startedJob = createJobWithTableAndFiles("started-job", tableId, "test3.parquet", "test4.parquet");
+        IngestJob finishedJob = createJobWithTableAndFiles("finished-job", tableId, "test3.parquet", "test4.parquet");
         store.jobValidated(ingestJobAccepted(acceptedJob, Instant.parse("2022-09-22T13:33:10Z")).jobRunId("accepted-run").build());
         store.jobValidated(ingestJobAccepted(startedJob, Instant.parse("2022-09-22T13:33:11Z")).jobRunId("started-run").build());
         store.jobValidated(ingestJobAccepted(finishedJob, Instant.parse("2022-09-22T13:33:12Z")).jobRunId("finished-run").build());


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1465

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests
    - Updated IngestJobMessageHandlerTest to add table lookup
    - Updated lots of tests to set both table ID and table name on ingest & bulk import jobs, status store queries
    - Removed some test cases for validating table name against bulk import job, as this is now done in IngestJobMessageHandler, affecting these test classes:
      - BulkImportExecutorIT
      - BulkImportStarterLambdaTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.