### PR TITLE
Issue 1802 - Do not wait for queue purge when purging no queues

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/AfterTestPurgeQueues.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/AfterTestPurgeQueues.java
@@ -47,7 +47,9 @@ public class AfterTestPurgeQueues {
 
     void testFailed() throws InterruptedException {
         LOGGER.info("Test failed, purging queues: {}", queueProperties);
-        purgeQueueRunner.purge(queueProperties);
+        if (!queueProperties.isEmpty()) {
+            purgeQueueRunner.purge(queueProperties);
+        }
     }
 
     public interface PurgeQueueRunner {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1802

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated AfterTestPurgeQueuesTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.