### PR TITLE
Issue 1679 - Purge queues on test failures in PythonApiIT

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PythonApiIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/PythonApiIT.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_JOB_QUEUE_URL;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.INGEST_JOB_QUEUE_URL;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.QUERY_QUEUE_URL;
 import static sleeper.configuration.properties.table.TableProperty.BULK_IMPORT_MIN_LEAF_PARTITION_COUNT;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.MAIN;
 
@@ -151,6 +152,10 @@ public class PythonApiIT {
     @Nested
     @DisplayName("Run SQS query")
     class RunSQSQuery {
+        @RegisterExtension
+        public final PurgeQueueExtension purgeQueueExtension = PurgeQueueExtension.purgeIfTestFailed(sleeper,
+                QUERY_QUEUE_URL);
+
         @AfterEach
         void tearDown() {
             sleeper.query().emptyResultsBucket();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1679

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated PythonApiIT tests

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.