### PR TITLE
1772 websocket queries no longer works and has permission errors

### DIFF
--- a/java/cdk/src/main/java/sleeper/cdk/stack/QueryStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/QueryStack.java
@@ -70,6 +70,7 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -230,6 +231,7 @@ public class QueryStack extends NestedStack {
                 .build();
 
         lambda.addEventSource(new SqsEventSource(leafPartitionQueriesQueue, eventSourceProps));
+        grantAccessToWebSocketQueryApi(lambda);
     }
 
     /***
@@ -532,7 +534,7 @@ public class QueryStack extends NestedStack {
     public Grant grantAccessToWebSocketQueryApi(IGrantable identity) {
         return Grant.addToPrincipal(GrantOnPrincipalOptions.builder()
                 .grantee(identity)
-                .actions(Collections.singletonList("execute-api:Invoke"))
+                .actions(List.of("execute-api:Invoke", "execute-api:ManageConnections"))
                 .resourceArns(Collections.singletonList(Stack.of(this).formatArn(ArnComponents.builder()
                         .service("execute-api")
                         .resource(this.webSocketApi.getRef())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1772

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.