### PR TITLE
Issue 1536 - Upload each system test's output to its own folder

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/nightly/NightlyTestOutput.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/nightly/NightlyTestOutput.java
@@ -53,8 +53,8 @@ public class NightlyTestOutput {
                 .build().upload(this);
     }
 
-    public Stream<Path> filesToUpload() {
-        return tests.stream().flatMap(TestResult::filesToUpload);
+    public Stream<NightlyTestUploadFile> uploads() {
+        return tests.stream().flatMap(TestResult::uploads);
     }
 
     public List<TestResult> getTests() {
@@ -112,8 +112,8 @@ public class NightlyTestOutput {
             }
             TestResult.Builder result = testEntry.getValue();
             try (Stream<Path> files = Files.list(testDirectory)) {
-                files.filter(LOG_FILE_MATCHER::matches)
-                        .forEach(result::logFile);
+                result.outputFiles(files.filter(LOG_FILE_MATCHER::matches)
+                        .collect(Collectors.toUnmodifiableList()));
             }
         }
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/nightly/NightlyTestUploadFile.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/nightly/NightlyTestUploadFile.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022-2023 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.drivers.nightly;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class NightlyTestUploadFile {
+
+    private final Path file;
+    private final String relativeS3Key;
+
+    private NightlyTestUploadFile(Path file, String s3Prefix) {
+        this.file = file;
+        this.relativeS3Key = s3Prefix + file.getFileName();
+    }
+
+    public static NightlyTestUploadFile fileInUploadDir(Path file) {
+        return new NightlyTestUploadFile(file, "");
+    }
+
+    public static NightlyTestUploadFile fileInS3RelativeDir(String s3RelativeDir, Path file) {
+        return new NightlyTestUploadFile(file, s3RelativeDir + "/");
+    }
+
+    public Path getFile() {
+        return file;
+    }
+
+    public String getRelativeS3Key() {
+        return relativeS3Key;
+    }
+
+    @Override
+    public String toString() {
+        return relativeS3Key + " from " + file;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        NightlyTestUploadFile that = (NightlyTestUploadFile) object;
+        return Objects.equals(file, that.file) && Objects.equals(relativeS3Key, that.relativeS3Key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(file, relativeS3Key);
+    }
+}

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/nightly/NightlyTestUploader.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/nightly/NightlyTestUploader.java
@@ -20,7 +20,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.file.Path;
 import java.util.Objects;
 
 public class NightlyTestUploader {
@@ -44,17 +43,16 @@ public class NightlyTestUploader {
 
     public void upload(NightlyTestOutput output) {
         LOGGER.info("Uploading to S3 bucket and folder: {}/{}", bucketName, prefix);
-        output.filesToUpload().parallel().forEach(this::upload);
+        output.uploads().parallel().forEach(this::upload);
         NightlyTestSummaryTable.fromS3(s3Client, bucketName)
                 .add(timestamp, output)
                 .saveToS3(s3Client, bucketName);
     }
 
-    public void upload(Path file) {
-        String filename = Objects.toString(file.getFileName());
-        LOGGER.info("Uploading {}", filename);
-        s3Client.putObject(bucketName, prefix + "/" + filename, file.toFile());
-        LOGGER.info("Uploaded {}", filename);
+    public void upload(NightlyTestUploadFile file) {
+        LOGGER.info("Uploading {}", file);
+        s3Client.putObject(bucketName, prefix + "/" + file.getRelativeS3Key(), file.getFile().toFile());
+        LOGGER.info("Uploaded {}", file);
     }
 
     public static final class Builder {

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/nightly/NightlyTestOutputFileSystemIT.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/nightly/NightlyTestOutputFileSystemIT.java
@@ -26,6 +26,8 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.systemtest.drivers.nightly.NightlyTestUploadFile.fileInS3RelativeDir;
+import static sleeper.systemtest.drivers.nightly.NightlyTestUploadFile.fileInUploadDir;
 
 class NightlyTestOutputFileSystemIT {
     @TempDir
@@ -40,8 +42,8 @@ class NightlyTestOutputFileSystemIT {
             Files.writeString(tempDir.resolve("bulkImportPerformance.log"), "test");
 
             // When / Then
-            assertThat(NightlyTestOutput.from(tempDir).filesToUpload())
-                    .containsExactly(tempDir.resolve("bulkImportPerformance.log"));
+            assertThat(NightlyTestOutput.from(tempDir).uploads())
+                    .containsExactly(fileInUploadDir(tempDir.resolve("bulkImportPerformance.log")));
         }
 
         @Test
@@ -50,7 +52,7 @@ class NightlyTestOutputFileSystemIT {
             Files.createDirectory(tempDir.resolve("testDir.log"));
 
             // When / Then
-            assertThat(NightlyTestOutput.from(tempDir).filesToUpload())
+            assertThat(NightlyTestOutput.from(tempDir).uploads())
                     .isEmpty();
         }
 
@@ -64,9 +66,9 @@ class NightlyTestOutputFileSystemIT {
             NightlyTestOutput output = NightlyTestOutput.from(tempDir);
 
             // Then
-            assertThat(output.filesToUpload()).containsExactly(
-                    tempDir.resolve("bulkImportPerformance.log"),
-                    tempDir.resolve("bulkImportPerformance.tearDown.log"));
+            assertThat(output.uploads()).containsExactly(
+                    fileInUploadDir(tempDir.resolve("bulkImportPerformance.log")),
+                    fileInUploadDir(tempDir.resolve("bulkImportPerformance.tearDown.log")));
             assertThat(output.getTests())
                     .extracting(TestResult::getTestName)
                     .containsExactly("bulkImportPerformance");
@@ -88,9 +90,9 @@ class NightlyTestOutputFileSystemIT {
             NightlyTestOutput output = NightlyTestOutput.from(tempDir);
 
             // Then
-            assertThat(output.filesToUpload()).containsExactly(
-                    tempDir.resolve("maven.log"),
-                    tempDir.resolve("maven/IngestBatcherIT.shouldCreateTwoJobs.report.log"));
+            assertThat(output.uploads()).containsExactly(
+                    fileInUploadDir(tempDir.resolve("maven.log")),
+                    fileInS3RelativeDir("maven", tempDir.resolve("maven/IngestBatcherIT.shouldCreateTwoJobs.report.log")));
             assertThat(output.getTests())
                     .extracting(TestResult::getTestName)
                     .containsExactly("maven");
@@ -107,8 +109,8 @@ class NightlyTestOutputFileSystemIT {
             NightlyTestOutput output = NightlyTestOutput.from(tempDir);
 
             // Then
-            assertThat(output.filesToUpload()).containsExactly(
-                    tempDir.resolve("maven.log"));
+            assertThat(output.uploads()).containsExactly(
+                    fileInUploadDir(tempDir.resolve("maven.log")));
             assertThat(output.getTests())
                     .extracting(TestResult::getTestName)
                     .containsExactly("maven");

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/nightly/NightlyTestOutputS3IT.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/nightly/NightlyTestOutputS3IT.java
@@ -68,10 +68,12 @@ class NightlyTestOutputS3IT {
     }
 
     @Test
-    void shouldUploadLogFile() throws Exception {
+    void shouldUploadLogFiles() throws Exception {
         // Given
         Instant startTime = Instant.parse("2023-05-04T09:35:00Z");
-        Files.writeString(tempDir.resolve("bulkImportPerformance.log"), "test data");
+        Files.writeString(tempDir.resolve("maven.log"), "root log test");
+        Files.createDirectory(tempDir.resolve("maven"));
+        Files.writeString(tempDir.resolve("maven/IngestBatcherIT.shouldCreateTwoJobs.report.log"), "nested log test");
 
         // When
         uploadFromTempDir(startTime);
@@ -79,7 +81,8 @@ class NightlyTestOutputS3IT {
         // Then
         assertThat(streamS3Objects())
                 .contains(
-                        tuple("20230504_093500/bulkImportPerformance.log", "test data"));
+                        tuple("20230504_093500/maven.log", "root log test"),
+                        tuple("20230504_093500/maven/IngestBatcherIT.shouldCreateTwoJobs.report.log", "nested log test"));
     }
 
     @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1536

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated NightlyTestOutputFileSystemIT, NightlyTestOutputS3IT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.