### PR TITLE
Issue 1693 - Implement splitting file references in S3StateStore

### DIFF
--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStoreTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStoreTest.java
@@ -231,7 +231,7 @@ public class InMemoryFileReferenceStoreTest {
                     store.splitFileReferences(List.of(
                             splitFileToChildPartitions(file, "L", "R"))))
                     .isInstanceOf(StateStoreException.class);
-            assertThat(store.getActiveFiles()).containsExactly(
+            assertThat(store.getActiveFiles()).containsExactlyInAnyOrder(
                     file,
                     splitFile(file, "L"),
                     splitFile(file, "R"));

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStoreTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStoreTest.java
@@ -178,6 +178,31 @@ public class InMemoryFileReferenceStoreTest {
         }
 
         @Test
+        void shouldSplitOneFileFromTwoOriginalPartitions() throws Exception {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            splitPartition("L", "LL", "LR", 2);
+            splitPartition("R", "RL", "RR", 7);
+            FileReference file = factory.rootFile("file", 100L);
+            FileReference leftFile = splitFile(file, "L");
+            FileReference rightFile = splitFile(file, "R");
+            store.addFiles(List.of(leftFile, rightFile));
+
+            // When
+            store.splitFileReferences(List.of(
+                    splitFileToChildPartitions(leftFile, "LL", "LR"),
+                    splitFileToChildPartitions(rightFile, "RL", "RR")));
+
+            // Then
+            assertThat(store.getActiveFiles())
+                    .containsExactlyInAnyOrder(
+                            splitFile(leftFile, "LL"),
+                            splitFile(leftFile, "LR"),
+                            splitFile(rightFile, "RL"),
+                            splitFile(rightFile, "RR"));
+        }
+
+        @Test
         void shouldSplitFilesInDifferentPartitions() throws Exception {
             // Given
             splitPartition("root", "L", "R", 5);

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReference.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReference.java
@@ -76,9 +76,7 @@ public class S3FileReference {
         return referencesByFilename.entrySet().stream()
                 .map(entry -> S3FileReference.builder()
                         .filename(entry.getKey())
-                        .internalReferences(entry.getValue().stream()
-                                .map(fileReference -> fileReference.toBuilder().lastStateStoreUpdateTime(updateTime).build())
-                                .collect(Collectors.toUnmodifiableList()))
+                        .internalReferencesUpdatedAt(entry.getValue(), updateTime)
                         .lastUpdateTime(updateTime)
                         .build());
     }
@@ -186,6 +184,12 @@ public class S3FileReference {
         public Builder internalReferences(List<FileReference> internalReferences) {
             this.internalReferences = internalReferences;
             return this;
+        }
+
+        public Builder internalReferencesUpdatedAt(List<FileReference> internalReferences, Instant updateTime) {
+            return internalReferences(internalReferences.stream()
+                    .map(fileReference -> fileReference.toBuilder().lastStateStoreUpdateTime(updateTime).build())
+                    .collect(Collectors.toUnmodifiableList()));
         }
 
         public Builder externalReferenceCount(int externalReferenceCount) {

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
@@ -160,8 +160,8 @@ class S3FileReferenceStore implements FileReferenceStore {
             for (S3FileReference existingFile : list) {
                 S3FileReference newFile = newFilesByName.get(existingFile.getFilename());
                 if (newFile != null) {
-                    existingFile = existingFile.withUpdatedReferences(newFile)
-                            .removeReferencesInPartition(oldReference.getPartitionId(), updateTime);
+                    existingFile = existingFile.removeReferencesInPartition(oldReference.getPartitionId(), updateTime)
+                            .withUpdatedReferences(newFile);
                 }
                 after.add(existingFile);
             }

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
@@ -183,7 +183,6 @@ class S3FileReferenceStore implements FileReferenceStore {
         } catch (IOException e) {
             throw new StateStoreException("IOException updating file references", e);
         }
-
     }
 
     @Override

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
@@ -125,7 +125,6 @@ class S3FileReferenceStore implements FileReferenceStore {
     @Override
     public void splitFileReferences(List<SplitFileReferenceRequest> splitRequests) throws StateStoreException {
         Instant updateTime = clock.instant();
-        Function<List<S3FileReference>, List<S3FileReference>> allUpdates = list -> list;
         Map<String, List<SplitFileReferenceRequest>> splitRequestByPartitionIdAndFilename = splitRequests.stream()
                 .collect(Collectors.groupingBy(
                         splitRequest -> getPartitionIdAndFilename(splitRequest.getOldReference())));
@@ -152,6 +151,7 @@ class S3FileReferenceStore implements FileReferenceStore {
                         return "";
                     }).findFirst().orElse("");
         };
+        Function<List<S3FileReference>, List<S3FileReference>> allUpdates = list -> list;
         for (SplitFileReferenceRequest splitRequest : splitRequests) {
             FileReference oldReference = splitRequest.getOldReference();
             Function<List<S3FileReference>, List<S3FileReference>> update = list -> {

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
@@ -168,10 +168,11 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                     .containsExactlyInAnyOrder(
                             splitFile(file, "L"),
                             splitFile(file, "R"));
+            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("3"));
         }
 
         @Test
-        void shouldSplitFilesInDifferentPartitions() throws Exception {
+        void shouldSplitFilesInDifferentPartitionsInOneUpdate() throws Exception {
             // Given
             splitPartition("root", "L", "R", 5);
             splitPartition("L", "LL", "LR", 2);
@@ -192,6 +193,7 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                             splitFile(file1, "LR"),
                             splitFile(file2, "RL"),
                             splitFile(file2, "RR"));
+            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("3"));
         }
 
         @Test
@@ -228,35 +230,7 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                     file,
                     splitFile(file, "L"),
                     splitFile(file, "R"));
-        }
-
-        @Test
-        void shouldSplitMultipleFilesInOneStateStoreUpdate() throws Exception {
-            // Given
-            splitPartition("root", "L", "R", 5);
-            splitPartition("L", "LL", "LR", 2);
-            splitPartition("R", "RL", "RR", 7);
-            FileReference file1 = factory.partitionFile("L", "file1", 100L);
-            FileReference file2 = factory.partitionFile("R", "file2", 200L);
-            store.addFiles(List.of(file1, file2));
-
-            // When
-            store.splitFileReferences(List.of(
-                    splitFileToChildPartitions(file1, "LL", "LR"),
-                    splitFileToChildPartitions(file2, "RL", "RR")));
-
-            // Then
-            assertThat(store.getActiveFiles())
-                    .containsExactlyInAnyOrder(
-                            splitFile(file1, "LL"),
-                            splitFile(file1, "LR"),
-                            splitFile(file2, "RL"),
-                            splitFile(file2, "RR"));
-            // Files revision should be 3
-            // - 1 - Initial revision
-            // - 2 - Add files
-            // - 3 - Split files
-            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("3"));
+            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("4"));
         }
     }
 

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
@@ -186,6 +186,42 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                             splitFile(file2, "RL"),
                             splitFile(file2, "RR"));
         }
+
+        @Test
+        void shouldFailToSplitFileWhichDoesNotExist() throws StateStoreException {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            FileReference file = factory.rootFile("file", 100L);
+
+            // When / Then
+            assertThatThrownBy(() ->
+                    store.splitFileReferences(List.of(
+                            splitFileToChildPartitions(file, "L", "R"))))
+                    .isInstanceOf(StateStoreException.class);
+            assertThat(store.getActiveFiles()).isEmpty();
+        }
+
+        @Test
+        void shouldFailToSplitFileWhenTheSameFileWasAddedBackToParentPartition() throws StateStoreException {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            FileReference file = factory.rootFile("file", 100L);
+            store.addFile(file);
+            store.splitFileReferences(List.of(splitFileToChildPartitions(file, "L", "R")));
+            // Ideally this would fail as the file is already referenced in partitions below it,
+            // but not all state stores may be able to implement that
+            store.addFile(file);
+
+            // When / Then
+            assertThatThrownBy(() ->
+                    store.splitFileReferences(List.of(
+                            splitFileToChildPartitions(file, "L", "R"))))
+                    .isInstanceOf(StateStoreException.class);
+            assertThat(store.getActiveFiles()).containsExactlyInAnyOrder(
+                    file,
+                    splitFile(file, "L"),
+                    splitFile(file, "R"));
+        }
     }
 
     @Nested

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
@@ -162,6 +162,30 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                             splitFile(file, "L"),
                             splitFile(file, "R"));
         }
+
+        @Test
+        void shouldSplitFilesInDifferentPartitions() throws Exception {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            splitPartition("L", "LL", "LR", 2);
+            splitPartition("R", "RL", "RR", 7);
+            FileReference file1 = factory.partitionFile("L", "file1", 100L);
+            FileReference file2 = factory.partitionFile("R", "file2", 200L);
+            store.addFiles(List.of(file1, file2));
+
+            // When
+            store.splitFileReferences(List.of(
+                    splitFileToChildPartitions(file1, "LL", "LR"),
+                    splitFileToChildPartitions(file2, "RL", "RR")));
+
+            // Then
+            assertThat(store.getActiveFiles())
+                    .containsExactlyInAnyOrder(
+                            splitFile(file1, "LL"),
+                            splitFile(file1, "LR"),
+                            splitFile(file2, "RL"),
+                            splitFile(file2, "RR"));
+        }
     }
 
     @Nested

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
@@ -16,6 +16,9 @@
 
 package sleeper.statestore.s3;
 
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -43,6 +46,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.REVISION_TABLENAME;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
@@ -50,6 +54,9 @@ import static sleeper.core.statestore.FilesReportTestHelper.activeFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.partialReadyForGCFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.readyForGCFilesReport;
 import static sleeper.core.statestore.SplitFileReferenceRequest.splitFileToChildPartitions;
+import static sleeper.statestore.s3.S3StateStore.CURRENT_FILES_REVISION_ID_KEY;
+import static sleeper.statestore.s3.S3StateStore.CURRENT_REVISION;
+import static sleeper.statestore.s3.S3StateStore.REVISION_ID_KEY;
 
 public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
 
@@ -221,6 +228,35 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                     file,
                     splitFile(file, "L"),
                     splitFile(file, "R"));
+        }
+
+        @Test
+        void shouldSplitMultipleFilesInOneStateStoreUpdate() throws Exception {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            splitPartition("L", "LL", "LR", 2);
+            splitPartition("R", "RL", "RR", 7);
+            FileReference file1 = factory.partitionFile("L", "file1", 100L);
+            FileReference file2 = factory.partitionFile("R", "file2", 200L);
+            store.addFiles(List.of(file1, file2));
+
+            // When
+            store.splitFileReferences(List.of(
+                    splitFileToChildPartitions(file1, "LL", "LR"),
+                    splitFileToChildPartitions(file2, "RL", "RR")));
+
+            // Then
+            assertThat(store.getActiveFiles())
+                    .containsExactlyInAnyOrder(
+                            splitFile(file1, "LL"),
+                            splitFile(file1, "LR"),
+                            splitFile(file2, "RL"),
+                            splitFile(file2, "RR"));
+            // Files revision should be 3
+            // - 1 - Initial revision
+            // - 2 - Add files
+            // - 3 - Split files
+            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("3"));
         }
     }
 
@@ -778,5 +814,24 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
 
     private static FileReference withLastUpdate(Instant updateTime, FileReference file) {
         return file.toBuilder().lastStateStoreUpdateTime(updateTime).build();
+    }
+
+    private String getCurrentFilesRevision() {
+        ScanRequest scanRequest = new ScanRequest()
+                .withTableName(instanceProperties.get(REVISION_TABLENAME))
+                .withConsistentRead(true);
+        ScanResult scanResult = dynamoDBClient.scan(scanRequest);
+        assertThat(scanResult.getItems()).hasSize(2);
+        String filesVersion = "";
+        for (Map<String, AttributeValue> item : scanResult.getItems()) {
+            if (item.get(REVISION_ID_KEY).toString().contains(CURRENT_FILES_REVISION_ID_KEY)) {
+                filesVersion = item.get(CURRENT_REVISION).getS();
+            }
+        }
+        return filesVersion;
+    }
+
+    private static String versionWithPrefix(String version) {
+        return "00000000000" + version;
     }
 }

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
@@ -49,6 +49,7 @@ import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 import static sleeper.core.statestore.FilesReportTestHelper.activeFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.partialReadyForGCFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.readyForGCFilesReport;
+import static sleeper.core.statestore.SplitFileReferenceRequest.splitFileToChildPartitions;
 
 public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
 
@@ -138,6 +139,28 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
             assertThat(store.getActiveFiles()).containsExactlyInAnyOrder(
                     withLastUpdate(updateTime, leftFile),
                     withLastUpdate(updateTime, rightFile));
+        }
+    }
+
+    @Nested
+    @DisplayName("Split file references across multiple partitions")
+    class SplitFileReferences {
+        @Test
+        void shouldSplitOneFileInRootPartition() throws Exception {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            FileReference file = factory.rootFile("file", 100L);
+            store.addFile(file);
+
+            // When
+            store.splitFileReferences(List.of(
+                    splitFileToChildPartitions(file, "L", "R")));
+
+            // Then
+            assertThat(store.getActiveFiles())
+                    .containsExactlyInAnyOrder(
+                            splitFile(file, "L"),
+                            splitFile(file, "R"));
         }
     }
 

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
@@ -16,9 +16,6 @@
 
 package sleeper.statestore.s3;
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import com.amazonaws.services.dynamodbv2.model.ScanRequest;
-import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +43,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.REVISION_TABLENAME;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
@@ -54,9 +50,6 @@ import static sleeper.core.statestore.FilesReportTestHelper.activeFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.partialReadyForGCFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.readyForGCFilesReport;
 import static sleeper.core.statestore.SplitFileReferenceRequest.splitFileToChildPartitions;
-import static sleeper.statestore.s3.S3StateStore.CURRENT_FILES_REVISION_ID_KEY;
-import static sleeper.statestore.s3.S3StateStore.CURRENT_REVISION;
-import static sleeper.statestore.s3.S3StateStore.REVISION_ID_KEY;
 
 public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
 
@@ -168,7 +161,6 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                     .containsExactlyInAnyOrder(
                             splitFile(file, "L"),
                             splitFile(file, "R"));
-            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("3"));
         }
 
         @Test
@@ -191,11 +183,10 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                             splitFile(file1, "R"),
                             splitFile(file2, "L"),
                             splitFile(file2, "R"));
-            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("3"));
         }
 
         @Test
-        void shouldSplitFilesInDifferentPartitionsInOneUpdate() throws Exception {
+        void shouldSplitFilesInDifferentPartitions() throws Exception {
             // Given
             splitPartition("root", "L", "R", 5);
             splitPartition("L", "LL", "LR", 2);
@@ -216,7 +207,6 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                             splitFile(file1, "LR"),
                             splitFile(file2, "RL"),
                             splitFile(file2, "RR"));
-            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("3"));
         }
 
         @Test
@@ -253,7 +243,6 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
                     file,
                     splitFile(file, "L"),
                     splitFile(file, "R"));
-            assertThat(getCurrentFilesRevision()).isEqualTo(versionWithPrefix("4"));
         }
     }
 
@@ -811,24 +800,5 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
 
     private static FileReference withLastUpdate(Instant updateTime, FileReference file) {
         return file.toBuilder().lastStateStoreUpdateTime(updateTime).build();
-    }
-
-    private String getCurrentFilesRevision() {
-        ScanRequest scanRequest = new ScanRequest()
-                .withTableName(instanceProperties.get(REVISION_TABLENAME))
-                .withConsistentRead(true);
-        ScanResult scanResult = dynamoDBClient.scan(scanRequest);
-        assertThat(scanResult.getItems()).hasSize(2);
-        String filesVersion = "";
-        for (Map<String, AttributeValue> item : scanResult.getItems()) {
-            if (item.get(REVISION_ID_KEY).toString().contains(CURRENT_FILES_REVISION_ID_KEY)) {
-                filesVersion = item.get(CURRENT_REVISION).getS();
-            }
-        }
-        return filesVersion;
-    }
-
-    private static String versionWithPrefix(String version) {
-        return "00000000000" + version;
     }
 }

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreTestBase.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3StateStoreTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1693

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Add S3FileReferenceStoreIT.SplitFileReferences

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.