### PR TITLE
Issue 1528 - Remove unnecessary catch in CompactSortedFilesRunner

### DIFF
--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
@@ -145,7 +145,7 @@ public class CompactSortedFilesRunner {
                 jobStatusStore, taskStatusStore, taskId, sqsJobQueueUrl, sqsClient, ecsClient, type, 3, 20);
     }
 
-    public void run() throws InterruptedException, IOException, ActionException {
+    public void run() throws InterruptedException, IOException, ActionException, IteratorException {
         Instant startTime = Instant.now();
         CompactionTaskStatus.Builder taskStatusBuilder = CompactionTaskStatus
                 .builder().taskId(taskId).type(type).startTime(startTime);
@@ -184,12 +184,7 @@ public class CompactSortedFilesRunner {
                 LOGGER.info("Received message: {}", message);
                 CompactionJob compactionJob = compactionJobSerDe.deserialiseFromString(message.getBody());
                 LOGGER.info("CompactionJob is: {}", compactionJob);
-                try {
-                    taskFinishedBuilder.addJobSummary(compact(compactionJob, message));
-                } catch (IOException | IteratorException e) {
-                    LOGGER.error("Exception running compactionJob", e);
-                    return;
-                }
+                taskFinishedBuilder.addJobSummary(compact(compactionJob, message));
                 totalNumberOfMessagesProcessed++;
                 numConsecutiveTimesNoMessages = 0;
             }
@@ -246,7 +241,7 @@ public class CompactSortedFilesRunner {
     }
 
     public static void main(String[] args)
-            throws InterruptedException, IOException, ObjectFactoryException, ActionException {
+            throws InterruptedException, IOException, ObjectFactoryException, ActionException, IteratorException {
         if (2 != args.length) {
             System.err.println("Error: must have 2 arguments (config bucket and compaction type (compaction or splittingcompaction)), got "
                     + args.length


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1528

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.