### PR TITLE
Issue 1739 - Changed default value of sleeper.fs.s3a.max-connections to 100 and added note to compaction batch size property

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -62,7 +62,7 @@ sleeper.log.retention.days=30
 # Used to set the value of fs.s3a.connection.maximum on the Hadoop configuration. This controls the
 # maximum number of http connections to S3.
 # See https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/performance.html
-sleeper.fs.s3a.max-connections=25
+sleeper.fs.s3a.max-connections=100
 
 # Used to set the value of fs.s3a.block.size on the Hadoop configuration. Uploads to S3 happen in
 # blocks, and this sets the size of blocks. If a larger value is used, then more data is buffered
@@ -827,7 +827,10 @@ sleeper.default.compaction.strategy.class=sleeper.compaction.strategy.impl.SizeR
 # The minimum number of files to read in a compaction job. Note that the state store must support
 # atomic updates for this many files. For the DynamoDBStateStore this is 49. It can be overridden on a
 # per-table basis.
-# This is a default value and will be used if not specified in the table.properties file.
+# This is a default value and will be used if not specified in the table.properties file. Also note
+# that as this many files may need to be open simultaneously, the value of
+# 'sleeper.fs.s3a.max-connections' must be at least the value of this plus one (the extra one is for
+# the output file).
 sleeper.default.compaction.files.batch.size=49
 
 # Used by the SizeRatioCompactionStrategy to decide if a group of files should be compacted.

--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -80,7 +80,10 @@ sleeper.table.compaction.strategy.class=sleeper.compaction.strategy.impl.SizeRat
 # file references and update the file reference count, and another 2 updates for an output file to add
 # a new file reference and update the reference count. There's a limit of 100 atomic updates, which
 # equates to 49 files in a compaction.
-# See also: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html
+# See also: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html.
+# Also note that as this many files may need to be open simultaneously, the value of
+# 'sleeper.fs.s3a.max-connections' must be at least the value of this plus one (the extra one is for
+# the output file).
 sleeper.table.compaction.files.batch.size=49
 
 # Used by the SizeRatioCompactionStrategy to decide if a group of files should be compacted.

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
@@ -120,7 +120,7 @@ public interface CommonProperty {
             .description("Used to set the value of fs.s3a.connection.maximum on the Hadoop configuration. This controls the " +
                     "maximum number of http connections to S3.\n" +
                     "See https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/performance.html")
-            .defaultValue("25")
+            .defaultValue("100")
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.COMMON).build();
     UserDefinedInstanceProperty S3_UPLOAD_BLOCK_SIZE = Index.propertyBuilder("sleeper.fs.s3a.upload.block.size")

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CompactionProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CompactionProperty.java
@@ -166,7 +166,9 @@ public interface CompactionProperty {
             .description("The minimum number of files to read in a compaction job. Note that the state store " +
                     "must support atomic updates for this many files. For the DynamoDBStateStore this " +
                     "is 49. It can be overridden on a per-table basis.\n" +
-                    "This is a default value and will be used if not specified in the table.properties file.")
+                    "This is a default value and will be used if not specified in the table.properties file. " +
+                    "Also note that as this many files may need to be open simultaneously, the value of 'sleeper.fs.s3a.max-connections' must " +
+                    "be at least the value of this plus one (the extra one is for the output file).")
             .defaultValue("49")
             .propertyGroup(InstancePropertyGroup.COMPACTION).build();
     UserDefinedInstanceProperty DEFAULT_SIZERATIO_COMPACTION_STRATEGY_RATIO = Index.propertyBuilder("sleeper.default.table.compaction.strategy.sizeratio.ratio")

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
@@ -180,7 +180,9 @@ public interface TableProperty extends SleeperProperty {
                     "the file references and update the file reference count, and another 2 updates for an output file " +
                     "to add a new file reference and update the reference count. There's a limit of 100 atomic updates, " +
                     "which equates to 49 files in a compaction.\n" +
-                    "See also: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html")
+                    "See also: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html. " +
+                    "Also note that as this many files may need to be open simultaneously, the value of 'sleeper.fs.s3a.max-connections' must " +
+                    "be at least the value of this plus one (the extra one is for the output file).")
             .propertyGroup(TablePropertyGroup.COMPACTION)
             .build();
     TableProperty SIZE_RATIO_COMPACTION_STRATEGY_RATIO = Index.propertyBuilder("sleeper.table.compaction.strategy.sizeratio.ratio")

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -103,7 +103,7 @@ sleeper.log.retention.days=30
 # Used to set the value of fs.s3a.connection.maximum on the Hadoop configuration. This controls the
 # maximum number of http connections to S3.
 # See https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/performance.html
-sleeper.fs.s3a.max-connections=25
+sleeper.fs.s3a.max-connections=100
 
 # Used to set the value of fs.s3a.block.size on the Hadoop configuration. Uploads to S3 happen in
 # blocks, and this sets the size of blocks. If a larger value is used, then more data is buffered
@@ -851,7 +851,10 @@ sleeper.default.compaction.strategy.class=sleeper.compaction.strategy.impl.SizeR
 # The minimum number of files to read in a compaction job. Note that the state store must support
 # atomic updates for this many files. For the DynamoDBStateStore this is 49. It can be overridden on a
 # per-table basis.
-# This is a default value and will be used if not specified in the table.properties file.
+# This is a default value and will be used if not specified in the table.properties file. Also note
+# that as this many files may need to be open simultaneously, the value of
+# 'sleeper.fs.s3a.max-connections' must be at least the value of this plus one (the extra one is for
+# the output file).
 sleeper.default.compaction.files.batch.size=49
 
 # Used by the SizeRatioCompactionStrategy to decide if a group of files should be compacted.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR addresses the following issues and references them in the PR title. For example, "Issue 1739 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1739

### Tests

- [X] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Only changes configuration
    - Branch has been tested on AWS and compactions with 49 input files ran successfully.

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.