### PR TITLE
Issue 1680 - Add new property for setting strongly consistent reads in DynamoDBTableIndex

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -110,6 +110,10 @@ sleeper.tables.index.dynamo.pointintimerecovery=false
 # properties to be reloaded from S3.
 sleeper.table.properties.provider.timeout.minutes=60
 
+# This specifies whether queries and scans against the table index DynamoDB tables are strongly
+# consistent.
+sleeper.tables.index.dynamo.consistent.reads=false
+
 
 ## The following properties relate to standard ingest.
 

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -196,6 +196,13 @@ public interface CommonProperty {
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
+    UserDefinedInstanceProperty TABLE_INDEX_DYNAMO_STRONGLY_CONSISTENT_READS = Index.propertyBuilder("sleeper.tables.index.dynamo.consistent.reads")
+            .description("This specifies whether queries and scans against the table index DynamoDB tables " +
+                    "are strongly consistent.")
+            .defaultValue("false")
+            .validationPredicate(Utils::isTrueOrFalse)
+            .propertyGroup(InstancePropertyGroup.COMMON)
+            .runCdkDeployWhenChanged(true).build();
 
     static List<UserDefinedInstanceProperty> getAll() {
         return Index.INSTANCE.getAll();

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
@@ -38,6 +38,7 @@ import static sleeper.configuration.properties.instance.CommonProperty.FORCE_REL
 import static sleeper.configuration.properties.instance.CommonProperty.MAXIMUM_CONNECTIONS_TO_S3;
 import static sleeper.configuration.properties.instance.CommonProperty.OPTIONAL_STACKS;
 import static sleeper.configuration.properties.instance.CommonProperty.RETAIN_INFRA_AFTER_DESTROY;
+import static sleeper.configuration.properties.instance.CommonProperty.TABLE_INDEX_DYNAMO_STRONGLY_CONSISTENT_READS;
 import static sleeper.configuration.properties.instance.CompactionProperty.COMPACTION_TASK_CPU_ARCHITECTURE;
 import static sleeper.configuration.properties.instance.CompactionProperty.COMPACTION_TASK_X86_CPU;
 import static sleeper.configuration.properties.instance.CompactionProperty.COMPACTION_TASK_X86_MEMORY;
@@ -94,6 +95,7 @@ public enum SystemTestInstance {
         properties.set(RETAIN_INFRA_AFTER_DESTROY, "false");
         properties.set(FORCE_RELOAD_PROPERTIES, "true");
         properties.set(DEFAULT_DYNAMO_STRONGLY_CONSISTENT_READS, "true");
+        properties.set(TABLE_INDEX_DYNAMO_STRONGLY_CONSISTENT_READS, "true");
         properties.set(DEFAULT_BULK_IMPORT_EMR_INSTANCE_ARCHITECTURE, EmrInstanceArchitecture.X86_64.toString());
         properties.set(DEFAULT_BULK_IMPORT_EMR_MASTER_X86_INSTANCE_TYPES, MAIN_EMR_MASTER_TYPES);
         properties.set(DEFAULT_BULK_IMPORT_EMR_EXECUTOR_X86_INSTANCE_TYPES, MAIN_EMR_EXECUTOR_TYPES);

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -151,6 +151,10 @@ sleeper.tables.index.dynamo.pointintimerecovery=false
 # properties to be reloaded from S3.
 sleeper.table.properties.provider.timeout.minutes=60
 
+# This specifies whether queries and scans against the table index DynamoDB tables are strongly
+# consistent.
+sleeper.tables.index.dynamo.consistent.reads=false
+
 
 ## The following properties relate to standard ingest.
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1680

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updating config for system tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.