### PR TITLE
Issue 1609 - Move optional stack system tests to performance test suite

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1197,7 +1197,7 @@
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <groups>SystemTest</groups>
-                            <excludedGroups>none</excludedGroups>
+                            <excludedGroups>slow</excludedGroups>
                             <forkedProcessTimeoutInSeconds>0</forkedProcessTimeoutInSeconds>
                         </configuration>
                     </plugin>
@@ -1271,6 +1271,7 @@
                             <includes>
                                 <include>${singleIT}</include>
                             </includes>
+                            <excludedGroups>none</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceIT.java
@@ -19,7 +19,6 @@ package sleeper.systemtest.suite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import sleeper.core.util.PollWithRetries;
@@ -37,6 +36,7 @@ import static sleeper.systemtest.suite.fixtures.SystemTestInstance.COMPACTION_PE
 import static sleeper.systemtest.suite.testutil.FileInfoSystemTestHelper.numberOfRecordsIn;
 
 @Tag("SystemTest")
+@Tag("slow")
 public class CompactionPerformanceIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
@@ -50,7 +50,6 @@ public class CompactionPerformanceIT {
     }
 
     @Test
-    @DisabledIf("systemTestClusterDisabled")
     void shouldMeetCompactionPerformanceStandards() throws InterruptedException {
         sleeper.systemTestCluster().updateProperties(properties -> {
             properties.set(INGEST_MODE, IngestMode.DIRECT.toString());
@@ -69,9 +68,5 @@ public class CompactionPerformanceIT {
                 .matches(stats -> stats.isAllFinishedOneRunEach(10)
                                 && stats.isMinAverageRunRecordsPerSecond(300000),
                         "meets minimum performance");
-    }
-
-    boolean systemTestClusterDisabled() {
-        return sleeper.systemTestCluster().isDisabled();
     }
 }

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksBulkImportIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksBulkImportIT.java
@@ -39,6 +39,7 @@ import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
 import static sleeper.systemtest.suite.testutil.PartitionsTestHelper.partitionsBuilder;
 
 @Tag("SystemTest")
+@Tag("slow")
 public class EksBulkImportIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrBulkImportPerformanceIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrBulkImportPerformanceIT.java
@@ -19,7 +19,6 @@ package sleeper.systemtest.suite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import sleeper.core.util.PollWithRetries;
@@ -39,6 +38,7 @@ import static sleeper.systemtest.suite.testutil.FileInfoSystemTestHelper.numberO
 import static sleeper.systemtest.suite.testutil.PartitionsTestHelper.create512StringPartitions;
 
 @Tag("SystemTest")
+@Tag("slow")
 public class EmrBulkImportPerformanceIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
@@ -52,7 +52,6 @@ public class EmrBulkImportPerformanceIT {
     }
 
     @Test
-    @DisabledIf("systemTestClusterDisabled")
     void shouldMeetBulkImportPerformanceStandardsAcrossManyPartitions() throws InterruptedException {
         sleeper.partitioning().setPartitions(create512StringPartitions(sleeper));
         sleeper.systemTestCluster().updateProperties(properties -> {
@@ -76,9 +75,5 @@ public class EmrBulkImportPerformanceIT {
                 .matches(stats -> stats.isAllFinishedOneRunEach(5)
                                 && stats.isMinAverageRunRecordsPerSecond(3_500_000),
                         "meets minimum performance");
-    }
-
-    boolean systemTestClusterDisabled() {
-        return sleeper.systemTestCluster().isDisabled();
     }
 }

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrPersistentBulkImportIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrPersistentBulkImportIT.java
@@ -40,6 +40,7 @@ import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
 import static sleeper.systemtest.suite.testutil.PartitionsTestHelper.partitionsBuilder;
 
 @Tag("SystemTest")
+@Tag("slow")
 public class EmrPersistentBulkImportIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestPerformanceIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/IngestPerformanceIT.java
@@ -19,7 +19,6 @@ package sleeper.systemtest.suite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import sleeper.core.util.PollWithRetries;
@@ -38,6 +37,7 @@ import static sleeper.systemtest.suite.testutil.FileInfoSystemTestHelper.numberO
 import static sleeper.systemtest.suite.testutil.PartitionsTestHelper.create128StringPartitions;
 
 @Tag("SystemTest")
+@Tag("slow")
 public class IngestPerformanceIT {
     private final SleeperSystemTest sleeper = SleeperSystemTest.getInstance();
 
@@ -51,7 +51,6 @@ public class IngestPerformanceIT {
     }
 
     @Test
-    @DisabledIf("systemTestClusterDisabled")
     void shouldMeetIngestPerformanceStandardsAcrossManyPartitions() throws InterruptedException {
         sleeper.partitioning().setPartitions(create128StringPartitions(sleeper));
         sleeper.systemTestCluster().updateProperties(properties -> {
@@ -72,9 +71,5 @@ public class IngestPerformanceIT {
                 .matches(stats -> stats.isAllFinishedOneRunEach(11)
                                 && stats.isMinAverageRunRecordsPerSecond(130_000),
                         "meets minimum performance");
-    }
-
-    boolean systemTestClusterDisabled() {
-        return sleeper.systemTestCluster().isDisabled();
     }
 }

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -34,10 +34,10 @@ VPC=$1
 SUBNETS=$2
 RESULTS_BUCKET=$3
 if [ "$4" == "performance" ]; then
-  TEST_SUITE_PARAMS="-Dsleeper.system.test.cluster.enabled=true"
+  TEST_SUITE_PARAMS=(-Dsleeper.system.test.cluster.enabled=true -DexcludedGroups=none)
   TEST_SUITE_NAME="performance"
 elif [ "$4" == "functional" ]; then
-  TEST_SUITE_PARAMS="-Dsleeper.system.test.cluster.enabled=false"
+  TEST_SUITE_PARAMS=()
   TEST_SUITE_NAME="functional"
 else
   echo "Invalid test type: $4"
@@ -88,7 +88,7 @@ runMavenSystemTests() {
     ./maven/tearDown.sh "$SHORT_ID" "${INSTANCE_IDS[@]}" &> "$OUTPUT_DIR/$TEST_NAME.tearDown.log"
 }
 
-runMavenSystemTests "mvn-$START_TIME_SHORT" $TEST_SUITE_NAME $TEST_SUITE_PARAMS
+runMavenSystemTests "mvn-$START_TIME_SHORT" $TEST_SUITE_NAME "${TEST_SUITE_PARAMS[@]}"
 runMavenSystemTests "dyn-$START_TIME_SHORT" dynamo-state-store -Dsleeper.system.test.force.statestore.classname=sleeper.statestore.dynamodb.DynamoDBStateStore
 
 echo "[$(time_str)] Uploading test output"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1609

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updates slow system tests with new tag
    - Reduces number of tables in MultipleTablesIT further to keep it relatively quick
    - Tested in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.