### PR TITLE
Issue 1829 - Add ability to run compactAllFiles.sh for a specific table

### DIFF
--- a/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateCompactionJobs.java
+++ b/java/compaction/compaction-job-creation/src/main/java/sleeper/compaction/job/creation/CreateCompactionJobs.java
@@ -107,13 +107,17 @@ public class CreateCompactionJobs {
                 .collect(Collectors.toUnmodifiableList());
         LOGGER.info("Found {} tables", tables.size());
         for (TableProperties table : tables) {
-            LOGGER.info("Performing pre-splits on files in {}", table.getId());
-            SplitFileReferences.from(stateStoreProvider.getStateStore(table)).split();
-            createJobsForTable(table);
+            createJobs(table);
         }
     }
 
-    public void createJobsForTable(TableProperties tableProperties) throws StateStoreException, IOException, ObjectFactoryException {
+    public void createJobs(TableProperties table) throws StateStoreException, IOException, ObjectFactoryException {
+        LOGGER.info("Performing pre-splits on files in {}", table.getId());
+        SplitFileReferences.from(stateStoreProvider.getStateStore(table)).split();
+        createJobsForTable(table);
+    }
+
+    private void createJobsForTable(TableProperties tableProperties) throws StateStoreException, IOException, ObjectFactoryException {
         TableIdentity tableId = tableProperties.getId();
         LOGGER.debug("Creating jobs for table {}", tableId);
         StateStore stateStore = stateStoreProvider.getStateStore(tableProperties);

--- a/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
+++ b/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
@@ -257,7 +257,9 @@ public class CreateCompactionJobsTest {
             TableProperties tableProperties1 = createTableProperties(schema, instanceProperties);
             TableProperties tableProperties2 = createTableProperties(schema, instanceProperties);
             StateStore stateStore1 = inMemoryStateStoreWithSinglePartition(schema);
+            stateStore1.fixTime(DEFAULT_UPDATE_TIME);
             StateStore stateStore2 = inMemoryStateStoreWithSinglePartition(schema);
+            stateStore2.fixTime(DEFAULT_UPDATE_TIME);
             FileReferenceFactory factory1 = FileReferenceFactory.fromUpdatedAt(stateStore1, DEFAULT_UPDATE_TIME);
             FileReference fileReference1 = factory1.rootFile("file1", 200L);
             FileReference fileReference2 = factory1.rootFile("file2", 200L);
@@ -299,6 +301,8 @@ public class CreateCompactionJobsTest {
                                 withJobId(fileReference4, job.getId()));
                 verifyJobCreationReported(job);
             });
+            assertThat(stateStore2.getFileReferences())
+                    .containsExactly(fileReference5, fileReference6, fileReference7, fileReference8);
         }
     }
 

--- a/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
+++ b/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.compaction.job.CompactionJobStatusTestData.jobCreated;
-import static sleeper.compaction.job.creation.CreateJobsTestUtils.createTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.COMPACTION_FILES_BATCH_SIZE;
 import static sleeper.configuration.properties.table.TableProperty.COMPACTION_STRATEGY_CLASS;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
@@ -58,7 +57,7 @@ public class CreateCompactionJobsTest {
     private static final Instant DEFAULT_UPDATE_TIME = Instant.parse("2024-02-13T11:19:00Z");
     private final InstanceProperties instanceProperties = CreateJobsTestUtils.createInstanceProperties();
     private final Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
-    private final TableProperties tableProperties = createTableProperties(schema, instanceProperties);
+    private final TableProperties tableProperties = CreateJobsTestUtils.createTableProperties(schema, instanceProperties);
     private final StateStore stateStore = inMemoryStateStoreWithNoPartitions();
     private final CompactionJobStatusStore jobStatusStore = new InMemoryCompactionJobStatusStore();
 
@@ -249,8 +248,8 @@ public class CreateCompactionJobsTest {
         @Test
         public void shouldCompactFilesInOneTable() throws Exception {
             // Given
-            TableProperties tableProperties1 = createTableProperties(schema, instanceProperties);
-            TableProperties tableProperties2 = createTableProperties(schema, instanceProperties);
+            TableProperties tableProperties1 = CreateJobsTestUtils.createTableProperties(schema, instanceProperties);
+            TableProperties tableProperties2 = CreateJobsTestUtils.createTableProperties(schema, instanceProperties);
             StateStore stateStore1 = inMemoryStateStoreWithSinglePartition(schema);
             stateStore1.fixTime(DEFAULT_UPDATE_TIME);
             StateStore stateStore2 = inMemoryStateStoreWithSinglePartition(schema);

--- a/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
+++ b/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
@@ -61,7 +61,7 @@ public class CreateCompactionJobsTest {
 
     @Nested
     @DisplayName("Compact files using strategy")
-    class CompactionFilesByStrategy {
+    class CompactFilesByStrategy {
         private final List<CompactionJob> jobs = new ArrayList<>();
         private final CreateCompactionJobs jobCreator = CreateCompactionJobs.standard(
                 ObjectFactory.noUserJars(), instanceProperties,

--- a/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
+++ b/java/compaction/compaction-job-creation/src/test/java/sleeper/compaction/job/creation/CreateCompactionJobsTest.java
@@ -77,11 +77,6 @@ public class CreateCompactionJobsTest {
                 new FixedStateStoreProvider(tableProperties, stateStore),
                 jobs::add, jobStatusStore);
 
-        @BeforeEach
-        void setUp() {
-            jobs.clear();
-        }
-
         @Test
         public void shouldCompactAllFilesInSinglePartition() throws Exception {
             // Given
@@ -315,11 +310,6 @@ public class CreateCompactionJobsTest {
                 new FixedTablePropertiesProvider(tableProperties),
                 new FixedStateStoreProvider(tableProperties, stateStore),
                 jobs::add, jobStatusStore);
-
-        @BeforeEach
-        void setUp() {
-            jobs.clear();
-        }
 
         @Test
         void shouldCreateJobsWhenStrategyDoesNotCreateJobsForWholeFilesWhenCompactingAllFiles() throws Exception {

--- a/scripts/utility/compactAllFiles.sh
+++ b/scripts/utility/compactAllFiles.sh
@@ -18,12 +18,10 @@
 set -e
 unset CDPATH
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <instance-id>"
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <instance-id> <optional-table-name>"
   exit 1
 fi
-
-INSTANCE_ID=$1
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd .. && pwd)
 
@@ -35,4 +33,4 @@ VERSION=$(cat "${TEMPLATE_DIR}/version.txt")
 echo "-------------------------------------------------------"
 echo "Forcing compaction job creation"
 echo "-------------------------------------------------------"
-java -cp "${JAR_DIR}/clients-${VERSION}-utility.jar" sleeper.clients.status.update.CreateJobsClient "${INSTANCE_ID}" --all
+java -cp "${JAR_DIR}/clients-${VERSION}-utility.jar" sleeper.clients.status.update.CreateJobsClient ALL "$@"

--- a/scripts/utility/compactFiles.sh
+++ b/scripts/utility/compactFiles.sh
@@ -18,12 +18,10 @@
 set -e
 unset CDPATH
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <instance-id>"
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <instance-id> <optional-table-name>"
   exit 1
 fi
-
-INSTANCE_ID=$1
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd .. && pwd)
 
@@ -35,4 +33,4 @@ VERSION=$(cat "${TEMPLATE_DIR}/version.txt")
 echo "-------------------------------------------------------"
 echo "Running compaction job creation"
 echo "-------------------------------------------------------"
-java -cp "${JAR_DIR}/clients-${VERSION}-utility.jar" sleeper.clients.status.update.CreateJobsClient "${INSTANCE_ID}"
+java -cp "${JAR_DIR}/clients-${VERSION}-utility.jar" sleeper.clients.status.update.CreateJobsClient DEFAULT "$@"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1829

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Added new test in CreateCompactionJobsTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.