### PR TITLE
Issue 1571 - Move RangeQueryUtils to parquet module, refactor for use in compaction

### DIFF
--- a/java/athena/src/main/java/sleeper/athena/record/SleeperRecordHandler.java
+++ b/java/athena/src/main/java/sleeper/athena/record/SleeperRecordHandler.java
@@ -49,7 +49,7 @@ import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.MapType;
 import sleeper.core.schema.type.StringType;
 import sleeper.core.schema.type.Type;
-import sleeper.utils.HadoopConfigurationProvider;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 
 import static sleeper.athena.metadata.IteratorApplyingMetadataHandler.SOURCE_TYPE;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;

--- a/java/athena/src/test/java/sleeper/athena/metadata/AbstractMetadataHandlerIT.java
+++ b/java/athena/src/test/java/sleeper/athena/metadata/AbstractMetadataHandlerIT.java
@@ -45,7 +45,7 @@ import static com.amazonaws.SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY;
 import static com.amazonaws.SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY;
 import static java.nio.file.Files.createTempDirectory;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public abstract class AbstractMetadataHandlerIT {

--- a/java/athena/src/test/java/sleeper/athena/record/AbstractRecordHandlerIT.java
+++ b/java/athena/src/test/java/sleeper/athena/record/AbstractRecordHandlerIT.java
@@ -52,7 +52,7 @@ import java.nio.file.Path;
 import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public abstract class AbstractRecordHandlerIT {

--- a/java/bulk-import/bulk-import-runner/src/main/java/sleeper/bulkimport/job/runner/BulkImportJobDriver.java
+++ b/java/bulk-import/bulk-import-runner/src/main/java/sleeper/bulkimport/job/runner/BulkImportJobDriver.java
@@ -37,8 +37,8 @@ import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.statestore.StateStore;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.status.store.job.IngestJobStatusStoreFactory;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
@@ -94,7 +94,7 @@ import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildA
 import static sleeper.core.record.process.RecordsProcessedSummaryTestData.summary;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.finishedIngestJobWithValidation;
 import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 class BulkImportJobDriverIT {

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/BulkImportStarterLambda.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/BulkImportStarterLambda.java
@@ -37,9 +37,9 @@ import sleeper.configuration.table.index.DynamoDBTableIndex;
 import sleeper.ingest.job.IngestJobMessageHandler;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.status.store.job.IngestJobStatusStoreFactory;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
+import sleeper.io.parquet.utils.HadoopPathUtils;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
-import sleeper.utils.HadoopPathUtils;
 
 import java.time.Instant;
 

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/BulkImportStarterLambdaIT.java
@@ -43,7 +43,7 @@ import sleeper.ingest.job.IngestJobMessageHandler;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.job.status.IngestJobStatusTestData;
 import sleeper.ingest.job.status.WriteToMemoryIngestJobStatusStore;
-import sleeper.utils.HadoopPathUtils;
+import sleeper.io.parquet.utils.HadoopPathUtils;
 
 import java.time.Instant;
 import java.util.List;

--- a/java/clients/src/main/java/sleeper/clients/QueryClient.java
+++ b/java/clients/src/main/java/sleeper/clients/QueryClient.java
@@ -37,11 +37,11 @@ import sleeper.core.schema.Schema;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.core.table.TableIndex;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.query.QueryException;
 import sleeper.query.executor.QueryExecutor;
 import sleeper.query.model.Query;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +51,7 @@ import java.util.concurrent.Executors;
 
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.utils.AwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationProvider.getConfigurationForClient;
+import static sleeper.io.parquet.utils.HadoopConfigurationProvider.getConfigurationForClient;
 
 /**
  * Allows a user to run a query from the command line.

--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployNewInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployNewInstance.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static sleeper.clients.util.ClientUtils.optionalArgument;
-import static sleeper.utils.HadoopConfigurationProvider.getConfigurationForClient;
+import static sleeper.io.parquet.utils.HadoopConfigurationProvider.getConfigurationForClient;
 
 public class DeployNewInstance {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeployNewInstance.class);

--- a/java/clients/src/test/java/sleeper/clients/status/report/partitions/PartitionsStatusReportIT.java
+++ b/java/clients/src/test/java/sleeper/clients/status/report/partitions/PartitionsStatusReportIT.java
@@ -51,7 +51,7 @@ import static sleeper.configuration.properties.table.TablePropertiesTestHelper.c
 import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class PartitionsStatusReportIT {

--- a/java/clients/src/test/java/sleeper/clients/status/update/AddTableIT.java
+++ b/java/clients/src/test/java/sleeper/clients/status/update/AddTableIT.java
@@ -60,7 +60,7 @@ import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class AddTableIT {

--- a/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateJobsLambda.java
+++ b/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateJobsLambda.java
@@ -36,8 +36,8 @@ import sleeper.configuration.properties.PropertiesReloader;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateJobsIT.java
+++ b/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateJobsIT.java
@@ -67,7 +67,7 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.DATA_BUCKET;
 import static sleeper.configuration.properties.instance.CommonProperty.FILE_SYSTEM;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class CreateJobsIT {

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -52,9 +52,9 @@ import sleeper.core.statestore.StateStoreException;
 import sleeper.io.parquet.record.ParquetReaderIterator;
 import sleeper.io.parquet.record.ParquetRecordReader;
 import sleeper.io.parquet.record.ParquetRecordWriterFactory;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.sketches.Sketches;
 import sleeper.sketches.s3.SketchesSerDeToS3;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.time.Instant;

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
@@ -49,13 +49,13 @@ import sleeper.core.iterator.IteratorException;
 import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.job.common.CommonJobUtils;
 import sleeper.job.common.action.ActionException;
 import sleeper.job.common.action.DeleteMessageAction;
 import sleeper.job.common.action.MessageReference;
 import sleeper.job.common.action.thread.PeriodicActionRunnable;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.time.Instant;

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesDynamoDBIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesDynamoDBIT.java
@@ -63,7 +63,7 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class CompactSortedFilesDynamoDBIT extends CompactSortedFilesTestBase {

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesRunnerLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesRunnerLocalStackIT.java
@@ -78,7 +78,7 @@ import static sleeper.configuration.properties.table.TablePropertiesTestHelper.c
 import static sleeper.configuration.properties.table.TableProperty.COMPACTION_FILES_BATCH_SIZE;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class CompactSortedFilesRunnerLocalStackIT {

--- a/java/garbage-collector/src/main/java/sleeper/garbagecollector/GarbageCollectorLambda.java
+++ b/java/garbage-collector/src/main/java/sleeper/garbagecollector/GarbageCollectorLambda.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.time.LocalDateTime;

--- a/java/garbage-collector/src/test/java/sleeper/garbagecollector/GarbageCollectorIT.java
+++ b/java/garbage-collector/src/test/java/sleeper/garbagecollector/GarbageCollectorIT.java
@@ -67,7 +67,7 @@ import static sleeper.configuration.properties.table.TablePropertiesTestHelper.c
 import static sleeper.configuration.properties.table.TableProperty.GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class GarbageCollectorIT {

--- a/java/ingest/ingest-batcher-submitter/src/main/java/sleeper/ingest/batcher/submitter/FileIngestRequestSerDe.java
+++ b/java/ingest/ingest-batcher-submitter/src/main/java/sleeper/ingest/batcher/submitter/FileIngestRequestSerDe.java
@@ -34,8 +34,8 @@ import java.util.stream.Collectors;
 
 import static sleeper.configuration.properties.instance.CommonProperty.FILE_SYSTEM;
 import static sleeper.core.util.NumberFormatUtils.formatBytes;
-import static sleeper.utils.HadoopPathUtils.getRequestPath;
-import static sleeper.utils.HadoopPathUtils.streamFiles;
+import static sleeper.io.parquet.utils.HadoopPathUtils.getRequestPath;
+import static sleeper.io.parquet.utils.HadoopPathUtils.streamFiles;
 
 public class FileIngestRequestSerDe {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileIngestRequestSerDe.class);

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/IngestFactory.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/IngestFactory.java
@@ -33,8 +33,8 @@ import sleeper.ingest.impl.partitionfilewriter.PartitionFileWriterFactory;
 import sleeper.ingest.impl.recordbatch.RecordBatchFactory;
 import sleeper.ingest.impl.recordbatch.arraylist.ArrayListRecordBatchFactory;
 import sleeper.ingest.impl.recordbatch.arrow.ArrowRecordBatchFactory;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.util.Iterator;

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/ECSIngestTask.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/ECSIngestTask.java
@@ -42,8 +42,8 @@ import sleeper.ingest.status.store.job.IngestJobStatusStoreFactory;
 import sleeper.ingest.status.store.task.IngestTaskStatusStoreFactory;
 import sleeper.ingest.task.IngestTask;
 import sleeper.ingest.task.IngestTaskStatusStore;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.util.UUID;

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobQueueConsumer.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobQueueConsumer.java
@@ -34,11 +34,11 @@ import sleeper.core.statestore.StateStoreException;
 import sleeper.core.table.TableIndex;
 import sleeper.ingest.IngestResult;
 import sleeper.ingest.job.status.IngestJobStatusStore;
+import sleeper.io.parquet.utils.HadoopPathUtils;
 import sleeper.job.common.action.ActionException;
 import sleeper.job.common.action.DeleteMessageAction;
 import sleeper.job.common.action.MessageReference;
 import sleeper.job.common.action.thread.PeriodicActionRunnable;
-import sleeper.utils.HadoopPathUtils;
 
 import java.io.IOException;
 import java.util.List;

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobRunner.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/IngestJobRunner.java
@@ -37,8 +37,8 @@ import sleeper.ingest.IngestFactory;
 import sleeper.ingest.IngestResult;
 import sleeper.io.parquet.record.ParquetReaderIterator;
 import sleeper.io.parquet.record.ParquetRecordReader;
+import sleeper.io.parquet.utils.HadoopPathUtils;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopPathUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsLocalStackITBase.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/IngestRecordsLocalStackITBase.java
@@ -31,7 +31,7 @@ import sleeper.statestore.s3.S3StateStore;
 import sleeper.statestore.s3.S3StateStoreCreator;
 
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class IngestRecordsLocalStackITBase extends IngestRecordsTestBase {

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorCommonIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorCommonIT.java
@@ -83,7 +83,7 @@ import static sleeper.ingest.testutils.LocalStackAwsV2ClientHelper.buildAwsV2Cli
 import static sleeper.ingest.testutils.RecordGenerator.genericKey1D;
 import static sleeper.ingest.testutils.ResultVerifier.readMergedRecordsFromPartitionDataFiles;
 import static sleeper.ingest.testutils.ResultVerifier.readRecordsFromPartitionDataFile;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class IngestCoordinatorCommonIT {

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/IngestCoordinatorUsingDirectWriteBackedByArrayListIT.java
@@ -68,7 +68,7 @@ import static sleeper.ingest.testutils.IngestCoordinatorTestHelper.parquetConfig
 import static sleeper.ingest.testutils.IngestCoordinatorTestHelper.standardIngestCoordinator;
 import static sleeper.ingest.testutils.ResultVerifier.readMergedRecordsFromPartitionDataFiles;
 import static sleeper.ingest.testutils.ResultVerifier.readRecordsFromPartitionDataFile;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class IngestCoordinatorUsingDirectWriteBackedByArrayListIT {

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobQueueConsumerTestBase.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobQueueConsumerTestBase.java
@@ -68,7 +68,7 @@ import static sleeper.configuration.properties.table.TablePropertiesTestHelper.c
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.ingest.testutils.LocalStackAwsV2ClientHelper.buildAwsV2Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public abstract class IngestJobQueueConsumerTestBase {

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobRunnerIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobRunnerIT.java
@@ -81,7 +81,7 @@ import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildA
 import static sleeper.core.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedPartitions;
 import static sleeper.ingest.testutils.LocalStackAwsV2ClientHelper.buildAwsV2Client;
 import static sleeper.ingest.testutils.ResultVerifier.readMergedRecordsFromPartitionDataFiles;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 class IngestJobRunnerIT {

--- a/java/parquet/src/main/java/sleeper/io/parquet/utils/HadoopConfigurationProvider.java
+++ b/java/parquet/src/main/java/sleeper/io/parquet/utils/HadoopConfigurationProvider.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.utils;
+package sleeper.io.parquet.utils;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/java/parquet/src/main/java/sleeper/io/parquet/utils/HadoopPathUtils.java
+++ b/java/parquet/src/main/java/sleeper/io/parquet/utils/HadoopPathUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.utils;
+package sleeper.io.parquet.utils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;

--- a/java/parquet/src/main/java/sleeper/io/parquet/utils/RangeQueryUtils.java
+++ b/java/parquet/src/main/java/sleeper/io/parquet/utils/RangeQueryUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.query.utils;
+package sleeper.io.parquet.utils;
 
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators.BinaryColumn;

--- a/java/parquet/src/main/java/sleeper/io/parquet/utils/RangeQueryUtils.java
+++ b/java/parquet/src/main/java/sleeper/io/parquet/utils/RangeQueryUtils.java
@@ -37,6 +37,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.gtEq;
 import static org.apache.parquet.filter2.predicate.FilterApi.intColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.longColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.lt;
+import static org.apache.parquet.filter2.predicate.FilterApi.or;
 
 public class RangeQueryUtils {
 
@@ -50,7 +51,7 @@ public class RangeQueryUtils {
 
         // Add in restriction that only want data from the partition (partitions do not include the maximum value)
         FilterPredicate partitionPredicate = getFilterPredicateNoCanonicalise(partitionRegion);
-        return org.apache.parquet.filter2.predicate.FilterApi.and(partitionPredicate, anyRegionFilter);
+        return and(partitionPredicate, anyRegionFilter);
     }
 
     private static FilterPredicate getFilterPredicate(List<Region> regions) {
@@ -59,16 +60,16 @@ public class RangeQueryUtils {
             Region canonicalRegion = RegionCanonicaliser.canonicaliseRegion(region);
             filters.add(getFilterPredicateNoCanonicalise(canonicalRegion));
         }
-        return or(filters);
+        return orList(filters);
     }
 
-    private static FilterPredicate or(List<FilterPredicate> predicates) {
+    private static FilterPredicate orList(List<FilterPredicate> predicates) {
         FilterPredicate anyPredicate = null;
         for (FilterPredicate predicate : predicates) {
             if (null == anyPredicate) {
                 anyPredicate = predicate;
             } else {
-                anyPredicate = org.apache.parquet.filter2.predicate.FilterApi.or(anyPredicate, predicate);
+                anyPredicate = or(anyPredicate, predicate);
             }
         }
         return anyPredicate;

--- a/java/parquet/src/test/java/sleeper/io/parquet/record/ParquetReaderIteratorIT.java
+++ b/java/parquet/src/test/java/sleeper/io/parquet/record/ParquetReaderIteratorIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.io.record;
+package sleeper.io.parquet.record;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -25,9 +25,6 @@ import sleeper.core.record.Record;
 import sleeper.core.schema.Field;
 import sleeper.core.schema.Schema;
 import sleeper.core.schema.type.LongType;
-import sleeper.io.parquet.record.ParquetReaderIterator;
-import sleeper.io.parquet.record.ParquetRecordReader;
-import sleeper.io.parquet.record.ParquetRecordWriterFactory;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/java/parquet/src/test/java/sleeper/io/parquet/record/ParquetRecordReaderIT.java
+++ b/java/parquet/src/test/java/sleeper/io/parquet/record/ParquetRecordReaderIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.io.record;
+package sleeper.io.parquet.record;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -30,8 +30,6 @@ import sleeper.core.schema.type.ListType;
 import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.MapType;
 import sleeper.core.schema.type.StringType;
-import sleeper.io.parquet.record.ParquetRecordReader;
-import sleeper.io.parquet.record.ParquetRecordWriterFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/java/parquet/src/test/java/sleeper/io/parquet/record/ParquetRecordWriterFactoryIT.java
+++ b/java/parquet/src/test/java/sleeper/io/parquet/record/ParquetRecordWriterFactoryIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.io.record;
+package sleeper.io.parquet.record;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -34,8 +34,6 @@ import sleeper.core.schema.Schema;
 import sleeper.core.schema.type.ByteArrayType;
 import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.StringType;
-import sleeper.io.parquet.record.ParquetRecordReader;
-import sleeper.io.parquet.record.ParquetRecordWriterFactory;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/java/parquet/src/test/java/sleeper/io/parquet/utils/HadoopConfigurationLocalStackUtils.java
+++ b/java/parquet/src/test/java/sleeper/io/parquet/utils/HadoopConfigurationLocalStackUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.utils;
+package sleeper.io.parquet.utils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.testcontainers.containers.localstack.LocalStackContainer;

--- a/java/parquet/src/test/java/sleeper/io/parquet/utils/HadoopPathUtilsIT.java
+++ b/java/parquet/src/test/java/sleeper/io/parquet/utils/HadoopPathUtilsIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.utils;
+package sleeper.io.parquet.utils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;

--- a/java/parquet/src/test/java/sleeper/io/parquet/utils/RangeQueryUtilsTest.java
+++ b/java/parquet/src/test/java/sleeper/io/parquet/utils/RangeQueryUtilsTest.java
@@ -34,7 +34,6 @@ import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.StringType;
 
 import java.util.Arrays;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,7 +44,6 @@ public class RangeQueryUtilsTest {
         // Given
         Field field = new Field("key", new IntType());
         Schema schema = Schema.builder().rowKeyFields(field).build();
-        List<Field> rowKeyFields = schema.getRowKeyFields();
         RangeFactory rangeFactory = new RangeFactory(schema);
         Range range = rangeFactory.createExactRange(field, 1);
         Region region = new Region(range);
@@ -53,7 +51,7 @@ public class RangeQueryUtilsTest {
         Region partitionRegion = new Region(partitionRange);
 
         // When
-        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(rowKeyFields, Arrays.asList(region), partitionRegion);
+        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(Arrays.asList(region), partitionRegion);
 
         // Then
         assertThat(predicate).isInstanceOf(And.class);
@@ -83,7 +81,6 @@ public class RangeQueryUtilsTest {
         // Given
         Field field = new Field("key", new LongType());
         Schema schema = Schema.builder().rowKeyFields(field).build();
-        List<Field> rowKeyFields = schema.getRowKeyFields();
         RangeFactory rangeFactory = new RangeFactory(schema);
         Range range = rangeFactory.createExactRange(field, 1L);
         Region region = new Region(range);
@@ -91,7 +88,7 @@ public class RangeQueryUtilsTest {
         Region partitionRegion = new Region(partitionRange);
 
         // When
-        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(rowKeyFields, Arrays.asList(region), partitionRegion);
+        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(Arrays.asList(region), partitionRegion);
 
         // Then
         assertThat(predicate).isInstanceOf(And.class);
@@ -121,7 +118,6 @@ public class RangeQueryUtilsTest {
         // Given
         Field field = new Field("key", new StringType());
         Schema schema = Schema.builder().rowKeyFields(field).build();
-        List<Field> rowKeyFields = schema.getRowKeyFields();
         RangeFactory rangeFactory = new RangeFactory(schema);
         Range range = rangeFactory.createExactRange(field, "B");
         Region region = new Region(range);
@@ -129,7 +125,7 @@ public class RangeQueryUtilsTest {
         Region partitionRegion = new Region(partitionRange);
 
         // When
-        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(rowKeyFields, Arrays.asList(region), partitionRegion);
+        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(Arrays.asList(region), partitionRegion);
 
         // Then
         assertThat(predicate).isInstanceOf(And.class);
@@ -159,7 +155,6 @@ public class RangeQueryUtilsTest {
         // Given
         Field field = new Field("key", new ByteArrayType());
         Schema schema = Schema.builder().rowKeyFields(field).build();
-        List<Field> rowKeyFields = schema.getRowKeyFields();
         RangeFactory rangeFactory = new RangeFactory(schema);
         Range range = rangeFactory.createExactRange(field, new byte[]{10, 20});
         Region region = new Region(range);
@@ -167,7 +162,7 @@ public class RangeQueryUtilsTest {
         Region partitionRegion = new Region(partitionRange);
 
         // When
-        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(rowKeyFields, Arrays.asList(region), partitionRegion);
+        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(Arrays.asList(region), partitionRegion);
 
         // Then
         assertThat(predicate).isInstanceOf(And.class);
@@ -197,7 +192,6 @@ public class RangeQueryUtilsTest {
         // Given
         Field field = new Field("key", new IntType());
         Schema schema = Schema.builder().rowKeyFields(field).build();
-        List<Field> rowKeyFields = schema.getRowKeyFields();
         RangeFactory rangeFactory = new RangeFactory(schema);
         Range range1 = rangeFactory.createExactRange(field, 1);
         Range range2 = rangeFactory.createRange(field, 5, 7);
@@ -207,7 +201,7 @@ public class RangeQueryUtilsTest {
         Region partitionRegion = new Region(partitionRange);
 
         // When
-        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(rowKeyFields, Arrays.asList(region1, region2), partitionRegion);
+        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(Arrays.asList(region1, region2), partitionRegion);
 
         // Then
         assertThat(predicate).isInstanceOf(And.class);
@@ -247,7 +241,6 @@ public class RangeQueryUtilsTest {
         Field field1 = new Field("key1", new ByteArrayType());
         Field field2 = new Field("key2", new IntType());
         Schema schema = Schema.builder().rowKeyFields(field1, field2).build();
-        List<Field> rowKeyFields = schema.getRowKeyFields();
         RangeFactory rangeFactory = new RangeFactory(schema);
         Range range1 = rangeFactory.createRange(field1, new byte[]{10}, new byte[]{20});
         Range range2 = rangeFactory.createRange(field2, 100, 200);
@@ -257,7 +250,7 @@ public class RangeQueryUtilsTest {
         Region partitionRegion = new Region(Arrays.asList(partitionRange1, partitionRange2));
 
         // When
-        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(rowKeyFields, Arrays.asList(region), partitionRegion);
+        FilterPredicate predicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(Arrays.asList(region), partitionRegion);
 
         // Then
         //  - Predicate should look like the following:

--- a/java/parquet/src/test/java/sleeper/io/parquet/utils/RangeQueryUtilsTest.java
+++ b/java/parquet/src/test/java/sleeper/io/parquet/utils/RangeQueryUtilsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.query.utils;
+package sleeper.io.parquet.utils;
 
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators.And;

--- a/java/query/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
+++ b/java/query/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
@@ -32,6 +32,7 @@ import sleeper.core.iterator.CloseableIterator;
 import sleeper.core.record.Record;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.query.QueryException;
 import sleeper.query.executor.QueryExecutor;
 import sleeper.query.model.LeafPartitionQuery;
@@ -48,7 +49,6 @@ import sleeper.query.recordretrieval.LeafPartitionQueryExecutor;
 import sleeper.query.tracker.DynamoDBQueryTracker;
 import sleeper.query.tracker.QueryStatusReportListeners;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/java/query/src/main/java/sleeper/query/recordretrieval/LeafPartitionRecordRetrieverImpl.java
+++ b/java/query/src/main/java/sleeper/query/recordretrieval/LeafPartitionRecordRetrieverImpl.java
@@ -31,8 +31,8 @@ import sleeper.core.record.Record;
 import sleeper.core.record.RecordComparator;
 import sleeper.core.schema.Schema;
 import sleeper.io.parquet.record.ParquetRecordReader;
+import sleeper.io.parquet.utils.RangeQueryUtils;
 import sleeper.query.model.LeafPartitionQuery;
-import sleeper.query.utils.RangeQueryUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -120,7 +120,7 @@ public class LeafPartitionRecordRetrieverImpl implements LeafPartitionRecordRetr
 
     @Override
     public CloseableIterator<Record> getRecords(Schema dataReadSchema, Schema tableSchema,
-            LeafPartitionQuery leafPartitionQuery) throws RecordRetrievalException {
+                                                LeafPartitionQuery leafPartitionQuery) throws RecordRetrievalException {
         List<String> files = leafPartitionQuery.getFiles();
         if (files.isEmpty()) {
             return new WrappedIterator<>(Collections.emptyIterator());

--- a/java/query/src/main/java/sleeper/query/recordretrieval/LeafPartitionRecordRetrieverImpl.java
+++ b/java/query/src/main/java/sleeper/query/recordretrieval/LeafPartitionRecordRetrieverImpl.java
@@ -127,7 +127,7 @@ public class LeafPartitionRecordRetrieverImpl implements LeafPartitionRecordRetr
         }
 
         FilterPredicate filterPredicate = RangeQueryUtils.getFilterPredicateMultidimensionalKey(
-                tableSchema.getRowKeyFields(), leafPartitionQuery.getRegions(), leafPartitionQuery.getPartitionRegion());
+                leafPartitionQuery.getRegions(), leafPartitionQuery.getPartitionRegion());
         return getRecords(files, dataReadSchema, filterPredicate);
     }
 

--- a/java/query/src/test/java/sleeper/query/lambda/SqsQueryProcessorLambdaIT.java
+++ b/java/query/src/test/java/sleeper/query/lambda/SqsQueryProcessorLambdaIT.java
@@ -118,10 +118,10 @@ import static sleeper.configuration.properties.instance.IngestProperty.INGEST_PA
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 import static sleeper.query.tracker.QueryState.COMPLETED;
 import static sleeper.query.tracker.QueryState.IN_PROGRESS;
 import static sleeper.query.tracker.QueryState.QUEUED;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class SqsQueryProcessorLambdaIT {
@@ -287,7 +287,7 @@ public class SqsQueryProcessorLambdaIT {
 
         // Then
         TrackedQuery.Builder builder = trackedQuery()
-            .queryId("abc").recordCount(0L);
+                .queryId("abc").recordCount(0L);
 
         assertThat(queryTracker.getStatus("abc"))
                 .usingRecursiveComparison()
@@ -307,7 +307,7 @@ public class SqsQueryProcessorLambdaIT {
 
         // Then
         builder = trackedQuery()
-            .queryId("abc").recordCount(0L);
+                .queryId("abc").recordCount(0L);
         assertThat(queryTracker.getStatus("abc"))
                 .usingRecursiveComparison()
                 .ignoringFields("lastUpdateTime", "expiryDate")

--- a/java/splitter/src/main/java/sleeper/splitter/FindPartitionsToSplitLambda.java
+++ b/java/splitter/src/main/java/sleeper/splitter/FindPartitionsToSplitLambda.java
@@ -30,8 +30,8 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.time.LocalDateTime;

--- a/java/splitter/src/main/java/sleeper/splitter/SplitPartitionLambda.java
+++ b/java/splitter/src/main/java/sleeper/splitter/SplitPartitionLambda.java
@@ -32,8 +32,8 @@ import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomData.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomData.java
@@ -23,12 +23,12 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
 import sleeper.systemtest.configuration.IngestMode;
 import sleeper.systemtest.configuration.SystemTestProperties;
 import sleeper.systemtest.configuration.SystemTestPropertyValues;
 import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataToDocker.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataToDocker.java
@@ -31,9 +31,9 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.S3TableProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.ingest.IngestFactory;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
 import sleeper.systemtest.configuration.SystemTestProperties;
-import sleeper.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.net.URI;

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
@@ -25,7 +25,7 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.record.Record;
 import sleeper.io.parquet.record.ParquetRecordWriterFactory;
-import sleeper.utils.HadoopConfigurationProvider;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 
 import java.io.IOException;
 import java.util.Iterator;

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/instance/SleeperInstanceTablesDriverIT.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/instance/SleeperInstanceTablesDriverIT.java
@@ -49,7 +49,7 @@ import static sleeper.configuration.properties.table.TablePropertiesTestHelper.c
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 import static sleeper.ingest.testutils.LocalStackAwsV2ClientHelper.buildAwsV2Client;
-import static sleeper.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
+import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
 public class SleeperInstanceTablesDriverIT {

--- a/java/trino/src/main/java/sleeper/trino/remotesleeperconnection/HadoopConfigurationProviderForDeployedS3Instance.java
+++ b/java/trino/src/main/java/sleeper/trino/remotesleeperconnection/HadoopConfigurationProviderForDeployedS3Instance.java
@@ -20,7 +20,7 @@ import org.apache.hadoop.conf.Configuration;
 
 import sleeper.configuration.properties.instance.InstanceProperties;
 
-import static sleeper.utils.HadoopConfigurationProvider.getConfigurationForECS;
+import static sleeper.io.parquet.utils.HadoopConfigurationProvider.getConfigurationForECS;
 
 public class HadoopConfigurationProviderForDeployedS3Instance implements HadoopConfigurationProvider {
     /**
@@ -31,7 +31,7 @@ public class HadoopConfigurationProviderForDeployedS3Instance implements HadoopC
      * are not visible by default when it runs inside a Trino plugin. It causes truly horrible bugs which are difficult
      * to track down. Setting the classloader to the same one that is used by this class resolves the issue.
      * <p>
-     * The configuration details are taken from {@link sleeper.utils.HadoopConfigurationProvider}.
+     * The configuration details are taken from {@link sleeper.io.parquet.utils.HadoopConfigurationProvider}.
      *
      * @return The Hadoop configuration.
      */


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1571

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Refactored to keep RangeQueryUtilsTest passing

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.