### PR TITLE
Issue 1613 - Make logger output number of active files created in DynamoDBFileInfoStore

### DIFF
--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
@@ -179,8 +179,8 @@ class DynamoDBFileInfoStore implements FileInfoStore {
             TransactWriteItemsResult transactWriteItemsResult = dynamoDB.transactWriteItems(transactWriteItemsRequest);
             List<ConsumedCapacity> consumedCapacity = transactWriteItemsResult.getConsumedCapacity();
             double totalConsumed = consumedCapacity.stream().mapToDouble(ConsumedCapacity::getCapacityUnits).sum();
-            LOGGER.debug("Updated status of {} files to ready for GC and added 2 active files, capacity consumed = {}",
-                    filesToBeMarkedReadyForGC.size(), totalConsumed);
+            LOGGER.debug("Updated status of {} files to ready for GC and added {} active files, capacity consumed = {}",
+                    filesToBeMarkedReadyForGC.size(), newFiles.size(), totalConsumed);
         } catch (TransactionCanceledException | ResourceNotFoundException
                  | TransactionInProgressException | IdempotentParameterMismatchException
                  | ProvisionedThroughputExceededException | InternalServerErrorException e) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1613

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updating log message

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.