### PR TITLE
Fixing s3a credentials to use DefaultAWSCredentials if not using LocalStack 

### DIFF
--- a/java/clients/pom.xml
+++ b/java/clients/pom.xml
@@ -253,6 +253,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <transformers>
+                        <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/java/clients/src/main/java/sleeper/clients/QueryClient.java
+++ b/java/clients/src/main/java/sleeper/clients/QueryClient.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Executors;
 
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.utils.AwsV1ClientHelper.buildAwsV1Client;
+import static sleeper.utils.HadoopConfigurationProvider.getConfigurationForClient;
 
 /**
  * Allows a user to run a query from the command line.
@@ -69,7 +70,6 @@ public class QueryClient extends QueryCommandLineClient {
         String tableName = tableProperties.get(TABLE_NAME);
         Configuration conf = HadoopConfigurationProvider.getConfigurationForQueryLambdas(getInstanceProperties(), tableProperties);
         conf.setIfUnset("fs.s3a.aws.credentials.provider", DefaultAWSCredentialsProviderChain.class.getName());
-
         StateStore stateStore = stateStoreProvider.getStateStore(tableProperties);
         List<Partition> partitions = stateStore.getAllPartitions();
         Map<String, List<String>> partitionToFileMapping = stateStore.getPartitionToActiveFilesMap();
@@ -121,7 +121,7 @@ public class QueryClient extends QueryCommandLineClient {
         AmazonDynamoDB dynamoDB = buildAwsV1Client(AmazonDynamoDBClientBuilder.standard());
         InstanceProperties instanceProperties = ClientUtils.getInstanceProperties(amazonS3, args[0]);
 
-        QueryClient queryClient = new QueryClient(amazonS3, instanceProperties, dynamoDB, new Configuration());
+        QueryClient queryClient = new QueryClient(amazonS3, instanceProperties, dynamoDB, getConfigurationForClient());
         queryClient.run();
     }
 }

--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployNewInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployNewInstance.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static sleeper.clients.util.ClientUtils.optionalArgument;
+import static sleeper.utils.HadoopConfigurationProvider.getConfigurationForClient;
 
 public class DeployNewInstance {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeployNewInstance.class);
@@ -161,7 +162,7 @@ public class DeployNewInstance {
         instanceProperties.loadFromS3GivenInstanceId(s3, instanceId);
         for (TableProperties tableProperties : deployInstanceConfiguration.getTableProperties()) {
             LOGGER.info("Adding table " + tableProperties.getId());
-            new AddTable(s3, dynamoDB, instanceProperties, tableProperties).run();
+            new AddTable(s3, dynamoDB, instanceProperties, tableProperties, getConfigurationForClient()).run();
         }
         LOGGER.info("Finished deployment of new instance");
     }

--- a/java/parquet/src/main/java/sleeper/utils/HadoopConfigurationProvider.java
+++ b/java/parquet/src/main/java/sleeper/utils/HadoopConfigurationProvider.java
@@ -18,6 +18,7 @@ package sleeper.utils;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.apache.hadoop.conf.Configuration;
 
 import sleeper.configuration.properties.instance.InstanceProperties;
@@ -33,6 +34,16 @@ public class HadoopConfigurationProvider {
     private HadoopConfigurationProvider() {
     }
 
+    public static Configuration getConfigurationForClient() {
+        Configuration conf = new Configuration();
+        if (System.getenv("AWS_ENDPOINT_URL") != null) {
+            setLocalStackConfiguration(conf);
+        } else {
+            conf.set("fs.s3a.aws.credentials.provider", DefaultAWSCredentialsProviderChain.class.getName());
+        }
+        return conf;
+    }
+
     public static Configuration getConfigurationForLambdas(InstanceProperties instanceProperties) {
         Configuration conf = new Configuration();
         conf.set("fs.s3a.connection.maximum", instanceProperties.get(MAXIMUM_CONNECTIONS_TO_S3));
@@ -45,6 +56,8 @@ public class HadoopConfigurationProvider {
         conf.set("fs.s3a.readahead.range", tableProperties.get(S3A_READAHEAD_RANGE));
         if (System.getenv("AWS_ENDPOINT_URL") != null) {
             setLocalStackConfiguration(conf);
+        } else {
+            conf.set("fs.s3a.aws.credentials.provider", "com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper");
         }
         return conf;
     }

--- a/java/parquet/src/test/java/sleeper/utils/HadoopConfigurationLocalStackUtils.java
+++ b/java/parquet/src/test/java/sleeper/utils/HadoopConfigurationLocalStackUtils.java
@@ -42,8 +42,8 @@ public class HadoopConfigurationLocalStackUtils {
         configuration.setInt("fs.s3a.connection.maximum", 25);
         configuration.setBoolean("fs.s3a.connection.ssl.enabled", false);
         // The following settings may be useful if the connection to the localstack S3 instance hangs.
-        // These settings attempt to force connection issues to generate errors ealy.
-        // The settings do help but errors mayn still take many minutes to appear.
+        // These settings attempt to force connection issues to generate errors early.
+        // The settings do help but errors may still take many minutes to appear.
         // configuration.set("fs.s3a.connection.timeout", "1000");
         // configuration.set("fs.s3a.connection.establish.timeout", "1");
         // configuration.set("fs.s3a.attempts.maximum", "1");


### PR DESCRIPTION
Fixing s3a credentials to use DefaultAWSCredentials if not using LocalStack 

Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/XXX

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.