### PR TITLE
Issue 1668 - Fail and retry compaction job if input files do not have jobId assigned to them

### DIFF
--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -251,7 +251,7 @@ public class CompactSortedFiles {
             }
         }
         stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(
-                compactionJob.getPartitionId(), compactionJob.getInputFiles(), outputFileInfos);
+                compactionJob.getId(), compactionJob.getPartitionId(), compactionJob.getInputFiles(), outputFileInfos);
         LOGGER.info("Compaction job {}: compaction committed to state store at {}", compactionJob.getId(), LocalDateTime.now());
         return new RecordsProcessed(0, 0);
     }

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -190,6 +190,7 @@ public class CompactSortedFiles {
 
         updateStateStoreSuccess(compactionJob.getInputFiles(),
                 compactionJob.getOutputFile(),
+                compactionJob.getId(),
                 compactionJob.getPartitionId(),
                 recordsWritten,
                 stateStore);
@@ -219,7 +220,7 @@ public class CompactSortedFiles {
             }
         }
         stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(
-                compactionJob.getPartitionId(), compactionJob.getInputFiles(), outputFileInfos);
+                compactionJob.getId(), compactionJob.getPartitionId(), compactionJob.getInputFiles(), outputFileInfos);
         return new RecordsProcessed(recordsProcessed, recordsProcessed);
     }
 
@@ -279,6 +280,7 @@ public class CompactSortedFiles {
 
     private static void updateStateStoreSuccess(List<String> inputFiles,
                                                 String outputFile,
+                                                String jobId,
                                                 String partitionId,
                                                 long recordsWritten,
                                                 StateStore stateStore) throws StateStoreException {
@@ -288,7 +290,7 @@ public class CompactSortedFiles {
                 .numberOfRecords(recordsWritten)
                 .build();
         try {
-            stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(partitionId, inputFiles, List.of(fileInfo));
+            stateStore.atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(jobId, partitionId, inputFiles, List.of(fileInfo));
             LOGGER.debug("Called atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFile method on StateStore");
         } catch (StateStoreException e) {
             LOGGER.error("Exception updating StateStore (moving input files to ready for GC and creating new active file): {}", e.getMessage());

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFiles.java
@@ -133,7 +133,7 @@ public class CompactSortedFiles {
         Instant startTime = Instant.now();
         String id = compactionJob.getId();
         if (!stateStore.areFilesAssignedToJob(id, compactionJob.getPartitionId(), compactionJob.getInputFiles())) {
-            throw new IllegalStateException("Cannot run compaction job, files are not assigned to this job yet");
+            throw new FilesNotAssignedException(compactionJob.getId());
         }
         LOGGER.info("Compaction job {}: compaction called at {}", id, startTime);
         jobStatusStore.jobStarted(compactionJob, startTime, taskId);

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,6 +188,10 @@ public class CompactSortedFilesRunner {
                     taskFinishedBuilder.addJobSummary(compact(compactionJob, message));
                     totalNumberOfMessagesProcessed++;
                     numConsecutiveTimesNoMessages = 0;
+                } catch (FilesNotAssignedException e) {
+                    LOGGER.error("Failed processing compaction job, putting job back on queue", e);
+                    numConsecutiveTimesNoMessages++;
+                    sqsClient.changeMessageVisibility(sqsJobQueueUrl, message.getReceiptHandle(), 5);
                 } catch (Exception e) {
                     LOGGER.error("Failed processing compaction job, putting job back on queue", e);
                     numConsecutiveTimesNoMessages++;

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/CompactSortedFilesRunner.java
@@ -53,6 +53,7 @@ import sleeper.core.util.LoggedDuration;
 import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.job.common.CommonJobUtils;
 import sleeper.job.common.action.ActionException;
+import sleeper.job.common.action.ChangeMessageVisibilityTimeoutAction;
 import sleeper.job.common.action.DeleteMessageAction;
 import sleeper.job.common.action.MessageReference;
 import sleeper.job.common.action.thread.PeriodicActionRunnable;
@@ -72,13 +73,15 @@ import static sleeper.configuration.properties.instance.CompactionProperty.COMPA
  * Retrieves compaction {@link CompactionJob}s from an SQS queue, and executes
  * them. It delegates the actual execution of the job to an instance of
  * {@link CompactSortedFiles}. It passes a
- * {@link sleeper.job.common.action.ChangeMessageVisibilityTimeoutAction} to
+ * {@link ChangeMessageVisibilityTimeoutAction} to
  * that class so that the message on the SQS queue can be kept alive whilst the job
  * is executing. It also handles deletion of the message when the job is completed.
  */
 public class CompactSortedFilesRunner {
     private static final Logger LOGGER = LoggerFactory.getLogger(CompactSortedFilesRunner.class);
-    private static final int FILES_NOT_ASSIGNED_RETRY_DELAY_SECONDS = 5;
+    private static final int DEFAULT_MAX_RETRIEVE_ATTEMPTS = 3;
+    private static final int DEFAULT_WAIT_TIME = 20;
+    private static final int DEFAULT_FILES_NOT_ASSIGNED_RETRY_DELAY_SECONDS = 5;
 
     private final InstanceProperties instanceProperties;
     private final ObjectFactory objectFactory;
@@ -96,54 +99,26 @@ public class CompactSortedFilesRunner {
     private final int maxMessageRetrieveAttempts;
     private final int waitTimeSeconds;
 
-    @SuppressWarnings("checkstyle:parameternumber")
-    public CompactSortedFilesRunner(
-            InstanceProperties instanceProperties,
-            ObjectFactory objectFactory,
-            TablePropertiesProvider tablePropertiesProvider,
-            PropertiesReloader propertiesReloader,
-            StateStoreProvider stateStoreProvider,
-            CompactionJobStatusStore jobStatusStore,
-            CompactionTaskStatusStore taskStatusStore,
-            String taskId,
-            String sqsJobQueueUrl,
-            AmazonSQS sqsClient,
-            AmazonECS ecsClient,
-            CompactionTaskType type,
-            int maxMessageRetrieveAttempts,
-            int waitTimeSeconds) {
-        this.instanceProperties = instanceProperties;
-        this.objectFactory = objectFactory;
-        this.tablePropertiesProvider = tablePropertiesProvider;
-        this.propertiesReloader = propertiesReloader;
-        this.stateStoreProvider = stateStoreProvider;
-        this.jobStatusStore = jobStatusStore;
-        this.taskStatusStore = taskStatusStore;
-        this.taskId = taskId;
-        this.sqsJobQueueUrl = sqsJobQueueUrl;
-        this.keepAliveFrequency = instanceProperties.getInt(COMPACTION_KEEP_ALIVE_PERIOD_IN_SECONDS);
-        this.sqsClient = sqsClient;
-        this.ecsClient = ecsClient;
-        this.type = type;
-        this.maxMessageRetrieveAttempts = maxMessageRetrieveAttempts;
-        this.waitTimeSeconds = waitTimeSeconds;
+    private CompactSortedFilesRunner(Builder builder) {
+        instanceProperties = builder.instanceProperties;
+        objectFactory = builder.objectFactory;
+        tablePropertiesProvider = builder.tablePropertiesProvider;
+        propertiesReloader = builder.propertiesReloader;
+        stateStoreProvider = builder.stateStoreProvider;
+        jobStatusStore = builder.jobStatusStore;
+        taskStatusStore = builder.taskStatusStore;
+        taskId = builder.taskId;
+        sqsJobQueueUrl = builder.sqsJobQueueUrl;
+        sqsClient = builder.sqsClient;
+        ecsClient = builder.ecsClient;
+        type = builder.type;
+        keepAliveFrequency = builder.keepAliveFrequency;
+        maxMessageRetrieveAttempts = builder.maxMessageRetrieveAttempts;
+        waitTimeSeconds = builder.waitTimeSeconds;
     }
 
-    public CompactSortedFilesRunner(
-            InstanceProperties instanceProperties,
-            ObjectFactory objectFactory,
-            TablePropertiesProvider tablePropertiesProvider,
-            PropertiesReloader propertiesReloader,
-            StateStoreProvider stateStoreProvider,
-            CompactionJobStatusStore jobStatusStore,
-            CompactionTaskStatusStore taskStatusStore,
-            String taskId,
-            String sqsJobQueueUrl,
-            AmazonSQS sqsClient,
-            AmazonECS ecsClient,
-            CompactionTaskType type) {
-        this(instanceProperties, objectFactory, tablePropertiesProvider, propertiesReloader, stateStoreProvider,
-                jobStatusStore, taskStatusStore, taskId, sqsJobQueueUrl, sqsClient, ecsClient, type, 3, 20);
+    public static Builder builder() {
+        return new Builder();
     }
 
     public void run() throws InterruptedException, IOException {
@@ -191,9 +166,9 @@ public class CompactSortedFilesRunner {
                     numConsecutiveTimesNoMessages = 0;
                 } catch (FilesNotAssignedException e) {
                     LOGGER.error("Failed processing compaction job, putting job back on queue. Will retry after {} seconds",
-                            FILES_NOT_ASSIGNED_RETRY_DELAY_SECONDS, e);
+                            DEFAULT_FILES_NOT_ASSIGNED_RETRY_DELAY_SECONDS, e);
                     numConsecutiveTimesNoMessages++;
-                    sqsClient.changeMessageVisibility(sqsJobQueueUrl, message.getReceiptHandle(), FILES_NOT_ASSIGNED_RETRY_DELAY_SECONDS);
+                    sqsClient.changeMessageVisibility(sqsJobQueueUrl, message.getReceiptHandle(), DEFAULT_FILES_NOT_ASSIGNED_RETRY_DELAY_SECONDS);
                 } catch (Exception e) {
                     LOGGER.error("Failed processing compaction job, putting job back on queue. Will retry immediately", e);
                     numConsecutiveTimesNoMessages++;
@@ -292,18 +267,18 @@ public class CompactSortedFilesRunner {
         }
 
         ObjectFactory objectFactory = new ObjectFactory(instanceProperties, s3Client, "/tmp");
-        CompactSortedFilesRunner runner = new CompactSortedFilesRunner(
-                instanceProperties, objectFactory,
-                tablePropertiesProvider,
-                propertiesReloader,
-                stateStoreProvider,
-                jobStatusStore,
-                taskStatusStore,
-                UUID.randomUUID().toString(),
-                sqsJobQueueUrl,
-                sqsClient,
-                ecsClient,
-                type);
+        CompactSortedFilesRunner runner = CompactSortedFilesRunner.builder()
+                .instanceProperties(instanceProperties)
+                .objectFactory(objectFactory)
+                .tablePropertiesProvider(tablePropertiesProvider)
+                .propertiesReloader(propertiesReloader)
+                .stateStoreProvider(stateStoreProvider)
+                .jobStatusStore(jobStatusStore)
+                .taskStatusStore(taskStatusStore)
+                .taskId(UUID.randomUUID().toString())
+                .sqsJobQueueUrl(sqsJobQueueUrl)
+                .type(type)
+                .buildWithDefaultClients();
         runner.run();
 
         sqsClient.shutdown();
@@ -314,5 +289,107 @@ public class CompactSortedFilesRunner {
         LOGGER.info("Shut down s3Client");
         ecsClient.shutdown();
         LOGGER.info("Shut down ecsClient");
+    }
+
+    public static final class Builder {
+        private InstanceProperties instanceProperties;
+        private ObjectFactory objectFactory;
+        private TablePropertiesProvider tablePropertiesProvider;
+        private PropertiesReloader propertiesReloader;
+        private StateStoreProvider stateStoreProvider;
+        private CompactionJobStatusStore jobStatusStore;
+        private CompactionTaskStatusStore taskStatusStore;
+        private String taskId;
+        private String sqsJobQueueUrl;
+        private AmazonSQS sqsClient;
+        private AmazonECS ecsClient;
+        private CompactionTaskType type;
+        private int keepAliveFrequency;
+        private int maxMessageRetrieveAttempts = DEFAULT_MAX_RETRIEVE_ATTEMPTS;
+        private int waitTimeSeconds = DEFAULT_WAIT_TIME;
+
+        private Builder() {
+        }
+
+        public Builder instanceProperties(InstanceProperties instanceProperties) {
+            this.instanceProperties = instanceProperties;
+            this.keepAliveFrequency = instanceProperties.getInt(COMPACTION_KEEP_ALIVE_PERIOD_IN_SECONDS);
+            return this;
+        }
+
+        public Builder objectFactory(ObjectFactory objectFactory) {
+            this.objectFactory = objectFactory;
+            return this;
+        }
+
+        public Builder tablePropertiesProvider(TablePropertiesProvider tablePropertiesProvider) {
+            this.tablePropertiesProvider = tablePropertiesProvider;
+            return this;
+        }
+
+        public Builder propertiesReloader(PropertiesReloader propertiesReloader) {
+            this.propertiesReloader = propertiesReloader;
+            return this;
+        }
+
+        public Builder stateStoreProvider(StateStoreProvider stateStoreProvider) {
+            this.stateStoreProvider = stateStoreProvider;
+            return this;
+        }
+
+        public Builder jobStatusStore(CompactionJobStatusStore jobStatusStore) {
+            this.jobStatusStore = jobStatusStore;
+            return this;
+        }
+
+        public Builder taskStatusStore(CompactionTaskStatusStore taskStatusStore) {
+            this.taskStatusStore = taskStatusStore;
+            return this;
+        }
+
+        public Builder taskId(String taskId) {
+            this.taskId = taskId;
+            return this;
+        }
+
+        public Builder sqsJobQueueUrl(String sqsJobQueueUrl) {
+            this.sqsJobQueueUrl = sqsJobQueueUrl;
+            return this;
+        }
+
+        public Builder sqsClient(AmazonSQS sqsClient) {
+            this.sqsClient = sqsClient;
+            return this;
+        }
+
+        public Builder ecsClient(AmazonECS ecsClient) {
+            this.ecsClient = ecsClient;
+            return this;
+        }
+
+        public Builder type(CompactionTaskType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder maxMessageRetrieveAttempts(int maxMessageRetrieveAttempts) {
+            this.maxMessageRetrieveAttempts = maxMessageRetrieveAttempts;
+            return this;
+        }
+
+        public Builder waitTimeSeconds(int waitTimeSeconds) {
+            this.waitTimeSeconds = waitTimeSeconds;
+            return this;
+        }
+
+        public CompactSortedFilesRunner buildWithDefaultClients() {
+            return sqsClient(AmazonSQSClientBuilder.defaultClient())
+                    .ecsClient(AmazonECSClientBuilder.defaultClient())
+                    .build();
+        }
+
+        public CompactSortedFilesRunner build() {
+            return new CompactSortedFilesRunner(this);
+        }
     }
 }

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/FilesNotAssignedException.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/FilesNotAssignedException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.compaction.jobexecution;
+
+public class FilesNotAssignedException extends IllegalStateException {
+    public FilesNotAssignedException(String jobId) {
+        super("Some files are not assigned to compaction job " + jobId);
+    }
+}

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/QueueMessageVisibility.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/jobexecution/QueueMessageVisibility.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.compaction.jobexecution;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+
+public class QueueMessageVisibility {
+    private QueueMessageVisibility() {
+    }
+
+    public static Client withSqsClient(AmazonSQS sqsClient) {
+        return (sqsClient::changeMessageVisibility);
+    }
+
+    @FunctionalInterface
+    public interface Client {
+        void update(String queueUrl, String messageReceiptHandle, int visibilityTimeout);
+    }
+}

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesEmptyOutputIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesEmptyOutputIT.java
@@ -53,6 +53,7 @@ class CompactSortedFilesEmptyOutputIT extends CompactSortedFilesTestBase {
         CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
 
         // When
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
         RecordsProcessedSummary summary = compactSortedFiles.compact();
 
@@ -86,6 +87,7 @@ class CompactSortedFilesEmptyOutputIT extends CompactSortedFilesTestBase {
         CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
 
         // When
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
         RecordsProcessedSummary summary = compactSortedFiles.compact();
 
@@ -125,6 +127,7 @@ class CompactSortedFilesEmptyOutputIT extends CompactSortedFilesTestBase {
                 List.of(file1, file2), "A", "B", "C");
 
         // When
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
         RecordsProcessedSummary summary = compactSortedFiles.compact();
 

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIT.java
@@ -63,6 +63,7 @@ class CompactSortedFilesIT extends CompactSortedFilesTestBase {
         CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
 
         // When
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
         RecordsProcessedSummary summary = compactSortedFiles.compact();
 
@@ -119,6 +120,7 @@ class CompactSortedFilesIT extends CompactSortedFilesTestBase {
             CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
 
             // When
+            stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
             CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
             RecordsProcessedSummary summary = compactSortedFiles.compact();
 
@@ -182,6 +184,7 @@ class CompactSortedFilesIT extends CompactSortedFilesTestBase {
             CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
 
             // When
+            stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
             CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
             RecordsProcessedSummary summary = compactSortedFiles.compact();
 

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIteratorIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesIteratorIT.java
@@ -67,6 +67,7 @@ class CompactSortedFilesIteratorIT extends CompactSortedFilesTestBase {
         CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
 
         // When
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
         RecordsProcessedSummary summary = compactSortedFiles.compact();
 
@@ -118,6 +119,7 @@ class CompactSortedFilesIteratorIT extends CompactSortedFilesTestBase {
                 List.of(file1, file2), "A", "B", "C");
 
         // When
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob);
         RecordsProcessedSummary summary = compactSortedFiles.compact();
 

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesLocalStackIT.java
@@ -139,6 +139,7 @@ public class CompactSortedFilesLocalStackIT extends CompactSortedFilesTestBase {
         FileInfo file2 = ingestRecordsGetFile(stateStore, data2);
 
         CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
 
         // When
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob, stateStore);
@@ -180,6 +181,7 @@ public class CompactSortedFilesLocalStackIT extends CompactSortedFilesTestBase {
 
         CompactionJob compactionJob = compactionFactory().createSplittingCompactionJob(
                 List.of(file1, file2), "A", "B", "C");
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
 
         // When
         CompactSortedFiles compactSortedFiles = createCompactSortedFiles(schema, compactionJob, stateStore);

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesReportingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesReportingIT.java
@@ -59,6 +59,7 @@ class CompactSortedFilesReportingIT extends CompactSortedFilesTestBase {
         CompactionJob compactionJob = compactionFactory().createCompactionJob(List.of(file1, file2), "root");
 
         // When
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(file1, file2));
         RecordsProcessedSummary summary = createCompactSortedFiles(schema, compactionJob, jobStatusStore).compact();
 
         // Then

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesRunnerLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesRunnerLocalStackIT.java
@@ -202,6 +202,8 @@ public class CompactSortedFilesRunnerLocalStackIT {
                             "value2", 123456789L)));
 
             // - Create two compaction jobs and put on queue
+            stateStore.atomicallyUpdateJobStatusOfFiles("job1", List.of(fileInfo1, fileInfo2));
+            stateStore.atomicallyUpdateJobStatusOfFiles("job2", List.of(fileInfo3, fileInfo4));
             CompactionJob job1 = compactionJobForFiles("job1", "output1.parquet", fileInfo1, fileInfo2);
             CompactionJob job2 = compactionJobForFiles("job2", "output2.parquet", fileInfo3, fileInfo4);
             String job1Json = CompactionJobSerDe.serialiseToString(job1);
@@ -283,6 +285,7 @@ public class CompactSortedFilesRunnerLocalStackIT {
                     .when(stateStore).atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(anyString(), any(), any());
             FileInfo fileInfo1 = ingestFileWith100Records();
             FileInfo fileInfo2 = ingestFileWith100Records();
+            stateStore.atomicallyUpdateJobStatusOfFiles("job1", List.of(fileInfo1, fileInfo2));
             String jobJson = sendCompactionJobForFilesGetJson("job1", "output1.parquet", fileInfo1, fileInfo2);
 
             // When
@@ -305,6 +308,7 @@ public class CompactSortedFilesRunnerLocalStackIT {
                     .when(stateStore).atomicallyUpdateFilesToReadyForGCAndCreateNewActiveFiles(anyString(), any(), any());
             FileInfo fileInfo1 = ingestFileWith100Records();
             FileInfo fileInfo2 = ingestFileWith100Records();
+            stateStore.atomicallyUpdateJobStatusOfFiles("job1", List.of(fileInfo1, fileInfo2));
             String jobJson = sendCompactionJobForFilesGetJson("job1", "output1.parquet", fileInfo1, fileInfo2);
 
             // When
@@ -341,6 +345,7 @@ public class CompactSortedFilesRunnerLocalStackIT {
                             "value2", 987654321L)));
             partitions.splitToNewChildren("root", "L", "R", 100L)
                     .applySplit(stateStore, "root");
+            stateStore.atomicallyUpdateJobStatusOfFiles("job1", List.of(fileInfo));
             CompactionJob job1 = splittingJobForFiles("job1", fileInfo);
             String job1Json = CompactionJobSerDe.serialiseToString(job1);
             SendMessageRequest sendMessageRequest = new SendMessageRequest()

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesRunnerLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesRunnerLocalStackIT.java
@@ -487,10 +487,21 @@ public class CompactSortedFilesRunnerLocalStackIT {
     }
 
     private CompactSortedFilesRunner createJobRunner(String taskId, StateStoreProvider stateStoreProvider) {
-        return new CompactSortedFilesRunner(
-                instanceProperties, ObjectFactory.noUserJars(),
-                tablePropertiesProvider, PropertiesReloader.neverReload(), stateStoreProvider, jobStatusStore, taskStatusStore,
-                taskId, instanceProperties.get(COMPACTION_JOB_QUEUE_URL), sqs, null, CompactionTaskType.COMPACTION, 1, 0);
+        return CompactSortedFilesRunner.builder()
+                .instanceProperties(instanceProperties)
+                .objectFactory(ObjectFactory.noUserJars())
+                .tablePropertiesProvider(tablePropertiesProvider)
+                .propertiesReloader(PropertiesReloader.neverReload())
+                .stateStoreProvider(stateStoreProvider)
+                .jobStatusStore(jobStatusStore)
+                .taskStatusStore(taskStatusStore)
+                .taskId(taskId)
+                .sqsJobQueueUrl(instanceProperties.get(COMPACTION_JOB_QUEUE_URL))
+                .sqsClient(sqs)
+                .type(CompactionTaskType.COMPACTION)
+                .maxMessageRetrieveAttempts(1)
+                .waitTimeSeconds(0)
+                .build();
     }
 
     private FileInfo ingestFileWith100Records() throws Exception {

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/CompactSortedFilesSplittingIT.java
@@ -152,6 +152,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
 
         CompactionJob splittingJob = compactionFactory()
                 .createSplittingCompactionJob(List.of(rootFile), "root", "L", "R");
+        stateStore.atomicallyUpdateJobStatusOfFiles(splittingJob.getId(), List.of(rootFile));
         createCompactSortedFiles(schema, splittingJob).compact();
         FileInfo leftFile1 = firstFileInPartition(stateStore.getActiveFiles(), "L");
         FileInfo leftFile2 = ingestRecordsGetFile(List.of(new Record(Map.of("key", 4L))));
@@ -159,6 +160,7 @@ class CompactSortedFilesSplittingIT extends CompactSortedFilesTestBase {
         // When
         CompactionJob compactionJob = compactionFactory()
                 .createCompactionJob(List.of(leftFile1, leftFile2), "L");
+        stateStore.atomicallyUpdateJobStatusOfFiles(compactionJob.getId(), List.of(leftFile1, leftFile2));
         RecordsProcessedSummary summary = createCompactSortedFiles(schema, compactionJob).compact();
 
         // Then the new file is recorded in the state store

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/QueueMessageVisibilityInMemory.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/QueueMessageVisibilityInMemory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.compaction.jobexecution.testutils;
+
+import sleeper.compaction.jobexecution.QueueMessageVisibility;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class QueueMessageVisibilityInMemory implements QueueMessageVisibility.Client {
+    Map<String, Integer> timeoutByReceiptHandle = new HashMap<>();
+
+    @Override
+    public void update(String queueUrl, String messageReceiptHandle, int visibilityTimeout) {
+        timeoutByReceiptHandle.put(messageReceiptHandle, visibilityTimeout);
+    }
+
+    public Map<String, Integer> getTimeoutsByReceiptHandle() {
+        return timeoutByReceiptHandle;
+    }
+}

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/QueueMessageVisibilityInMemoryTest.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/QueueMessageVisibilityInMemoryTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.compaction.jobexecution.testutils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueueMessageVisibilityInMemoryTest {
+    @Test
+    void shouldSetVisibilityOfMessageOnSameQueue() {
+        QueueMessageVisibilityInMemory queueMessageVisibility = new QueueMessageVisibilityInMemory();
+        queueMessageVisibility.update("test-queue", "message-1", 123);
+        queueMessageVisibility.update("test-queue", "message-2", 456);
+
+
+        assertThat(queueMessageVisibility.getTimeoutsByReceiptHandle())
+                .isEqualTo(Map.of(
+                        "message-1", 123,
+                        "message-2", 456));
+    }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1668

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - CompactSortedFilesRunnerLocalStackIT.shouldSetVisibilityTimeoutForMessageIfFilesNotAssignedToJobYet
    - QueueMessageVisibilityInMemoryTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.