### PR TITLE
Issue 1491 - Fix EMR Serverless bulk import

### DIFF
--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportArguments.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportArguments.java
@@ -92,7 +92,8 @@ public class BulkImportArguments {
 
     private static Optional<String> mergeSparkValue(
             String key, Map<String, String> baseConfig, Map<String, String> userConfig) {
-        return Stream.of(userConfig.get(key), baseConfig.get(key))
+        return Stream.of(userConfig, baseConfig)
+                .map(config -> config.get(key))
                 .filter(Objects::nonNull)
                 .findFirst();
     }

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrPlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrPlatformExecutor.java
@@ -110,7 +110,7 @@ public class EmrPlatformExecutor implements PlatformExecutor {
                 .withSteps(new StepConfig()
                         .withName("Bulk Load (job id " + bulkImportJob.getId() + ")")
                         .withHadoopJarStep(new HadoopJarStepConfig().withJar("command-runner.jar")
-                                .withArgs(arguments.constructArgs(
+                                .withArgs(arguments.sparkSubmitCommandForCluster(
                                         clusterName + "-EMR",
                                         EmrJarLocation.getJarLocation(instanceProperties)))))
                 .withTags(instanceProperties.getTags().entrySet().stream()

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutor.java
@@ -28,6 +28,7 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_BUCKET;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_APPLICATION_ID;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_CLUSTER_NAME;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_CLUSTER_ROLE_ARN;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 
@@ -48,6 +49,7 @@ public class EmrServerlessPlatformExecutor implements PlatformExecutor {
     public void runJobOnPlatform(BulkImportArguments arguments) {
         BulkImportJob bulkImportJob = arguments.getBulkImportJob();
         String jobName = String.join("-", "job", arguments.getJobRunId());
+        String applicationName = instanceProperties.get(BULK_IMPORT_EMR_SERVERLESS_CLUSTER_NAME);
         String applicationId = instanceProperties.get(BULK_IMPORT_EMR_SERVERLESS_APPLICATION_ID);
 
         StartJobRunRequest job = StartJobRunRequest.builder()
@@ -58,7 +60,7 @@ public class EmrServerlessPlatformExecutor implements PlatformExecutor {
                 .jobDriver(JobDriver.builder().sparkSubmit(SparkSubmit.builder()
                         .entryPoint("/workdir/bulk-import-runner.jar")
                         .entryPointArguments(instanceProperties.get(CONFIG_BUCKET),
-                                bulkImportJob.getId(), applicationId + "-EMRS", arguments.getJobRunId())
+                                bulkImportJob.getId(), applicationName + "-EMRS", arguments.getJobRunId())
                         .sparkSubmitParameters(arguments.sparkSubmitParametersForServerless())
                         .build()).build())
                 .configurationOverrides(

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutor.java
@@ -23,24 +23,11 @@ import software.amazon.awssdk.services.emrserverless.model.S3MonitoringConfigura
 import software.amazon.awssdk.services.emrserverless.model.SparkSubmit;
 import software.amazon.awssdk.services.emrserverless.model.StartJobRunRequest;
 
-import sleeper.bulkimport.configuration.BulkImportPlatformSpec;
-import sleeper.bulkimport.configuration.ConfigurationUtils;
 import sleeper.bulkimport.job.BulkImportJob;
 import sleeper.configuration.properties.instance.InstanceProperties;
-import sleeper.configuration.properties.table.TableProperties;
-import sleeper.configuration.properties.table.TablePropertiesProvider;
-import sleeper.configuration.properties.validation.EmrInstanceArchitecture;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_BUCKET;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_APPLICATION_ID;
-import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_CLUSTER_NAME;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_CLUSTER_ROLE_ARN;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
@@ -51,29 +38,17 @@ import static sleeper.configuration.properties.instance.CommonProperty.ID;
 public class EmrServerlessPlatformExecutor implements PlatformExecutor {
     private final EmrServerlessClient emrClient;
     private final InstanceProperties instanceProperties;
-    private final TablePropertiesProvider tablePropertiesProvider;
 
     public EmrServerlessPlatformExecutor(EmrServerlessClient emrClient,
-                                         InstanceProperties instanceProperties,
-                                         TablePropertiesProvider tablePropertiesProvider) {
+                                         InstanceProperties instanceProperties) {
         this.emrClient = emrClient;
         this.instanceProperties = instanceProperties;
-        this.tablePropertiesProvider = tablePropertiesProvider;
     }
 
     @Override
     public void runJobOnPlatform(BulkImportArguments arguments) {
         BulkImportJob bulkImportJob = arguments.getBulkImportJob();
-        TableProperties tableProperties = tablePropertiesProvider
-                .getByName(bulkImportJob.getTableName());
-        BulkImportPlatformSpec platformSpec = new BulkImportPlatformSpec(tableProperties,
-                bulkImportJob);
-        String bulkImportBucket = instanceProperties.get(BULK_IMPORT_BUCKET);
-        String clusterName = instanceProperties.get(BULK_IMPORT_EMR_SERVERLESS_CLUSTER_NAME);
         String jobName = String.join("-", "job", arguments.getJobRunId());
-        String logUri = bulkImportBucket.isEmpty() ? "s3://" + clusterName
-                : "s3://" + bulkImportBucket;
-
         String taskId = String.join("-", "sleeper", instanceProperties.get(ID),
                 bulkImportJob.getTableName(), bulkImportJob.getId());
 
@@ -90,49 +65,17 @@ public class EmrServerlessPlatformExecutor implements PlatformExecutor {
                         .entryPoint("/workdir/bulk-import-runner.jar")
                         .entryPointArguments(instanceProperties.get(CONFIG_BUCKET),
                                 bulkImportJob.getId(), taskId, arguments.getJobRunId())
-                        .sparkSubmitParameters(
-                                constructSparkArgs(taskId, arguments, bulkImportJob, platformSpec))
+                        .sparkSubmitParameters(arguments.sparkSubmitParametersForServerless())
                         .build()).build())
                 .configurationOverrides(
                         ConfigurationOverrides.builder()
                                 .monitoringConfiguration(MonitoringConfiguration.builder()
-                                        .s3MonitoringConfiguration(S3MonitoringConfiguration
-                                                .builder().logUri(logUri).build())
+                                        .s3MonitoringConfiguration(S3MonitoringConfiguration.builder()
+                                                .logUri("s3://" + instanceProperties.get(BULK_IMPORT_BUCKET))
+                                                .build())
                                         .build())
                                 .build())
                 .build();
         emrClient.startJobRun(job);
-    }
-
-    private String constructSparkArgs(String taskId, BulkImportArguments arguments,
-                                      BulkImportJob bulkImportJob, BulkImportPlatformSpec platformSpec) {
-        Map<String, String> instancePropertiesSparkConf = ConfigurationUtils
-                .getSparkServerlessConfigurationFromInstanceProperties(instanceProperties,
-                        EmrInstanceArchitecture.X86_64);
-
-        Map<String, String> jobSparkArgs = arguments.getBulkImportJob().getSparkConf();
-        if (jobSparkArgs != null) {
-            jobSparkArgs = jobSparkArgs.entrySet()
-                    .stream().filter(prop -> prop.getKey().contains("sleeper.bulk.import.emr.serverless.spark"))
-                    .map(i -> Map.entry(
-                            i.getKey().split("sleeper\\.bulk\\.import\\.emr\\.serverless\\.")[1],
-                            i.getValue()))
-                    .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-
-            Map<String, String> sparkConf = Stream
-                    .of(instancePropertiesSparkConf, jobSparkArgs)
-                    .flatMap(map -> map.entrySet().stream())
-                    .collect(Collectors.toMap(Map.Entry::getKey,
-                            Map.Entry::getValue, (m1, m2) -> m2, HashMap::new));
-            bulkImportJob = bulkImportJob.toBuilder().sparkConf(sparkConf).build();
-        }
-
-        List<String> args = arguments.constructArgs(bulkImportJob, taskId);
-
-        StringBuilder argsAsString = new StringBuilder();
-        args.forEach(arg -> {
-            argsAsString.append(arg).append(" ");
-        });
-        return argsAsString.toString();
     }
 }

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/PersistentEmrPlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/PersistentEmrPlatformExecutor.java
@@ -57,7 +57,7 @@ public class PersistentEmrPlatformExecutor implements PlatformExecutor {
                 .withName("Bulk Load (job id " + arguments.getBulkImportJob().getId() + ")")
                 .withActionOnFailure(ActionOnFailure.CONTINUE)
                 .withHadoopJarStep(new HadoopJarStepConfig().withJar("command-runner.jar")
-                        .withArgs(arguments.constructArgs(
+                        .withArgs(arguments.sparkSubmitCommandForCluster(
                                 clusterName, EmrJarLocation.getJarLocation(instanceProperties))));
         AddJobFlowStepsRequest addJobFlowStepsRequest = new AddJobFlowStepsRequest()
                 .withJobFlowId(clusterId)

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/PlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/PlatformExecutor.java
@@ -44,7 +44,7 @@ public interface PlatformExecutor {
                         AmazonElasticMapReduceClientBuilder.defaultClient(),
                         instanceProperties);
             case "EMRServerless":
-                return new EmrServerlessPlatformExecutor(EmrServerlessClient.create(), instanceProperties, tablePropertiesProvider);
+                return new EmrServerlessPlatformExecutor(EmrServerlessClient.create(), instanceProperties);
             default:
                 throw new IllegalArgumentException("Invalid platform: " + platform);
         }

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
@@ -145,7 +145,7 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
                 .platformSpec(bulkImportJob.getPlatformSpec())
                 .sparkConf(sparkProperties)
                 .build();
-        return arguments.constructArgs(cloneWithUpdatedProps, taskId, jarLocation);
+        return arguments.sparkSubmitCommandForCluster(cloneWithUpdatedProps, taskId, jarLocation);
     }
 
     private static String jobPodPrefix(BulkImportJob job) {

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
@@ -117,35 +117,21 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
 
     private List<String> constructArgs(BulkImportArguments arguments, String taskId) {
         BulkImportJob bulkImportJob = arguments.getBulkImportJob();
-        Map<String, String> sparkProperties = getDefaultSparkConfig(bulkImportJob);
-
-        // Create Spark conf by copying DEFAULT_CONFIG and over-writing any entries
-        // which have been specified in the Spark conf on the bulk import job.
-        if (null != bulkImportJob.getSparkConf()) {
-            sparkProperties.putAll(bulkImportJob.getSparkConf());
-        }
+        Map<String, String> baseSparkConfig = getDefaultSparkConfig(bulkImportJob);
 
         // Point to locations in the Docker image
         String jarLocation;
         if (instanceProperties.getBoolean(EKS_IS_NATIVE_LIBS_IMAGE)) {
-            sparkProperties.put("spark.executorEnv.JAVA_HOME", NATIVE_IMAGE_JAVA_HOME);
-            sparkProperties.put("spark.driver.extraJavaOptions", "-Dlog4j.configuration=" + NATIVE_IMAGE_LOG4J_LOCATION);
-            sparkProperties.put("spark.executor.extraJavaOptions", "-Dlog4j.configuration=" + NATIVE_IMAGE_LOG4J_LOCATION);
+            baseSparkConfig.put("spark.executorEnv.JAVA_HOME", NATIVE_IMAGE_JAVA_HOME);
+            baseSparkConfig.put("spark.driver.extraJavaOptions", "-Dlog4j.configuration=" + NATIVE_IMAGE_LOG4J_LOCATION);
+            baseSparkConfig.put("spark.executor.extraJavaOptions", "-Dlog4j.configuration=" + NATIVE_IMAGE_LOG4J_LOCATION);
             jarLocation = NATIVE_IMAGE_JAR_LOCATION;
         } else {
-            sparkProperties.put("spark.executorEnv.JAVA_HOME", SPARK_IMAGE_JAVA_HOME);
+            baseSparkConfig.put("spark.executorEnv.JAVA_HOME", SPARK_IMAGE_JAVA_HOME);
             jarLocation = SPARK_IMAGE_JAR_LOCATION;
         }
 
-        BulkImportJob cloneWithUpdatedProps = new BulkImportJob.Builder()
-                .className(bulkImportJob.getClassName())
-                .files(bulkImportJob.getFiles())
-                .id(bulkImportJob.getId())
-                .tableName(bulkImportJob.getTableName())
-                .platformSpec(bulkImportJob.getPlatformSpec())
-                .sparkConf(sparkProperties)
-                .build();
-        return arguments.sparkSubmitCommandForCluster(cloneWithUpdatedProps, taskId, jarLocation);
+        return arguments.sparkSubmitCommandForCluster(taskId, jarLocation, baseSparkConfig);
     }
 
     private static String jobPodPrefix(BulkImportJob job) {

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportArgumentsTest.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportArgumentsTest.java
@@ -50,7 +50,7 @@ public class BulkImportArgumentsTest {
                 .build();
 
         // When / Then
-        assertThat(arguments.constructArgs("test-task", "s3a://jarsBucket/bulk-import-runner-1.2.3.jar"))
+        assertThat(arguments.sparkSubmitCommandForCluster("test-task", "s3a://jarsBucket/bulk-import-runner-1.2.3.jar"))
                 .containsExactly("spark-submit",
                         "--deploy-mode",
                         "cluster",

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutorIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutorIT.java
@@ -56,7 +56,6 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_CLUSTER_ROLE_ARN;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
-import static sleeper.configuration.properties.instance.EMRServerlessProperty.BULK_IMPORT_EMR_SERVERLESS_EXECUTOR_DISK;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
@@ -118,7 +117,7 @@ public class EmrServerlessPlatformExecutorIT {
                 .id("my-job")
                 .files(List.of("file.parquet"))
                 .tableName("table-name")
-                .sparkConf(BULK_IMPORT_EMR_SERVERLESS_EXECUTOR_DISK.getPropertyName(), "100G")
+                .sparkConf("spark.emr-serverless.executor.disk", "100G")
                 .build();
         BulkImportArguments arguments = BulkImportArguments.builder()
                 .instanceProperties(instanceProperties)
@@ -132,7 +131,7 @@ public class EmrServerlessPlatformExecutorIT {
                 .withRequestBody(equalToJson(
                         exampleString("example/emr-serverless/jobrun-request.json"), false, true))
                 .withRequestBody(matchingJsonPath("$.jobDriver.sparkSubmit.sparkSubmitParameters",
-                        containing("spark.emr-serverless.executor.disk=100G"))));
+                        containing(" --conf spark.emr-serverless.executor.disk=100G "))));
     }
 
     private EmrServerlessPlatformExecutor executor(WireMockRuntimeInfo runtimeInfo) {

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutorIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutorIT.java
@@ -29,7 +29,6 @@ import software.amazon.awssdk.services.emrserverless.EmrServerlessClient;
 
 import sleeper.bulkimport.job.BulkImportJob;
 import sleeper.configuration.properties.instance.InstanceProperties;
-import sleeper.configuration.properties.table.TableProperties;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -56,9 +55,6 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_CLUSTER_ROLE_ARN;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
-import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
-import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
-import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 
 @WireMockTest
 public class EmrServerlessPlatformExecutorIT {
@@ -67,7 +63,6 @@ public class EmrServerlessPlatformExecutorIT {
     public static final String WIREMOCK_SECRET_KEY = "wiremock-secret-key";
 
     private final InstanceProperties instanceProperties = createTestInstanceProperties();
-    private final TableProperties tableProperties = createTestTableProperties(instanceProperties, schemaWithKey("key"));
 
     @BeforeEach
     void setUp() {
@@ -78,7 +73,6 @@ public class EmrServerlessPlatformExecutorIT {
         instanceProperties.set(BULK_IMPORT_EMR_SERVERLESS_APPLICATION_ID, "application-id");
         instanceProperties.set(BULK_IMPORT_EMR_SERVERLESS_CLUSTER_ROLE_ARN, "cluster-role");
         instanceProperties.set(BULK_IMPORT_CLASS_NAME, "BulkImportClass");
-        tableProperties.set(TABLE_NAME, "table-name");
     }
 
     @Test

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutorIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/EmrServerlessPlatformExecutorIT.java
@@ -69,7 +69,7 @@ public class EmrServerlessPlatformExecutorIT {
         instanceProperties.set(ID, "instance");
         instanceProperties.set(CONFIG_BUCKET, "config-bucket");
         instanceProperties.set(BULK_IMPORT_BUCKET, "import-bucket");
-        instanceProperties.set(BULK_IMPORT_EMR_SERVERLESS_CLUSTER_NAME, "cluster-name");
+        instanceProperties.set(BULK_IMPORT_EMR_SERVERLESS_CLUSTER_NAME, "my-application");
         instanceProperties.set(BULK_IMPORT_EMR_SERVERLESS_APPLICATION_ID, "application-id");
         instanceProperties.set(BULK_IMPORT_EMR_SERVERLESS_CLUSTER_ROLE_ARN, "cluster-role");
         instanceProperties.set(BULK_IMPORT_CLASS_NAME, "BulkImportClass");

--- a/java/bulk-import/bulk-import-starter/src/test/resources/example/emr-serverless/jobrun-request.json
+++ b/java/bulk-import/bulk-import-starter/src/test/resources/example/emr-serverless/jobrun-request.json
@@ -6,7 +6,7 @@
       "entryPointArguments": [
         "config-bucket",
         "my-job",
-        "application-id",
+        "application-id-EMRS",
         "run-id"
       ]
     }

--- a/java/bulk-import/bulk-import-starter/src/test/resources/example/emr-serverless/jobrun-request.json
+++ b/java/bulk-import/bulk-import-starter/src/test/resources/example/emr-serverless/jobrun-request.json
@@ -6,7 +6,7 @@
       "entryPointArguments": [
         "config-bucket",
         "my-job",
-        "sleeper-instance-table-name-my-job",
+        "application-id",
         "run-id"
       ]
     }

--- a/java/bulk-import/bulk-import-starter/src/test/resources/example/emr-serverless/jobrun-request.json
+++ b/java/bulk-import/bulk-import-starter/src/test/resources/example/emr-serverless/jobrun-request.json
@@ -6,7 +6,7 @@
       "entryPointArguments": [
         "config-bucket",
         "my-job",
-        "application-id-EMRS",
+        "my-application-EMRS",
         "run-id"
       ]
     }

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EmrServerlessBulkImportStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EmrServerlessBulkImportStack.java
@@ -141,7 +141,7 @@ public class EmrServerlessBulkImportStack extends NestedStack {
         String uri = accountId + ".dkr.ecr." + region + ".amazonaws.com/" + repo + ":" + version;
 
         CfnApplicationProps props = CfnApplicationProps.builder()
-                .name(String.join("-", "sleeper", instanceId, "emr", "serverless"))
+                .name(String.join("-", "sleeper", instanceId))
                 .releaseLabel(instanceProperties.get(BULK_IMPORT_EMR_SERVERLESS_RELEASE))
                 .architecture(instanceProperties.get(BULK_IMPORT_EMR_SERVERLESS_ARCHITECTURE))
                 .type("Spark")

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/DirectEmrServerlessDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/DirectEmrServerlessDriver.java
@@ -25,7 +25,6 @@ import sleeper.bulkimport.job.BulkImportJobSerDe;
 import sleeper.bulkimport.starter.executor.BulkImportArguments;
 import sleeper.bulkimport.starter.executor.EmrServerlessPlatformExecutor;
 import sleeper.configuration.properties.instance.InstanceProperties;
-import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.status.store.job.IngestJobStatusStoreFactory;
 import sleeper.systemtest.drivers.instance.SleeperInstanceContext;
@@ -46,8 +45,7 @@ public class DirectEmrServerlessDriver {
                                      AmazonS3 s3Client, AmazonDynamoDB dynamoDBClient, EmrServerlessClient emrClient) {
         this(instance.getInstanceProperties(),
                 IngestJobStatusStoreFactory.getStatusStore(dynamoDBClient, instance.getInstanceProperties()),
-                new EmrServerlessPlatformExecutor(emrClient, instance.getInstanceProperties(), new TablePropertiesProvider(
-                        instance.getInstanceProperties(), s3Client, dynamoDBClient)), s3Client);
+                new EmrServerlessPlatformExecutor(emrClient, instance.getInstanceProperties()), s3Client);
     }
 
     public DirectEmrServerlessDriver(InstanceProperties properties,

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/ingest/SystemTestDirectEmrServerless.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/ingest/SystemTestDirectEmrServerless.java
@@ -51,7 +51,7 @@ public class SystemTestDirectEmrServerless {
         sentJobIds.add(jobId);
         driver.sendJob(BulkImportJob.builder()
                 .id(jobId)
-                .tableName(instance.getTableName())
+                .tableId(instance.getTableId())
                 .files(sourceFiles.getIngestJobFilesInBucket(Stream.of(files)))
                 .build());
         return this;


### PR DESCRIPTION
Fixed setting Spark properties when none were set in the job.

Made Spark properties set on a job consistent between bulk import types. The Sleeper property prefix is no longer used for EMR Serverless.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1491

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Improved EmrServerlessPlatformExecutorIT
    - Added StateMachinePlatformExecutorTest.shouldIgnoreUserConfigurationIfSetToNull

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.