### PR TITLE
Issue 1646 - Add missing Javadoc to state store methods

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
@@ -90,9 +90,9 @@ public class ReinitialiseTable {
         LOGGER.info("State store type: {}", stateStore.getClass().getName());
 
         if (deletePartitions) {
-            stateStore.clearFileData();
-        } else {
             stateStore.clearSleeperTable();
+        } else {
+            stateStore.clearFileData();
         }
         deleteObjectsInTableBucket(instanceProperties);
         if (deletePartitions) {

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
@@ -90,9 +90,9 @@ public class ReinitialiseTable {
         LOGGER.info("State store type: {}", stateStore.getClass().getName());
 
         if (deletePartitions) {
-            stateStore.clearSleeperTable();
+            stateStore.clearFileData();
         } else {
-            stateStore.clearFiles();
+            stateStore.clearSleeperTable();
         }
         deleteObjectsInTableBucket(instanceProperties);
         if (deletePartitions) {

--- a/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/ReinitialiseTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public class ReinitialiseTable {
         LOGGER.info("State store type: {}", stateStore.getClass().getName());
 
         if (deletePartitions) {
-            stateStore.clearTable();
+            stateStore.clearSleeperTable();
         } else {
             stateStore.clearFiles();
         }

--- a/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
@@ -124,14 +124,14 @@ public class DelegatingStateStore implements StateStore {
     }
 
     @Override
-    public void clearTable() {
-        fileInfoStore.clearTable();
-        partitionStore.clearTable();
+    public void clearSleeperTable() {
+        fileInfoStore.clearSleeperTable();
+        partitionStore.clearSleeperTable();
     }
 
     @Override
     public void clearFiles() {
-        fileInfoStore.clearTable();
+        fileInfoStore.clearSleeperTable();
     }
 
     /**

--- a/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
@@ -134,11 +134,6 @@ public class DelegatingStateStore implements StateStore {
         fileInfoStore.clearSleeperTable();
     }
 
-    /**
-     * Used to set the current time. Should only be called during tests.
-     *
-     * @param now Time to set to be the current time
-     */
     @Override
     public void fixTime(Instant now) {
         fileInfoStore.fixTime(now);

--- a/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/DelegatingStateStore.java
@@ -124,14 +124,13 @@ public class DelegatingStateStore implements StateStore {
     }
 
     @Override
-    public void clearSleeperTable() {
-        fileInfoStore.clearSleeperTable();
-        partitionStore.clearSleeperTable();
+    public void clearFileData() {
+        fileInfoStore.clearFileData();
     }
 
     @Override
-    public void clearFiles() {
-        fileInfoStore.clearSleeperTable();
+    public void clearPartitionData() {
+        partitionStore.clearPartitionData();
     }
 
     @Override

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
@@ -131,6 +131,8 @@ public interface FileInfoStore {
 
     /**
      * Clears all file data from the file info store.
+     * <p>
+     * Note that this does not delete any of the actual files
      */
     void clearSleeperTable();
 

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
@@ -134,7 +134,7 @@ public interface FileInfoStore {
      * <p>
      * Note that this does not delete any of the actual files.
      */
-    void clearSleeperTable();
+    void clearFileData();
 
     /**
      * Used to set the current time. Should only be called during tests.

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
@@ -135,7 +135,9 @@ public interface FileInfoStore {
     void clearSleeperTable();
 
     /**
-     * Fixes the next update time that the file info store will use when performing updates.
+     * Used to set the current time. Should only be called during tests.
+     *
+     * @param time Time to set to be the current time
      */
     void fixTime(Instant time);
 }

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
@@ -119,7 +119,7 @@ public interface FileInfoStore {
 
     boolean hasNoFiles();
 
-    void clearTable();
+    void clearSleeperTable();
 
     void fixTime(Instant time);
 }

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
@@ -132,7 +132,7 @@ public interface FileInfoStore {
     /**
      * Clears all file data from the file info store.
      * <p>
-     * Note that this does not delete any of the actual files
+     * Note that this does not delete any of the actual files.
      */
     void clearSleeperTable();
 

--- a/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/FileInfoStore.java
@@ -115,11 +115,27 @@ public interface FileInfoStore {
      */
     AllFileReferences getAllFileReferencesWithMaxUnreferenced(int maxUnreferencedFiles) throws StateStoreException;
 
+    /**
+     * Performs extra setup steps that are needed before the file info store can be used.
+     *
+     * @throws StateStoreException if initialisation fails
+     */
     void initialise() throws StateStoreException;
 
+    /**
+     * Returns whether the file info store has files in it or not.
+     *
+     * @return a boolean representing whether the state store has files in it or not.
+     */
     boolean hasNoFiles();
 
+    /**
+     * Clears all file data from the file info store.
+     */
     void clearSleeperTable();
 
+    /**
+     * Fixes the next update time that the file info store will use when performing updates.
+     */
     void fixTime(Instant time);
 }

--- a/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,5 +69,5 @@ public interface PartitionStore {
      */
     void initialise(List<Partition> partitions) throws StateStoreException;
 
-    void clearTable();
+    void clearSleeperTable();
 }

--- a/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
@@ -75,5 +75,5 @@ public interface PartitionStore {
      * Note that after calling this method the partition store must be initialised
      * before the Sleeper table can be used again.
      */
-    void clearSleeperTable();
+    void clearPartitionData();
 }

--- a/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
@@ -69,5 +69,8 @@ public interface PartitionStore {
      */
     void initialise(List<Partition> partitions) throws StateStoreException;
 
+    /**
+     * Clears all partition data from the partition store.
+     */
     void clearSleeperTable();
 }

--- a/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/PartitionStore.java
@@ -71,6 +71,9 @@ public interface PartitionStore {
 
     /**
      * Clears all partition data from the partition store.
+     * <p>
+     * Note that after calling this method the partition store must be initialised
+     * before the Sleeper table can be used again.
      */
     void clearSleeperTable();
 }

--- a/java/core/src/main/java/sleeper/core/statestore/StateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/StateStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,5 +21,8 @@ package sleeper.core.statestore;
  */
 public interface StateStore extends FileInfoStore, PartitionStore {
 
-    void clearFiles();
+    default void clearSleeperTable() {
+        clearFileData();
+        clearPartitionData();
+    }
 }

--- a/java/core/src/main/java/sleeper/core/statestore/StateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/StateStore.java
@@ -20,7 +20,12 @@ package sleeper.core.statestore;
  * and the {@link sleeper.core.partition.Partition}s).
  */
 public interface StateStore extends FileInfoStore, PartitionStore {
-
+    /**
+     * Clears all file data and partition data from the state store.
+     * <p>
+     * Note that this does not delete any of the actual files, and after calling this
+     * method the partition store must be initialised before the Sleeper table can be used again.
+     */
     default void clearSleeperTable() {
         clearFileData();
         clearPartitionData();

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/FixedPartitionStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/FixedPartitionStore.java
@@ -69,7 +69,7 @@ public class FixedPartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearSleeperTable() {
+    public void clearPartitionData() {
         throw new UnsupportedOperationException("Cannot clear partitions with FixedPartitionStore");
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/FixedPartitionStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/FixedPartitionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class FixedPartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearTable() {
+    public void clearSleeperTable() {
         throw new UnsupportedOperationException("Cannot clear partitions with FixedPartitionStore");
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
@@ -186,7 +186,7 @@ public class InMemoryFileInfoStore implements FileInfoStore {
     }
 
     @Override
-    public void clearTable() {
+    public void clearSleeperTable() {
         partitionById.clear();
     }
 

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileInfoStore.java
@@ -186,7 +186,7 @@ public class InMemoryFileInfoStore implements FileInfoStore {
     }
 
     @Override
-    public void clearSleeperTable() {
+    public void clearFileData() {
         partitionById.clear();
     }
 

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryPartitionStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryPartitionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class InMemoryPartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearTable() {
+    public void clearSleeperTable() {
         partitions = List.of();
     }
 

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryPartitionStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryPartitionStore.java
@@ -61,7 +61,7 @@ public class InMemoryPartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearSleeperTable() {
+    public void clearPartitionData() {
         partitions = List.of();
     }
 

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
@@ -355,7 +355,7 @@ class DynamoDBFileInfoStore implements FileInfoStore {
     }
 
     @Override
-    public void clearSleeperTable() {
+    public void clearFileData() {
         clearDynamoTable(activeTableName, fileInfoFormat::getActiveFileKey);
         clearDynamoTable(fileReferenceCountTableName, item -> fileInfoFormat.createReferenceCountKey(item.get(FILENAME).getS()));
     }

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileInfoStore.java
@@ -355,7 +355,7 @@ class DynamoDBFileInfoStore implements FileInfoStore {
     }
 
     @Override
-    public void clearTable() {
+    public void clearSleeperTable() {
         clearDynamoTable(activeTableName, fileInfoFormat::getActiveFileKey);
         clearDynamoTable(fileReferenceCountTableName, item -> fileInfoFormat.createReferenceCountKey(item.get(FILENAME).getS()));
     }

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBPartitionStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBPartitionStore.java
@@ -195,7 +195,7 @@ class DynamoDBPartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearTable() {
+    public void clearSleeperTable() {
         deleteAllDynamoTableItems(dynamoDB, new QueryRequest().withTableName(dynamoTableName)
                         .withExpressionAttributeNames(Map.of("#TableId", TABLE_ID))
                         .withExpressionAttributeValues(new DynamoDBRecordBuilder()

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBPartitionStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBPartitionStore.java
@@ -195,7 +195,7 @@ class DynamoDBPartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearSleeperTable() {
+    public void clearPartitionData() {
         deleteAllDynamoTableItems(dynamoDB, new QueryRequest().withTableName(dynamoTableName)
                         .withExpressionAttributeNames(Map.of("#TableId", TABLE_ID))
                         .withExpressionAttributeValues(new DynamoDBRecordBuilder()

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileInfoStore.java
@@ -426,7 +426,7 @@ class S3FileInfoStore implements FileInfoStore {
     }
 
     @Override
-    public void clearSleeperTable() {
+    public void clearFileData() {
         Path path = new Path(stateStorePath + "/files");
         try {
             path.getFileSystem(conf).delete(path, true);

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileInfoStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileInfoStore.java
@@ -426,7 +426,7 @@ class S3FileInfoStore implements FileInfoStore {
     }
 
     @Override
-    public void clearTable() {
+    public void clearSleeperTable() {
         Path path = new Path(stateStorePath + "/files");
         try {
             path.getFileSystem(conf).delete(path, true);

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3PartitionStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3PartitionStore.java
@@ -221,7 +221,7 @@ class S3PartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearSleeperTable() {
+    public void clearPartitionData() {
         Path path = new Path(stateStorePath + "/partitions");
         try {
             path.getFileSystem(conf).delete(path, true);

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3PartitionStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3PartitionStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,7 +221,7 @@ class S3PartitionStore implements PartitionStore {
     }
 
     @Override
-    public void clearTable() {
+    public void clearSleeperTable() {
         Path path = new Path(stateStorePath + "/partitions");
         try {
             path.getFileSystem(conf).delete(path, true);

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
@@ -100,7 +100,7 @@ public class DynamoDBStateStoreMultipleTablesIT extends DynamoDBStateStoreTestBa
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearFiles();
+        stateStore1.clearSleeperTable();
 
         // Then
         assertThat(stateStore1.getActiveFiles()).isEmpty();
@@ -124,7 +124,7 @@ public class DynamoDBStateStoreMultipleTablesIT extends DynamoDBStateStoreTestBa
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearSleeperTable();
+        stateStore1.clearFileData();
 
         // Then
         assertThat(stateStore1.getAllPartitions()).isEmpty();

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
@@ -100,7 +100,7 @@ public class DynamoDBStateStoreMultipleTablesIT extends DynamoDBStateStoreTestBa
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearSleeperTable();
+        stateStore1.clearFileData();
 
         // Then
         assertThat(stateStore1.getActiveFiles()).isEmpty();
@@ -124,7 +124,7 @@ public class DynamoDBStateStoreMultipleTablesIT extends DynamoDBStateStoreTestBa
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearFileData();
+        stateStore1.clearSleeperTable();
 
         // Then
         assertThat(stateStore1.getAllPartitions()).isEmpty();

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBStateStoreMultipleTablesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,7 +124,7 @@ public class DynamoDBStateStoreMultipleTablesIT extends DynamoDBStateStoreTestBa
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearTable();
+        stateStore1.clearSleeperTable();
 
         // Then
         assertThat(stateStore1.getAllPartitions()).isEmpty();

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
@@ -88,7 +88,7 @@ public class S3StateStoreMultipleTablesIT extends S3StateStoreTestBase {
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearSleeperTable();
+        stateStore1.clearFileData();
 
         // Then
         assertThat(stateStore1.getActiveFiles()).isEmpty();
@@ -112,7 +112,7 @@ public class S3StateStoreMultipleTablesIT extends S3StateStoreTestBase {
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearFileData();
+        stateStore1.clearSleeperTable();
 
         // Then
         assertThat(stateStore1.getAllPartitions()).isEmpty();

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
@@ -88,7 +88,7 @@ public class S3StateStoreMultipleTablesIT extends S3StateStoreTestBase {
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearFiles();
+        stateStore1.clearSleeperTable();
 
         // Then
         assertThat(stateStore1.getActiveFiles()).isEmpty();
@@ -112,7 +112,7 @@ public class S3StateStoreMultipleTablesIT extends S3StateStoreTestBase {
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearSleeperTable();
+        stateStore1.clearFileData();
 
         // Then
         assertThat(stateStore1.getAllPartitions()).isEmpty();

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreMultipleTablesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class S3StateStoreMultipleTablesIT extends S3StateStoreTestBase {
         stateStore2.addFile(file2);
 
         // When
-        stateStore1.clearTable();
+        stateStore1.clearSleeperTable();
 
         // Then
         assertThat(stateStore1.getAllPartitions()).isEmpty();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1646

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Javadoc updates

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.