### PR TITLE
Issue 1720 - Only split files references with no job ID assigned

### DIFF
--- a/java/clients/src/test/java/sleeper/clients/status/report/filestatus/FilesStatusReportTest.java
+++ b/java/clients/src/test/java/sleeper/clients/status/report/filestatus/FilesStatusReportTest.java
@@ -149,7 +149,6 @@ public class FilesStatusReportTest extends FilesStatusReportTestBase {
         FileReference pendingSplit = fileReferenceFactory.partitionFile("B", "pending-split.parquet", 2000);
         FileReference oldFile = fileReferenceFactory.partitionFile("A", "split.parquet", 2000L);
         stateStore.addFiles(List.of(rootFile, pendingSplit, oldFile));
-        stateStore.atomicallyUpdateJobStatusOfFiles("job1", List.of(oldFile));
         stateStore.splitFileReferences(List.of(splitFileToChildPartitions(oldFile, "B", "C")));
 
         // When / Then

--- a/java/core/src/main/java/sleeper/core/statestore/SplitFileReferences.java
+++ b/java/core/src/main/java/sleeper/core/statestore/SplitFileReferences.java
@@ -43,6 +43,7 @@ public class SplitFileReferences {
 
     public void split() throws StateStoreException {
         Map<String, List<FileReference>> activeFilesByPartitionId = stateStore.getActiveFiles().stream()
+                .filter(fileReference -> fileReference.getJobId() == null)
                 .collect(Collectors.groupingBy(FileReference::getPartitionId));
         List<Partition> nonLeafPartitions = stateStore.getAllPartitions().stream()
                 .filter(not(Partition::isLeafPartition)).collect(Collectors.toList());

--- a/java/core/src/main/java/sleeper/core/statestore/SplitFileReferences.java
+++ b/java/core/src/main/java/sleeper/core/statestore/SplitFileReferences.java
@@ -42,8 +42,7 @@ public class SplitFileReferences {
     }
 
     public void split() throws StateStoreException {
-        Map<String, List<FileReference>> activeFilesByPartitionId = stateStore.getActiveFiles().stream()
-                .filter(fileReference -> fileReference.getJobId() == null)
+        Map<String, List<FileReference>> activeFilesByPartitionId = stateStore.getActiveFilesWithNoJobId().stream()
                 .collect(Collectors.groupingBy(FileReference::getPartitionId));
         List<Partition> nonLeafPartitions = stateStore.getAllPartitions().stream()
                 .filter(not(Partition::isLeafPartition)).collect(Collectors.toList());

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStore.java
@@ -111,8 +111,13 @@ public class InMemoryFileReferenceStore implements FileReferenceStore {
             }
             Map<String, FileReference> referenceByPartitionId = file.getInternalReferences().stream()
                     .collect(Collectors.toMap(FileReference::getPartitionId, Function.identity()));
+
             if (!referenceByPartitionId.containsKey(splitRequest.getFromPartitionId())) {
                 throw new StateStoreException("File reference not found in partition: " + splitRequest.getFilename());
+            }
+            FileReference reference = referenceByPartitionId.get(splitRequest.getFromPartitionId());
+            if (reference.getJobId() != null) {
+                throw new StateStoreException("File is already assigned to a compaction job with id: " + reference.getJobId());
             }
             for (FileReference newReference : splitRequest.getNewReferences()) {
                 if (referenceByPartitionId.containsKey(newReference.getPartitionId())) {

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/InMemoryFileReferenceStore.java
@@ -111,7 +111,6 @@ public class InMemoryFileReferenceStore implements FileReferenceStore {
             }
             Map<String, FileReference> referenceByPartitionId = file.getInternalReferences().stream()
                     .collect(Collectors.toMap(FileReference::getPartitionId, Function.identity()));
-
             if (!referenceByPartitionId.containsKey(splitRequest.getFromPartitionId())) {
                 throw new StateStoreException("File reference not found in partition: " + splitRequest.getFilename());
             }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/SplitFileReferencesTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/SplitFileReferencesTest.java
@@ -73,8 +73,7 @@ public class SplitFileReferencesTest {
         SplitFileReferences.from(store).split();
 
         // Then
-        assertThat(store.getActiveFiles()).containsExactly(
-                withLastUpdate(DEFAULT_UPDATE_TIME, file));
+        assertThat(store.getActiveFiles()).containsExactly(file);
     }
 
     @Test
@@ -88,8 +87,7 @@ public class SplitFileReferencesTest {
         SplitFileReferences.from(store).split();
 
         // Then
-        assertThat(store.getActiveFiles()).containsExactly(
-                withJobId(DEFAULT_UPDATE_TIME, "job1", file));
+        assertThat(store.getActiveFiles()).containsExactly(withJobId("job1", file));
     }
 
     private FileReference splitFile(FileReference file, String partitionId) {
@@ -97,11 +95,7 @@ public class SplitFileReferencesTest {
                 .lastStateStoreUpdateTime(DEFAULT_UPDATE_TIME).build();
     }
 
-    private static FileReference withJobId(Instant updateTime, String jobId, FileReference file) {
-        return file.toBuilder().jobId(jobId).lastStateStoreUpdateTime(updateTime).build();
-    }
-
-    private static FileReference withLastUpdate(Instant updateTime, FileReference file) {
-        return file.toBuilder().lastStateStoreUpdateTime(updateTime).build();
+    private static FileReference withJobId(String jobId, FileReference file) {
+        return file.toBuilder().jobId(jobId).build();
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/inmemory/SplitFileReferencesTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/inmemory/SplitFileReferencesTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.core.statestore.inmemory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import sleeper.core.partition.PartitionsBuilder;
+import sleeper.core.schema.Schema;
+import sleeper.core.schema.type.LongType;
+import sleeper.core.statestore.FileReference;
+import sleeper.core.statestore.FileReferenceFactory;
+import sleeper.core.statestore.SplitFileReferences;
+import sleeper.core.statestore.StateStore;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
+import static sleeper.core.statestore.SplitFileReference.referenceForChildPartition;
+import static sleeper.core.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedPartitions;
+
+public class SplitFileReferencesTest {
+    private static final Instant DEFAULT_UPDATE_TIME = Instant.parse("2023-10-04T14:08:00Z");
+    private final Schema schema = schemaWithKey("key", new LongType());
+    private final PartitionsBuilder partitions = new PartitionsBuilder(schema).rootFirst("root")
+            .splitToNewChildren("root", "L", "R", 5L);
+    private final FileReferenceFactory factory = FileReferenceFactory.fromUpdatedAt(partitions.buildTree(), DEFAULT_UPDATE_TIME);
+    private final StateStore store = inMemoryStateStoreWithFixedPartitions(partitions.buildList());
+
+    @BeforeEach
+    void setUp() {
+        store.fixTime(DEFAULT_UPDATE_TIME);
+    }
+
+    @Test
+    void shouldFindFileInNonLeafPartitionToSplit() throws Exception {
+        // Given
+        FileReference file = factory.rootFile("file1", 100L);
+        store.addFile(file);
+
+        // When
+        SplitFileReferences.from(store).split();
+
+        // Then
+        assertThat(store.getActiveFiles()).containsExactly(
+                splitFile(file, "L"),
+                splitFile(file, "R"));
+    }
+
+    @Test
+    void shouldIgnoreFileInLeafPartition() throws Exception {
+        // Given
+        FileReference file = factory.partitionFile("L", "file1", 100L);
+        store.addFile(file);
+
+        // When
+        SplitFileReferences.from(store).split();
+
+        // Then
+        assertThat(store.getActiveFiles()).containsExactly(
+                withLastUpdate(DEFAULT_UPDATE_TIME, file));
+    }
+
+    @Test
+    void shouldIgnoreFileWithJobIdAssigned() throws Exception {
+        // Given
+        FileReference file = factory.rootFile("file1", 100L);
+        store.addFile(file);
+        store.atomicallyUpdateJobStatusOfFiles("job1", List.of(file));
+
+        // When
+        SplitFileReferences.from(store).split();
+
+        // Then
+        assertThat(store.getActiveFiles()).containsExactly(
+                withJobId(DEFAULT_UPDATE_TIME, "job1", file));
+    }
+
+    private FileReference splitFile(FileReference file, String partitionId) {
+        return referenceForChildPartition(file, partitionId).toBuilder()
+                .lastStateStoreUpdateTime(DEFAULT_UPDATE_TIME).build();
+    }
+
+    private static FileReference withJobId(Instant updateTime, String jobId, FileReference file) {
+        return file.toBuilder().jobId(jobId).lastStateStoreUpdateTime(updateTime).build();
+    }
+
+    private static FileReference withLastUpdate(Instant updateTime, FileReference file) {
+        return file.toBuilder().lastStateStoreUpdateTime(updateTime).build();
+    }
+}

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStore.java
@@ -189,9 +189,10 @@ class DynamoDBFileReferenceStore implements FileReferenceStore {
                 .withTableName(activeTableName)
                 .withKey(fileReferenceFormat.createActiveFileKey(oldReference.getPartitionId(), oldReference.getFilename()))
                 .withExpressionAttributeNames(Map.of(
-                        "#PartitionAndFilename", PARTITION_ID_AND_FILENAME))
+                        "#PartitionAndFilename", PARTITION_ID_AND_FILENAME,
+                        "#JobId", JOB_ID))
                 .withConditionExpression(
-                        "attribute_exists(#PartitionAndFilename)")));
+                        "attribute_exists(#PartitionAndFilename) and attribute_not_exists(#JobId)")));
         for (FileReference newReference : newReferences) {
             writes.add(new TransactWriteItem().withPut(putNewFile(newReference, updateTime)));
         }

--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
@@ -173,6 +173,10 @@ class S3FileReferenceStore implements FileReferenceStore {
                                 return "File reference already exists with partitionId and filename: " + newPartitionAndFilename;
                             }
                         }
+                        FileReference existingOldReference = activePartitionFiles.get(oldPartitionAndFilename);
+                        if (existingOldReference.getJobId() != null) {
+                            return "File is already assigned to a compaction job with id: " + existingOldReference.getJobId();
+                        }
                         return "";
                     }).findFirst().orElse("");
         };
@@ -463,7 +467,7 @@ class S3FileReferenceStore implements FileReferenceStore {
         }
         Duration duration = Duration.between(start, clock.instant());
         LOGGER.info("Update {}; took {} seconds",
-            success ? "succeeded" : "failed", duration.toSeconds());
+                success ? "succeeded" : "failed", duration.toSeconds());
     }
 
     private void sleep(int n) {

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStoreIT.java
@@ -328,6 +328,23 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreTestBase {
             assertThat(store.getAllFileReferencesWithMaxUnreferenced(100))
                     .isEqualTo(activeFilesReport(DEFAULT_UPDATE_TIME, expectedReferences));
         }
+
+        @Test
+        void shouldThrowExceptionWhenSplittingFileThatHasBeenAssignedToTheJob() throws Exception {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            FileReference file = factory.rootFile("file", 100L);
+            store.addFile(file);
+            store.atomicallyUpdateJobStatusOfFiles("job1", List.of(file));
+
+            // When / Then
+            assertThatThrownBy(() -> store.splitFileReferences(List.of(splitFileToChildPartitions(file, "L", "R"))))
+                    .isInstanceOf(StateStoreException.class);
+            assertThat(store.getActiveFiles())
+                    .containsExactly(file.toBuilder().jobId("job1").build());
+            assertThat(store.getAllFileReferencesWithMaxUnreferenced(100))
+                    .isEqualTo(activeFilesReport(DEFAULT_UPDATE_TIME, file.toBuilder().jobId("job1").build()));
+        }
     }
 
     @Nested

--- a/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/s3/S3FileReferenceStoreIT.java
@@ -329,6 +329,23 @@ public class S3FileReferenceStoreIT extends S3StateStoreTestBase {
             assertThat(store.getAllFileReferencesWithMaxUnreferenced(100))
                     .isEqualTo(activeFilesReport(DEFAULT_UPDATE_TIME, expectedReferences));
         }
+
+        @Test
+        void shouldThrowExceptionWhenSplittingFileThatHasBeenAssignedToTheJob() throws Exception {
+            // Given
+            splitPartition("root", "L", "R", 5);
+            FileReference file = factory.rootFile("file", 100L);
+            store.addFile(file);
+            store.atomicallyUpdateJobStatusOfFiles("job1", List.of(file));
+
+            // When / Then
+            assertThatThrownBy(() -> store.splitFileReferences(List.of(splitFileToChildPartitions(file, "L", "R"))))
+                    .isInstanceOf(StateStoreException.class);
+            assertThat(store.getActiveFiles())
+                    .containsExactly(file.toBuilder().jobId("job1").build());
+            assertThat(store.getAllFileReferencesWithMaxUnreferenced(100))
+                    .isEqualTo(activeFilesReport(DEFAULT_UPDATE_TIME, file.toBuilder().jobId("job1").build()));
+        }
     }
 
     @Nested


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1720

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - SplitFileReferencesTest
    - Updating state store tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.