### PR TITLE
Issue 1546 - Clear system test instance when only config file is present

### DIFF
--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/instance/SleeperInstanceTablesDriverIT.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/instance/SleeperInstanceTablesDriverIT.java
@@ -44,6 +44,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 import static sleeper.configuration.properties.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.DATA_BUCKET;
+import static sleeper.configuration.properties.instance.CommonProperty.ID;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
@@ -64,7 +65,6 @@ public class SleeperInstanceTablesDriverIT {
     private final SleeperInstanceTablesDriver driver = new SleeperInstanceTablesDriver(s3, s3v2, dynamoDB, hadoop);
     private final InstanceProperties instanceProperties = createTestInstanceProperties();
     private final TableProperties tableProperties = createTestTableProperties(instanceProperties, schemaWithKey("key"));
-
 
     @BeforeEach
     void setUp() {
@@ -102,5 +102,15 @@ public class SleeperInstanceTablesDriverIT {
     void shouldDeleteNothingWhenNoTablesArePresent() {
         assertThatCode(() -> driver.deleteAll(instanceProperties))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldDeleteNothingWhenNoTablesArePresentAndInstancePropertiesAreSavedInConfigBucket() {
+        instanceProperties.saveToS3(s3);
+        driver.deleteAll(instanceProperties);
+
+        InstanceProperties loaded = new InstanceProperties();
+        loaded.loadFromS3GivenInstanceId(s3, instanceProperties.get(ID));
+        assertThat(loaded).isEqualTo(instanceProperties);
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1546 

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - SleeperInstanceTablesDriverIT.shouldDeleteNothingWhenNoTablesArePresentAndInstancePropertiesAreSavedInConfigBucket

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.