### PR TITLE
Issue 1733 - Adding logging of number of attempts and total sleep time when updating S3 state store

### DIFF
--- a/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/s3/S3FileReferenceStore.java
@@ -406,7 +406,9 @@ class S3FileReferenceStore implements FileReferenceStore {
         Instant start = clock.instant();
         boolean success = false;
         int numberAttempts = 0;
+        long totalTimeSleeping = 0L;
         while (numberAttempts < 10) {
+            numberAttempts++;
             RevisionId revisionId = getCurrentFilesRevisionId();
             String filesPath = getFilesPath(revisionId);
             List<AllReferencesToAFile> files;
@@ -416,8 +418,7 @@ class S3FileReferenceStore implements FileReferenceStore {
                         numberAttempts, revisionId, filesPath);
             } catch (IOException e) {
                 LOGGER.debug("IOException thrown attempting to read file information; retrying");
-                numberAttempts++;
-                sleep(numberAttempts);
+                totalTimeSleeping += sleep(numberAttempts);
                 continue;
             }
 
@@ -440,7 +441,6 @@ class S3FileReferenceStore implements FileReferenceStore {
                 writeFilesToParquet(updatedFiles, nextRevisionIdPath);
             } catch (IOException e) {
                 LOGGER.debug("IOException thrown attempting to write file information; retrying");
-                numberAttempts++;
                 continue;
             }
             try {
@@ -454,25 +454,26 @@ class S3FileReferenceStore implements FileReferenceStore {
                 Path path = new Path(nextRevisionIdPath);
                 path.getFileSystem(conf).delete(path, false);
                 LOGGER.info("Deleted file {}", path);
-                numberAttempts++;
-                sleep(numberAttempts);
+                totalTimeSleeping += sleep(numberAttempts);
             }
         }
         Duration duration = Duration.between(start, clock.instant());
-        LOGGER.info("Update {}; took {} seconds",
-            success ? "succeeded" : "failed", duration.toSeconds());
+        LOGGER.info("Update {}; required {} attempts to update the statestore; took {} seconds; spent {} milliseconds sleeping",
+            success ? "succeeded" : "failed", numberAttempts, duration.toSeconds(), totalTimeSleeping);
     }
 
-    private void sleep(int n) {
+    private long sleep(int n) {
         // Implements exponential back-off with jitter, see
         // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
         int sleepTimeInSeconds = (int) Math.min(120, Math.pow(2.0, n + 1));
         long sleepTimeWithJitter = (long) (Math.random() * sleepTimeInSeconds * 1000L);
+        LOGGER.debug("Sleeping for {} milliseconds", sleepTimeWithJitter);
         try {
             Thread.sleep(sleepTimeWithJitter);
         } catch (InterruptedException e) {
             // Do nothing
         }
+        return sleepTimeWithJitter;
     }
 
     private RevisionId getCurrentFilesRevisionId() {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1733

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Only adds logging

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.