### PR TITLE
Issue 1672 - Run splitting compactions before compaction jobs are created

### DIFF
--- a/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateJobs.java
+++ b/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateJobs.java
@@ -29,6 +29,7 @@ import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.partition.Partition;
 import sleeper.core.statestore.FileReference;
+import sleeper.core.statestore.SplitFileReferences;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.core.table.TableIdentity;
@@ -106,6 +107,8 @@ public class CreateJobs {
                 .collect(Collectors.toUnmodifiableList());
         LOGGER.info("Found {} tables", tables.size());
         for (TableProperties table : tables) {
+            LOGGER.debug("Performing pre-splits on files in {}", table.getId());
+            SplitFileReferences.from(stateStoreProvider.getStateStore(table)).split();
             createJobsForTable(table);
         }
     }

--- a/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateJobs.java
+++ b/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateJobs.java
@@ -107,7 +107,7 @@ public class CreateJobs {
                 .collect(Collectors.toUnmodifiableList());
         LOGGER.info("Found {} tables", tables.size());
         for (TableProperties table : tables) {
-            LOGGER.debug("Performing pre-splits on files in {}", table.getId());
+            LOGGER.info("Performing pre-splits on files in {}", table.getId());
             SplitFileReferences.from(stateStoreProvider.getStateStore(table)).split();
             createJobsForTable(table);
         }

--- a/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/strategy/DelegatingCompactionStrategy.java
+++ b/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/strategy/DelegatingCompactionStrategy.java
@@ -98,7 +98,7 @@ public class DelegatingCompactionStrategy implements CompactionStrategy {
             if (partition.isLeafPartition()) {
                 compactionJobs.addAll(createJobsForLeafPartition(partition, activeFilesWithJobId, activeFilesWithNoJobId));
             } else {
-                compactionJobs.addAll(createJobsForNonLeafPartition(partition, activeFilesWithNoJobId, partitionIdToPartition));
+                createJobsForNonLeafPartition(partition, activeFilesWithNoJobId, partitionIdToPartition);
             }
         }
 

--- a/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/strategy/DelegatingCompactionStrategy.java
+++ b/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/strategy/DelegatingCompactionStrategy.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static sleeper.compaction.strategy.impl.CompactionUtils.getFilesInAscendingOrder;
 import static sleeper.configuration.properties.table.TableProperty.COMPACTION_FILES_BATCH_SIZE;
 
 /**
@@ -97,9 +96,6 @@ public class DelegatingCompactionStrategy implements CompactionStrategy {
 
             if (partition.isLeafPartition()) {
                 compactionJobs.addAll(createJobsForLeafPartition(partition, activeFilesWithJobId, activeFilesWithNoJobId));
-            } else {
-                // TODO this will be removed soon, to make checkstyle happy the return value is not used
-                createJobsForNonLeafPartition(partition, activeFilesWithNoJobId, partitionIdToPartition);
             }
         }
 
@@ -122,44 +118,5 @@ public class DelegatingCompactionStrategy implements CompactionStrategy {
         }
         LOGGER.info("Created {} compaction job{} for partition {}, table {}", jobs.size(), 1 == jobs.size() ? "" : "s", partition.getId(), tableName);
         return jobs;
-    }
-
-    private List<CompactionJob> createJobsForNonLeafPartition(
-            Partition partition, List<FileReference> fileReferences, Map<String, Partition> partitionIdToPartition) {
-        List<CompactionJob> compactionJobs = new ArrayList<>();
-        List<FileReference> filesInAscendingOrder = getFilesInAscendingOrder(tableName, partition, fileReferences);
-
-        // Iterate through files, creating jobs for batches of compactionFilesBatchSize files
-        List<FileReference> filesForJob = new ArrayList<>();
-        for (FileReference fileReference : filesInAscendingOrder) {
-            filesForJob.add(fileReference);
-            if (filesForJob.size() >= compactionFilesBatchSize) {
-                // Create job for these files
-                LOGGER.info("Creating a job to compact {} files and split into 2 partitions (parent partition is {}, table {})",
-                        filesForJob.size(), partition, tableName);
-                compactionJobs.add(createSplittingCompactionJob(partition, partitionIdToPartition, filesForJob));
-                filesForJob.clear();
-            }
-        }
-
-        // If there are any files left (even just 1), create a job for them
-        if (!filesForJob.isEmpty()) {
-            // Create job for these files
-            LOGGER.info("Creating a job to compact {} files in partition {}, table {}",
-                    filesForJob.size(), partition, tableName);
-            compactionJobs.add(createSplittingCompactionJob(partition, partitionIdToPartition, filesForJob));
-        }
-        return compactionJobs;
-    }
-
-    private CompactionJob createSplittingCompactionJob(Partition partition, Map<String, Partition> partitionIdToPartition, List<FileReference> filesForJob) {
-        List<String> childPartitions = partitionIdToPartition.get(partition.getId()).getChildPartitionIds();
-        Partition leftPartition = partitionIdToPartition.get(childPartitions.get(0));
-        Partition rightPartition = partitionIdToPartition.get(childPartitions.get(1));
-
-        return factory.createSplittingCompactionJob(filesForJob,
-                partition.getId(),
-                leftPartition.getId(),
-                rightPartition.getId());
     }
 }

--- a/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/strategy/DelegatingCompactionStrategy.java
+++ b/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/strategy/DelegatingCompactionStrategy.java
@@ -98,6 +98,7 @@ public class DelegatingCompactionStrategy implements CompactionStrategy {
             if (partition.isLeafPartition()) {
                 compactionJobs.addAll(createJobsForLeafPartition(partition, activeFilesWithJobId, activeFilesWithNoJobId));
             } else {
+                // TODO this will be removed soon, to make checkstyle happy the return value is not used
                 createJobsForNonLeafPartition(partition, activeFilesWithNoJobId, partitionIdToPartition);
             }
         }

--- a/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/strategy/impl/BasicCompactionStrategyTest.java
+++ b/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/strategy/impl/BasicCompactionStrategyTest.java
@@ -23,9 +23,7 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
-import sleeper.core.schema.Field;
 import sleeper.core.schema.Schema;
-import sleeper.core.schema.type.IntType;
 import sleeper.core.statestore.FileReference;
 import sleeper.core.statestore.FileReferenceFactory;
 
@@ -203,39 +201,5 @@ public class BasicCompactionStrategyTest {
                 .iteratorConfig(null).build();
         assertThat(compactionJobs).containsExactly(
                 expectedCompactionJob1, expectedCompactionJob2, expectedCompactionJob3);
-    }
-
-    @Test
-    public void shouldCreateSplittingJobs() {
-        // Given
-        Field field = new Field("key", new IntType());
-        Schema schema = Schema.builder().rowKeyFields(field).build();
-        tableProperties.set(COMPACTION_FILES_BATCH_SIZE, "2");
-        tableProperties.setSchema(schema);
-        BasicCompactionStrategy strategy = new BasicCompactionStrategy();
-        strategy.init(instanceProperties, tableProperties);
-        PartitionTree partitionTree = new PartitionsBuilder(schema)
-                .singlePartition("root")
-                .splitToNewChildren("root", "left", "right", 10)
-                .buildTree();
-        FileReferenceFactory factory = FileReferenceFactory.from(partitionTree);
-        FileReference fileReference1 = factory.rootFile("file1", 100L);
-        FileReference fileReference2 = factory.rootFile("file2", 200L);
-        List<FileReference> fileReferences = List.of(fileReference1, fileReference2);
-
-        // When
-        List<CompactionJob> compactionJobs = strategy.createCompactionJobs(List.of(), fileReferences, partitionTree.getAllPartitions());
-
-        // Then
-        assertThat(compactionJobs).hasSize(1);
-        CompactionJob expectedCompactionJob = jobForTable()
-                .jobId(compactionJobs.get(0).getId()) // Job id is a UUID so we don't know what it will be
-                .partitionId("root")
-                .inputFiles(List.of("file1", "file2"))
-                .isSplittingJob(true)
-                .childPartitions(List.of("left", "right"))
-                .iteratorClassName(null)
-                .iteratorConfig(null).build();
-        assertThat(compactionJobs).containsExactly(expectedCompactionJob);
     }
 }

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/CompactSortedFilesTestBase.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/jobexecution/testutils/CompactSortedFilesTestBase.java
@@ -71,7 +71,7 @@ public class CompactSortedFilesTestBase {
         return new CompactionJobFactory(instanceProperties, tableProperties);
     }
 
-    protected CompactionJob createCompactionJob() throws Exception {
+    protected List<CompactionJob> createCompactionJobs() throws Exception {
         List<CompactionJob> jobs = new ArrayList<>();
         CreateJobs jobCreator = CreateJobs.standard(ObjectFactory.noUserJars(), instanceProperties,
                 new FixedTablePropertiesProvider(tableProperties),
@@ -79,10 +79,7 @@ public class CompactSortedFilesTestBase {
                 jobs::add,
                 CompactionJobStatusStore.NONE);
         jobCreator.createJobs();
-        if (jobs.size() != 1) {
-            throw new IllegalStateException("Expected 1 compaction job, found: " + jobs);
-        }
-        return jobs.get(0);
+        return jobs;
     }
 
     protected CompactSortedFiles createCompactSortedFiles(Schema schema, CompactionJob compactionJob) throws Exception {

--- a/java/core/src/main/java/sleeper/core/statestore/SplitFileReferences.java
+++ b/java/core/src/main/java/sleeper/core/statestore/SplitFileReferences.java
@@ -16,6 +16,9 @@
 
 package sleeper.core.statestore;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import sleeper.core.partition.Partition;
 
 import java.util.ArrayList;
@@ -27,6 +30,7 @@ import static java.util.function.Predicate.not;
 import static sleeper.core.statestore.SplitFileReferenceRequest.splitFileToChildPartitions;
 
 public class SplitFileReferences {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SplitFileReferences.class);
     private final StateStore stateStore;
 
     public SplitFileReferences(StateStore stateStore) {
@@ -47,7 +51,7 @@ public class SplitFileReferences {
                 .flatMap(partition -> activeFilesByPartitionId.getOrDefault(partition.getId(), List.of()).stream()
                         .map(fileReference -> splitFileInPartition(fileReference, partition)))
                 .forEach(splitRequests::add);
-
+        LOGGER.info("Found {} files in non-leaf partitions that need splitting", splitRequests.size());
         stateStore.splitFileReferences(splitRequests);
     }
 

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SystemTestCompaction.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/dsl/SystemTestCompaction.java
@@ -47,7 +47,6 @@ public class SystemTestCompaction {
     }
 
     public SystemTestCompaction splitAndCompactFiles() throws InterruptedException {
-        createJobs().invokeTasks(1).waitForJobs();
         forceCreateJobs().invokeTasks(1).waitForJobs(
                 PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(5), Duration.ofMinutes(30)));
         return this;


### PR DESCRIPTION
Functional system test is passing

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1672

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated CreateJobs / CompactSortedFiles tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.