### PR TITLE
Issue 1553 - Store metadata for files that have been split

### DIFF
--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -316,7 +316,7 @@ public class CompactSortedFiles {
                         .filename(outputFilename)
                         .numberOfRecords(inputFileInfo.getNumberOfRecords() / 2)
                         .countApproximate(true)
-                        .hasAllRecordsInFile(false)
+                        .onlyContainsDataForThisPartition(false)
                         .build());
             }
         }
@@ -419,7 +419,7 @@ public class CompactSortedFiles {
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .numberOfRecords(recordsWritten.getLeft())
                 .countApproximate(false)
-                .hasAllRecordsInFile(true)
+                .onlyContainsDataForThisPartition(true)
                 .build();
         FileInfo rightFileInfo = FileInfo.builder()
                 .filename(outputFiles.getRight())
@@ -427,7 +427,7 @@ public class CompactSortedFiles {
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .numberOfRecords(recordsWritten.getRight())
                 .countApproximate(false)
-                .hasAllRecordsInFile(true)
+                .onlyContainsDataForThisPartition(true)
                 .build();
         try {
             stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(filesToBeMarkedReadyForGC, leftFileInfo, rightFileInfo);

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -315,6 +315,7 @@ public class CompactSortedFiles {
                         .partitionId(childPartitionId)
                         .filename(outputFilename)
                         .numberOfRecords(inputFileInfo.getNumberOfRecords() / 2)
+                        .countApproximate(true)
                         .build());
             }
         }

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -316,6 +316,7 @@ public class CompactSortedFiles {
                         .filename(outputFilename)
                         .numberOfRecords(inputFileInfo.getNumberOfRecords() / 2)
                         .countApproximate(true)
+                        .hasAllRecordsInFile(false)
                         .build());
             }
         }

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -418,12 +418,16 @@ public class CompactSortedFiles {
                 .partitionId(childPartitions.get(0))
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .numberOfRecords(recordsWritten.getLeft())
+                .countApproximate(false)
+                .hasAllRecordsInFile(true)
                 .build();
         FileInfo rightFileInfo = FileInfo.builder()
                 .filename(outputFiles.getRight())
                 .partitionId(childPartitions.get(1))
                 .fileStatus(FileInfo.FileStatus.ACTIVE)
                 .numberOfRecords(recordsWritten.getRight())
+                .countApproximate(false)
+                .hasAllRecordsInFile(true)
                 .build();
         try {
             stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(filesToBeMarkedReadyForGC, leftFileInfo, rightFileInfo);

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
@@ -239,15 +239,14 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             // And the new files are recorded in the state store
             List<FileInfo> activeFiles = stateStore.getActiveFiles();
             assertThat(activeFiles)
-                    .extracting(FileInfo::getPartitionId, FileInfo::getNumberOfRecords)
-                    .containsExactlyInAnyOrder(tuple("L", 1L), tuple("R", 1L));
+                    .extracting(FileInfo::getPartitionId, FileInfo::getNumberOfRecords, FileInfo::isCountApproximate)
+                    .containsExactlyInAnyOrder(tuple("L", 1L, true), tuple("R", 1L, true));
 
             // And the new files each have all the copied records and sketches
             assertThat(activeFiles).allSatisfy(file -> {
                 assertThat(readDataFile(schema, file.getFilename())).isEqualTo(records);
                 assertThat(asDecilesMaps(getSketches(schema, file.getFilename())))
                         .isEqualTo(asDecilesMaps(rootSketches));
-                assertThat(file.isCountApproximate()).isTrue();
             });
 
             // And the original file is ready for GC

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
@@ -108,7 +108,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             // - Check the new files do not have approximate counts
             assertThat(stateStore.getActiveFiles()).allSatisfy(file -> {
                 assertThat(file.isCountApproximate()).isFalse();
-                assertThat(file.hasAllRecordsInFile()).isTrue();
+                assertThat(file.onlyContainsDataForThisPartition()).isTrue();
             });
         }
 
@@ -164,7 +164,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             // - Check the new files do not have approximate counts
             assertThat(stateStore.getActiveFiles()).allSatisfy(file -> {
                 assertThat(file.isCountApproximate()).isFalse();
-                assertThat(file.hasAllRecordsInFile()).isTrue();
+                assertThat(file.onlyContainsDataForThisPartition()).isTrue();
             });
         }
 
@@ -219,7 +219,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             // - Check the new files do not have approximate counts
             assertThat(stateStore.getActiveFiles()).allSatisfy(file -> {
                 assertThat(file.isCountApproximate()).isFalse();
-                assertThat(file.hasAllRecordsInFile()).isTrue();
+                assertThat(file.onlyContainsDataForThisPartition()).isTrue();
             });
         }
     }
@@ -263,7 +263,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             // And the new files represent parts of the original file and have approximate counts
             assertThat(activeFiles).allSatisfy(file -> {
                 assertThat(file.isCountApproximate()).isTrue();
-                assertThat(file.hasAllRecordsInFile()).isFalse();
+                assertThat(file.onlyContainsDataForThisPartition()).isFalse();
             });
 
             // And the new files each have all the copied records and sketches

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
@@ -100,10 +100,16 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
 
             // - Check DynamoDBStateStore has correct active files
             assertThat(stateStore.getActiveFiles())
-                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                    .extracting(FileInfo::getPartitionId, FileInfo::getFilename, FileInfo::getNumberOfRecords)
                     .containsExactlyInAnyOrder(
-                            dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L),
-                            dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L));
+                            tuple("A", compactionJob.getOutputFiles().getLeft(), 100L),
+                            tuple("B", compactionJob.getOutputFiles().getRight(), 100L));
+
+            // - Check the new files do not have approximate counts
+            assertThat(stateStore.getActiveFiles()).allSatisfy(file -> {
+                assertThat(file.isCountApproximate()).isFalse();
+                assertThat(file.hasAllRecordsInFile()).isTrue();
+            });
         }
 
         @Test
@@ -150,10 +156,16 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
 
             // - Check DynamoDBStateStore has correct active files
             assertThat(stateStore.getActiveFiles())
-                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                    .extracting(FileInfo::getPartitionId, FileInfo::getFilename, FileInfo::getNumberOfRecords)
                     .containsExactlyInAnyOrder(
-                            dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L),
-                            dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L));
+                            tuple("A", compactionJob.getOutputFiles().getLeft(), 100L),
+                            tuple("B", compactionJob.getOutputFiles().getRight(), 100L));
+
+            // - Check the new files do not have approximate counts
+            assertThat(stateStore.getActiveFiles()).allSatisfy(file -> {
+                assertThat(file.isCountApproximate()).isFalse();
+                assertThat(file.hasAllRecordsInFile()).isTrue();
+            });
         }
 
         @Test
@@ -199,10 +211,16 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
 
             // - Check DynamoDBStateStore has correct active files
             assertThat(stateStore.getActiveFiles())
-                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields("lastStateStoreUpdateTime")
+                    .extracting(FileInfo::getPartitionId, FileInfo::getFilename, FileInfo::getNumberOfRecords)
                     .containsExactlyInAnyOrder(
-                            dataHelper.expectedPartitionFile("A", compactionJob.getOutputFiles().getLeft(), 100L),
-                            dataHelper.expectedPartitionFile("B", compactionJob.getOutputFiles().getRight(), 100L));
+                            tuple("A", compactionJob.getOutputFiles().getLeft(), 100L),
+                            tuple("B", compactionJob.getOutputFiles().getRight(), 100L));
+
+            // - Check the new files do not have approximate counts
+            assertThat(stateStore.getActiveFiles()).allSatisfy(file -> {
+                assertThat(file.isCountApproximate()).isFalse();
+                assertThat(file.hasAllRecordsInFile()).isTrue();
+            });
         }
     }
 
@@ -242,7 +260,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
                     .extracting(FileInfo::getPartitionId, FileInfo::getNumberOfRecords)
                     .containsExactlyInAnyOrder(tuple("L", 1L), tuple("R", 1L));
 
-            // And the new files represent parts of the original file and do not have approximate counts
+            // And the new files represent parts of the original file and have approximate counts
             assertThat(activeFiles).allSatisfy(file -> {
                 assertThat(file.isCountApproximate()).isTrue();
                 assertThat(file.hasAllRecordsInFile()).isFalse();

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
@@ -239,8 +239,14 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
             // And the new files are recorded in the state store
             List<FileInfo> activeFiles = stateStore.getActiveFiles();
             assertThat(activeFiles)
-                    .extracting(FileInfo::getPartitionId, FileInfo::getNumberOfRecords, FileInfo::isCountApproximate)
-                    .containsExactlyInAnyOrder(tuple("L", 1L, true), tuple("R", 1L, true));
+                    .extracting(FileInfo::getPartitionId, FileInfo::getNumberOfRecords)
+                    .containsExactlyInAnyOrder(tuple("L", 1L), tuple("R", 1L));
+
+            // And the new files represent parts of the original file and do not have approximate counts
+            assertThat(activeFiles).allSatisfy(file -> {
+                assertThat(file.isCountApproximate()).isTrue();
+                assertThat(file.hasAllRecordsInFile()).isFalse();
+            });
 
             // And the new files each have all the copied records and sketches
             assertThat(activeFiles).allSatisfy(file -> {

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
@@ -247,6 +247,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
                 assertThat(readDataFile(schema, file.getFilename())).isEqualTo(records);
                 assertThat(asDecilesMaps(getSketches(schema, file.getFilename())))
                         .isEqualTo(asDecilesMaps(rootSketches));
+                assertThat(file.isCountApproximate()).isTrue();
             });
 
             // And the original file is ready for GC

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
@@ -36,15 +36,17 @@ public class FileInfo {
     private final String jobId;
     private final Long lastStateStoreUpdateTime; // The latest time (in milliseconds since the epoch) that the status of the file was updated in the StateStore
     private boolean countApproximate;
+    private boolean hasAllRecordsInFile;
 
     private FileInfo(Builder builder) {
-        this.filename = builder.filename;
-        this.partitionId = builder.partitionId;
-        this.numberOfRecords = builder.numberOfRecords;
-        this.fileStatus = builder.fileStatus;
-        this.jobId = builder.jobId;
-        this.lastStateStoreUpdateTime = builder.lastStateStoreUpdateTime;
-        this.countApproximate = builder.countApproximate;
+        filename = builder.filename;
+        partitionId = builder.partitionId;
+        numberOfRecords = builder.numberOfRecords;
+        fileStatus = builder.fileStatus;
+        jobId = builder.jobId;
+        lastStateStoreUpdateTime = builder.lastStateStoreUpdateTime;
+        countApproximate = builder.countApproximate;
+        hasAllRecordsInFile = builder.hasAllRecordsInFile;
     }
 
     public static Builder builder() {
@@ -79,6 +81,10 @@ public class FileInfo {
         return countApproximate;
     }
 
+    public boolean hasAllRecordsInFile() {
+        return hasAllRecordsInFile;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -88,12 +94,12 @@ public class FileInfo {
             return false;
         }
         FileInfo fileInfo = (FileInfo) o;
-        return countApproximate == fileInfo.countApproximate && Objects.equals(filename, fileInfo.filename) && Objects.equals(partitionId, fileInfo.partitionId) && Objects.equals(numberOfRecords, fileInfo.numberOfRecords) && fileStatus == fileInfo.fileStatus && Objects.equals(jobId, fileInfo.jobId) && Objects.equals(lastStateStoreUpdateTime, fileInfo.lastStateStoreUpdateTime);
+        return countApproximate == fileInfo.countApproximate && hasAllRecordsInFile == fileInfo.hasAllRecordsInFile && Objects.equals(filename, fileInfo.filename) && Objects.equals(partitionId, fileInfo.partitionId) && Objects.equals(numberOfRecords, fileInfo.numberOfRecords) && fileStatus == fileInfo.fileStatus && Objects.equals(jobId, fileInfo.jobId) && Objects.equals(lastStateStoreUpdateTime, fileInfo.lastStateStoreUpdateTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(filename, partitionId, numberOfRecords, fileStatus, jobId, lastStateStoreUpdateTime, countApproximate);
+        return Objects.hash(filename, partitionId, numberOfRecords, fileStatus, jobId, lastStateStoreUpdateTime, countApproximate, hasAllRecordsInFile);
     }
 
     @Override
@@ -106,6 +112,7 @@ public class FileInfo {
                 ", jobId='" + jobId + '\'' +
                 ", lastStateStoreUpdateTime=" + lastStateStoreUpdateTime +
                 ", countApproximate=" + countApproximate +
+                ", hasAllRecordsInFile=" + hasAllRecordsInFile +
                 '}';
     }
 
@@ -117,7 +124,8 @@ public class FileInfo {
                 .fileStatus(fileStatus)
                 .jobId(jobId)
                 .lastStateStoreUpdateTime(lastStateStoreUpdateTime)
-                .countApproximate(countApproximate);
+                .countApproximate(countApproximate)
+                .hasAllRecordsInFile(hasAllRecordsInFile);
     }
 
     public static final class Builder {
@@ -128,6 +136,7 @@ public class FileInfo {
         private String jobId;
         private Long lastStateStoreUpdateTime;
         private boolean countApproximate;
+        private boolean hasAllRecordsInFile = true;
 
         private Builder() {
         }
@@ -172,6 +181,11 @@ public class FileInfo {
 
         public Builder countApproximate(boolean countApproximate) {
             this.countApproximate = countApproximate;
+            return this;
+        }
+
+        public Builder hasAllRecordsInFile(boolean hasAllRecordsInFile) {
+            this.hasAllRecordsInFile = hasAllRecordsInFile;
             return this;
         }
 

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
@@ -36,7 +36,7 @@ public class FileInfo {
     private final String jobId;
     private final Long lastStateStoreUpdateTime; // The latest time (in milliseconds since the epoch) that the status of the file was updated in the StateStore
     private boolean countApproximate;
-    private boolean hasAllRecordsInFile;
+    private boolean onlyContainsDataForThisPartition;
 
     private FileInfo(Builder builder) {
         filename = builder.filename;
@@ -46,7 +46,7 @@ public class FileInfo {
         jobId = builder.jobId;
         lastStateStoreUpdateTime = builder.lastStateStoreUpdateTime;
         countApproximate = builder.countApproximate;
-        hasAllRecordsInFile = builder.hasAllRecordsInFile;
+        onlyContainsDataForThisPartition = builder.onlyContainsDataForThisPartition;
     }
 
     public static Builder builder() {
@@ -81,8 +81,8 @@ public class FileInfo {
         return countApproximate;
     }
 
-    public boolean hasAllRecordsInFile() {
-        return hasAllRecordsInFile;
+    public boolean onlyContainsDataForThisPartition() {
+        return onlyContainsDataForThisPartition;
     }
 
     @Override
@@ -94,12 +94,12 @@ public class FileInfo {
             return false;
         }
         FileInfo fileInfo = (FileInfo) o;
-        return countApproximate == fileInfo.countApproximate && hasAllRecordsInFile == fileInfo.hasAllRecordsInFile && Objects.equals(filename, fileInfo.filename) && Objects.equals(partitionId, fileInfo.partitionId) && Objects.equals(numberOfRecords, fileInfo.numberOfRecords) && fileStatus == fileInfo.fileStatus && Objects.equals(jobId, fileInfo.jobId) && Objects.equals(lastStateStoreUpdateTime, fileInfo.lastStateStoreUpdateTime);
+        return countApproximate == fileInfo.countApproximate && onlyContainsDataForThisPartition == fileInfo.onlyContainsDataForThisPartition && Objects.equals(filename, fileInfo.filename) && Objects.equals(partitionId, fileInfo.partitionId) && Objects.equals(numberOfRecords, fileInfo.numberOfRecords) && fileStatus == fileInfo.fileStatus && Objects.equals(jobId, fileInfo.jobId) && Objects.equals(lastStateStoreUpdateTime, fileInfo.lastStateStoreUpdateTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(filename, partitionId, numberOfRecords, fileStatus, jobId, lastStateStoreUpdateTime, countApproximate, hasAllRecordsInFile);
+        return Objects.hash(filename, partitionId, numberOfRecords, fileStatus, jobId, lastStateStoreUpdateTime, countApproximate, onlyContainsDataForThisPartition);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class FileInfo {
                 ", jobId='" + jobId + '\'' +
                 ", lastStateStoreUpdateTime=" + lastStateStoreUpdateTime +
                 ", countApproximate=" + countApproximate +
-                ", hasAllRecordsInFile=" + hasAllRecordsInFile +
+                ", onlyContainsDataForThisPartition=" + onlyContainsDataForThisPartition +
                 '}';
     }
 
@@ -125,7 +125,7 @@ public class FileInfo {
                 .jobId(jobId)
                 .lastStateStoreUpdateTime(lastStateStoreUpdateTime)
                 .countApproximate(countApproximate)
-                .hasAllRecordsInFile(hasAllRecordsInFile);
+                .onlyContainsDataForThisPartition(onlyContainsDataForThisPartition);
     }
 
     public static final class Builder {
@@ -136,7 +136,7 @@ public class FileInfo {
         private String jobId;
         private Long lastStateStoreUpdateTime;
         private boolean countApproximate;
-        private boolean hasAllRecordsInFile = true;
+        private boolean onlyContainsDataForThisPartition;
 
         private Builder() {
         }
@@ -184,8 +184,8 @@ public class FileInfo {
             return this;
         }
 
-        public Builder hasAllRecordsInFile(boolean hasAllRecordsInFile) {
-            this.hasAllRecordsInFile = hasAllRecordsInFile;
+        public Builder onlyContainsDataForThisPartition(boolean onlyContainsDataForThisPartition) {
+            this.onlyContainsDataForThisPartition = onlyContainsDataForThisPartition;
             return this;
         }
 

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
@@ -135,7 +135,7 @@ public class FileInfo {
         private FileStatus fileStatus;
         private String jobId;
         private Long lastStateStoreUpdateTime;
-        private boolean countApproximate = true;
+        private boolean countApproximate;
         private boolean hasAllRecordsInFile = true;
 
         private Builder() {

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
@@ -135,7 +135,7 @@ public class FileInfo {
         private FileStatus fileStatus;
         private String jobId;
         private Long lastStateStoreUpdateTime;
-        private boolean countApproximate;
+        private boolean countApproximate = true;
         private boolean hasAllRecordsInFile = true;
 
         private Builder() {

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfo.java
@@ -35,6 +35,7 @@ public class FileInfo {
     private final FileStatus fileStatus;
     private final String jobId;
     private final Long lastStateStoreUpdateTime; // The latest time (in milliseconds since the epoch) that the status of the file was updated in the StateStore
+    private boolean countApproximate;
 
     private FileInfo(Builder builder) {
         this.filename = builder.filename;
@@ -43,6 +44,7 @@ public class FileInfo {
         this.fileStatus = builder.fileStatus;
         this.jobId = builder.jobId;
         this.lastStateStoreUpdateTime = builder.lastStateStoreUpdateTime;
+        this.countApproximate = builder.countApproximate;
     }
 
     public static Builder builder() {
@@ -73,21 +75,25 @@ public class FileInfo {
         return numberOfRecords;
     }
 
+    public boolean isCountApproximate() {
+        return countApproximate;
+    }
+
     @Override
-    public boolean equals(Object object) {
-        if (this == object) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (object == null || getClass() != object.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        FileInfo fileInfo = (FileInfo) object;
-        return Objects.equals(filename, fileInfo.filename) && Objects.equals(partitionId, fileInfo.partitionId) && Objects.equals(numberOfRecords, fileInfo.numberOfRecords) && fileStatus == fileInfo.fileStatus && Objects.equals(jobId, fileInfo.jobId) && Objects.equals(lastStateStoreUpdateTime, fileInfo.lastStateStoreUpdateTime);
+        FileInfo fileInfo = (FileInfo) o;
+        return countApproximate == fileInfo.countApproximate && Objects.equals(filename, fileInfo.filename) && Objects.equals(partitionId, fileInfo.partitionId) && Objects.equals(numberOfRecords, fileInfo.numberOfRecords) && fileStatus == fileInfo.fileStatus && Objects.equals(jobId, fileInfo.jobId) && Objects.equals(lastStateStoreUpdateTime, fileInfo.lastStateStoreUpdateTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(filename, partitionId, numberOfRecords, fileStatus, jobId, lastStateStoreUpdateTime);
+        return Objects.hash(filename, partitionId, numberOfRecords, fileStatus, jobId, lastStateStoreUpdateTime, countApproximate);
     }
 
     @Override
@@ -99,6 +105,7 @@ public class FileInfo {
                 ", fileStatus=" + fileStatus +
                 ", jobId='" + jobId + '\'' +
                 ", lastStateStoreUpdateTime=" + lastStateStoreUpdateTime +
+                ", countApproximate=" + countApproximate +
                 '}';
     }
 
@@ -109,7 +116,8 @@ public class FileInfo {
                 .numberOfRecords(numberOfRecords)
                 .fileStatus(fileStatus)
                 .jobId(jobId)
-                .lastStateStoreUpdateTime(lastStateStoreUpdateTime);
+                .lastStateStoreUpdateTime(lastStateStoreUpdateTime)
+                .countApproximate(countApproximate);
     }
 
     public static final class Builder {
@@ -119,6 +127,7 @@ public class FileInfo {
         private FileStatus fileStatus;
         private String jobId;
         private Long lastStateStoreUpdateTime;
+        private boolean countApproximate;
 
         private Builder() {
         }
@@ -159,6 +168,11 @@ public class FileInfo {
             } else {
                 return lastStateStoreUpdateTime(lastStateStoreUpdateTime.toEpochMilli());
             }
+        }
+
+        public Builder countApproximate(boolean countApproximate) {
+            this.countApproximate = countApproximate;
+            return this;
         }
 
         public FileInfo build() {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1553

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - CompactSortedFilesSplittingIT

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.