### PR TITLE
Issue 1663 - Purge splitting job queue on failure in partition splitting system tests

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/MultipleTablesIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/MultipleTablesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.COMPACTION_JOB_QUEUE_URL;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.INGEST_JOB_QUEUE_URL;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.PARTITION_SPLITTING_QUEUE_URL;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.SPLITTING_COMPACTION_JOB_QUEUE_URL;
 import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
 import static sleeper.core.testutils.printers.FileInfoPrinter.printExpectedFilesForAllTables;
 import static sleeper.core.testutils.printers.FileInfoPrinter.printTableFilesExpectingIdentical;
@@ -53,7 +54,7 @@ public class MultipleTablesIT {
     private final Schema schema = SystemTestSchema.DEFAULT_SCHEMA;
     @RegisterExtension
     public final PurgeQueueExtension purgeQueue = PurgeQueueExtension
-            .purgeIfTestFailed(sleeper, INGEST_JOB_QUEUE_URL, PARTITION_SPLITTING_QUEUE_URL, COMPACTION_JOB_QUEUE_URL);
+            .purgeIfTestFailed(sleeper, INGEST_JOB_QUEUE_URL, PARTITION_SPLITTING_QUEUE_URL, SPLITTING_COMPACTION_JOB_QUEUE_URL, COMPACTION_JOB_QUEUE_URL);
 
     @BeforeEach
     void setUp() {

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PartitionSplittingIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PartitionSplittingIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import java.util.stream.LongStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.COMPACTION_JOB_QUEUE_URL;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.PARTITION_SPLITTING_QUEUE_URL;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.SPLITTING_COMPACTION_JOB_QUEUE_URL;
 import static sleeper.configuration.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
 import static sleeper.core.testutils.printers.FileInfoPrinter.printFiles;
 import static sleeper.core.testutils.printers.PartitionsPrinter.printPartitions;
@@ -59,7 +60,7 @@ public class PartitionSplittingIT {
             sleeper.reportsForExtension().partitionStatus());
     @RegisterExtension
     public final PurgeQueueExtension purgeQueue = PurgeQueueExtension
-            .purgeIfTestFailed(sleeper, PARTITION_SPLITTING_QUEUE_URL, COMPACTION_JOB_QUEUE_URL);
+            .purgeIfTestFailed(sleeper, PARTITION_SPLITTING_QUEUE_URL, SPLITTING_COMPACTION_JOB_QUEUE_URL, COMPACTION_JOB_QUEUE_URL);
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1663

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated MultipleTablesIT
    - Updated PartitionSplittingIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.