### PR TITLE
Issue 1844 - Split system test contexts to track deployed and current instances/tables separately

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/compaction/AwsCompactionDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/compaction/AwsCompactionDriver.java
@@ -38,7 +38,7 @@ import sleeper.core.statestore.StateStoreException;
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.drivers.util.SystemTestClients;
 import sleeper.systemtest.dsl.compaction.CompactionDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.io.IOException;
 import java.util.List;
@@ -53,12 +53,12 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 public class AwsCompactionDriver implements CompactionDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsCompactionDriver.class);
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final LambdaClient lambdaClient;
     private final AmazonDynamoDB dynamoDBClient;
     private final AmazonSQS sqsClient;
 
-    public AwsCompactionDriver(SleeperInstanceContext instance, SystemTestClients clients) {
+    public AwsCompactionDriver(SystemTestInstanceContext instance, SystemTestClients clients) {
         this.instance = instance;
         this.lambdaClient = clients.getLambda();
         this.dynamoDBClient = clients.getDynamoDB();

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/compaction/AwsCompactionReportsDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/compaction/AwsCompactionReportsDriver.java
@@ -29,7 +29,7 @@ import sleeper.compaction.job.status.CompactionJobStatus;
 import sleeper.compaction.status.store.job.CompactionJobStatusStoreFactory;
 import sleeper.compaction.status.store.task.CompactionTaskStatusStoreFactory;
 import sleeper.compaction.task.CompactionTaskStatusStore;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.ReportingContext;
 import sleeper.systemtest.dsl.reporting.SystemTestReport;
@@ -38,10 +38,10 @@ import java.time.Instant;
 import java.util.List;
 
 public class AwsCompactionReportsDriver implements CompactionReportsDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonDynamoDB dynamoDB;
 
-    public AwsCompactionReportsDriver(SleeperInstanceContext instance, AmazonDynamoDB dynamoDB) {
+    public AwsCompactionReportsDriver(SystemTestInstanceContext instance, AmazonDynamoDB dynamoDB) {
         this.instance = instance;
         this.dynamoDB = dynamoDB;
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsDataGenerationTasksDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsDataGenerationTasksDriver.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.ecs.model.RunTaskResult;
 import com.amazonaws.services.ecs.model.Task;
 
 import sleeper.core.util.PollWithRetries;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 
@@ -32,11 +32,11 @@ import static sleeper.systemtest.drivers.ingest.WaitForGenerateData.ecsTaskStatu
 
 public class AwsDataGenerationTasksDriver implements DataGenerationTasksDriver {
     private final SystemTestDeploymentContext systemTest;
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonECS ecsClient;
 
     public AwsDataGenerationTasksDriver(SystemTestDeploymentContext systemTest,
-                                        SleeperInstanceContext instance,
+                                        SystemTestInstanceContext instance,
                                         AmazonECS ecsClient) {
         this.systemTest = systemTest;
         this.instance = instance;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsDataGenerationTasksDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsDataGenerationTasksDriver.java
@@ -21,8 +21,8 @@ import com.amazonaws.services.ecs.model.RunTaskResult;
 import com.amazonaws.services.ecs.model.Task;
 
 import sleeper.core.util.PollWithRetries;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 
 import java.util.List;
@@ -31,11 +31,11 @@ import java.util.stream.Collectors;
 import static sleeper.systemtest.drivers.ingest.WaitForGenerateData.ecsTaskStatusFormat;
 
 public class AwsDataGenerationTasksDriver implements DataGenerationTasksDriver {
-    private final SystemTestDeploymentContext systemTest;
+    private final DeployedSystemTestResources systemTest;
     private final SystemTestInstanceContext instance;
     private final AmazonECS ecsClient;
 
-    public AwsDataGenerationTasksDriver(SystemTestDeploymentContext systemTest,
+    public AwsDataGenerationTasksDriver(DeployedSystemTestResources systemTest,
                                         SystemTestInstanceContext instance,
                                         AmazonECS ecsClient) {
         this.systemTest = systemTest;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsDirectIngestDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsDirectIngestDriver.java
@@ -22,7 +22,7 @@ import sleeper.core.record.Record;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.ingest.IngestFactory;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,9 +30,9 @@ import java.nio.file.Path;
 import java.util.Iterator;
 
 public class AwsDirectIngestDriver implements DirectIngestDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
 
-    public AwsDirectIngestDriver(SleeperInstanceContext instance) {
+    public AwsDirectIngestDriver(SystemTestInstanceContext instance) {
         this.instance = instance;
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsIngestBatcherDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsIngestBatcherDriver.java
@@ -30,7 +30,7 @@ import sleeper.ingest.batcher.store.DynamoDBIngestBatcherStore;
 import sleeper.ingest.batcher.submitter.FileIngestRequestSerDe;
 import sleeper.systemtest.drivers.util.SystemTestClients;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
 
 import java.time.Duration;
@@ -46,7 +46,7 @@ import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 public class AwsIngestBatcherDriver implements IngestBatcherDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsIngestBatcherDriver.class);
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext sourceFiles;
     private final AmazonDynamoDB dynamoDBClient;
     private final AmazonSQS sqsClient;
@@ -54,7 +54,7 @@ public class AwsIngestBatcherDriver implements IngestBatcherDriver {
     private final PollWithRetries pollBatcherStore = PollWithRetries
             .intervalAndPollingTimeout(Duration.ofSeconds(5), Duration.ofMinutes(2));
 
-    public AwsIngestBatcherDriver(SleeperInstanceContext instance,
+    public AwsIngestBatcherDriver(SystemTestInstanceContext instance,
                                   IngestSourceFilesContext sourceFiles,
                                   SystemTestClients clients) {
         this.instance = instance;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsIngestReportsDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsIngestReportsDriver.java
@@ -33,7 +33,7 @@ import sleeper.ingest.status.store.task.IngestTaskStatusStoreFactory;
 import sleeper.ingest.task.IngestTaskStatusStore;
 import sleeper.job.common.QueueMessageCount;
 import sleeper.systemtest.drivers.util.SystemTestClients;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.ReportingContext;
 import sleeper.systemtest.dsl.reporting.SystemTestReport;
@@ -42,12 +42,12 @@ import java.time.Instant;
 import java.util.List;
 
 public class AwsIngestReportsDriver implements IngestReportsDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonDynamoDB dynamoDB;
     private final QueueMessageCount.Client queueMessages;
     private final AmazonElasticMapReduce emr;
 
-    public AwsIngestReportsDriver(SleeperInstanceContext instance,
+    public AwsIngestReportsDriver(SystemTestInstanceContext instance,
                                   SystemTestClients clients) {
         this.instance = instance;
         this.dynamoDB = clients.getDynamoDB();

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsInvokeIngestTasksDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsInvokeIngestTasksDriver.java
@@ -28,18 +28,18 @@ import sleeper.ingest.status.store.task.IngestTaskStatusStoreFactory;
 import sleeper.ingest.task.IngestTaskStatusStore;
 import sleeper.systemtest.drivers.util.SystemTestClients;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.INGEST_LAMBDA_FUNCTION;
 
 public class AwsInvokeIngestTasksDriver implements InvokeIngestTasksDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsInvokeIngestTasksDriver.class);
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonDynamoDB dynamoDBClient;
     private final LambdaClient lambdaClient;
 
-    public AwsInvokeIngestTasksDriver(SleeperInstanceContext instance, SystemTestClients clients) {
+    public AwsInvokeIngestTasksDriver(SystemTestInstanceContext instance, SystemTestClients clients) {
         this.instance = instance;
         this.dynamoDBClient = clients.getDynamoDB();
         this.lambdaClient = clients.getLambda();

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsPurgeQueueDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsPurgeQueueDriver.java
@@ -22,17 +22,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import sleeper.configuration.properties.instance.InstanceProperty;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
 
 import java.util.List;
 
 public class AwsPurgeQueueDriver implements PurgeQueueDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsPurgeQueueDriver.class);
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonSQS sqsClient;
 
-    public AwsPurgeQueueDriver(SleeperInstanceContext instance, AmazonSQS sqsClient) {
+    public AwsPurgeQueueDriver(SystemTestInstanceContext instance, AmazonSQS sqsClient) {
         this.instance = instance;
         this.sqsClient = sqsClient;
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/DirectEmrServerlessDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/DirectEmrServerlessDriver.java
@@ -28,7 +28,7 @@ import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.status.store.job.IngestJobStatusStoreFactory;
 import sleeper.systemtest.drivers.util.SystemTestClients;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -37,12 +37,12 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.ingest.job.status.IngestJobValidatedEvent.ingestJobAccepted;
 
 public class DirectEmrServerlessDriver implements DirectBulkImportDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonS3 s3Client;
     private final AmazonDynamoDB dynamoDBClient;
     private final EmrServerlessClient emrClient;
 
-    public DirectEmrServerlessDriver(SleeperInstanceContext instance,
+    public DirectEmrServerlessDriver(SystemTestInstanceContext instance,
                                      SystemTestClients clients) {
         this.instance = instance;
         this.s3Client = clients.getS3();

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/AwsSleeperTablesDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/AwsSleeperTablesDriver.java
@@ -43,7 +43,7 @@ import sleeper.core.util.PollWithRetries;
 import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
 import sleeper.systemtest.drivers.util.SystemTestClients;
-import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SleeperTablesDriver;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -67,20 +67,20 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.InstanceProperties.S3_INSTANCE_PROPERTIES_FILE;
 import static sleeper.dynamodb.tools.DynamoDBUtils.streamPagedResults;
 
-public class AwsSleeperInstanceTablesDriver implements SleeperInstanceTablesDriver {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AwsSleeperInstanceTablesDriver.class);
+public class AwsSleeperTablesDriver implements SleeperTablesDriver {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsSleeperTablesDriver.class);
 
     private final AmazonS3 s3;
     private final S3Client s3v2;
     private final AmazonDynamoDB dynamoDB;
     private final Configuration hadoopConfiguration;
 
-    public AwsSleeperInstanceTablesDriver(SystemTestClients clients) {
+    public AwsSleeperTablesDriver(SystemTestClients clients) {
         this(clients.getS3(), clients.getS3V2(), clients.getDynamoDB(),
                 HadoopConfigurationProvider.getConfigurationForClient());
     }
 
-    public AwsSleeperInstanceTablesDriver(
+    public AwsSleeperTablesDriver(
             AmazonS3 s3, S3Client s3v2, AmazonDynamoDB dynamoDB, Configuration hadoopConfiguration) {
         this.s3 = s3;
         this.s3v2 = s3v2;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/metrics/AwsTableMetricsDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/metrics/AwsTableMetricsDriver.java
@@ -38,7 +38,7 @@ import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.table.TableIdentity;
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.drivers.util.SystemTestClients;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.reporting.ReportingContext;
 
@@ -66,12 +66,12 @@ public class AwsTableMetricsDriver implements TableMetricsDriver {
     private static final String QUERY_METRIC_STATISTIC = "Average";
     private static final int QUERY_METRIC_PERIOD_SECONDS = 5 * 60;
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final ReportingContext reporting;
     private final LambdaClient lambda;
     private final CloudWatchClient cloudWatch;
 
-    public AwsTableMetricsDriver(SleeperInstanceContext instance,
+    public AwsTableMetricsDriver(SystemTestInstanceContext instance,
                                  ReportingContext reporting,
                                  SystemTestClients clients) {
         this.instance = instance;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/partitioning/AwsPartitionReportDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/partitioning/AwsPartitionReportDriver.java
@@ -19,15 +19,15 @@ package sleeper.systemtest.drivers.partitioning;
 import sleeper.clients.status.report.partitions.PartitionsStatus;
 import sleeper.clients.status.report.partitions.PartitionsStatusReporter;
 import sleeper.core.statestore.StateStoreException;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReport;
 
 public class AwsPartitionReportDriver implements PartitionReportDriver {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
 
-    public AwsPartitionReportDriver(SleeperInstanceContext instance) {
+    public AwsPartitionReportDriver(SystemTestInstanceContext instance) {
         this.instance = instance;
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/partitioning/AwsPartitionSplittingDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/partitioning/AwsPartitionSplittingDriver.java
@@ -19,7 +19,7 @@ package sleeper.systemtest.drivers.partitioning;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 
 import sleeper.clients.deploy.InvokeLambda;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.partitioning.WaitForPartitionSplitting;
 
@@ -27,10 +27,10 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 
 public class AwsPartitionSplittingDriver implements PartitionSplittingDriver {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final LambdaClient lambdaClient;
 
-    public AwsPartitionSplittingDriver(SleeperInstanceContext instance, LambdaClient lambdaClient) {
+    public AwsPartitionSplittingDriver(SystemTestInstanceContext instance, LambdaClient lambdaClient) {
         this.instance = instance;
         this.lambdaClient = lambdaClient;
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonBulkImportDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonBulkImportDriver.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.drivers.python;
 
 import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.nio.file.Path;
 import java.util.stream.Stream;
@@ -26,11 +26,11 @@ import static sleeper.configuration.properties.instance.CommonProperty.ID;
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_BUCKET;
 
 public class PythonBulkImportDriver implements IngestByAnyQueueDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final PythonRunner pythonRunner;
     private final Path pythonDir;
 
-    public PythonBulkImportDriver(SleeperInstanceContext instance, Path pythonDir) {
+    public PythonBulkImportDriver(SystemTestInstanceContext instance, Path pythonDir) {
         this.instance = instance;
         this.pythonRunner = new PythonRunner(pythonDir);
         this.pythonDir = pythonDir;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonIngestDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonIngestDriver.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.drivers.python;
 
 import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.nio.file.Path;
 import java.util.stream.Stream;
@@ -26,11 +26,11 @@ import static sleeper.configuration.properties.instance.CommonProperty.ID;
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_BUCKET;
 
 public class PythonIngestDriver implements IngestByAnyQueueDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final PythonRunner pythonRunner;
     private final Path pythonDir;
 
-    public PythonIngestDriver(SleeperInstanceContext instance, Path pythonDir) {
+    public PythonIngestDriver(SystemTestInstanceContext instance, Path pythonDir) {
         this.instance = instance;
         this.pythonRunner = new PythonRunner(pythonDir);
         this.pythonDir = pythonDir;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonIngestLocalFileDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonIngestLocalFileDriver.java
@@ -17,18 +17,18 @@
 package sleeper.systemtest.drivers.python;
 
 import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.nio.file.Path;
 
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
 
 public class PythonIngestLocalFileDriver implements IngestLocalFileByAnyQueueDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final PythonRunner pythonRunner;
     private final Path pythonDir;
 
-    public PythonIngestLocalFileDriver(SleeperInstanceContext instance, Path pythonDir) {
+    public PythonIngestLocalFileDriver(SystemTestInstanceContext instance, Path pythonDir) {
         this.instance = instance;
         this.pythonRunner = new PythonRunner(pythonDir);
         this.pythonDir = pythonDir;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonQueryDriver.java
@@ -21,7 +21,7 @@ import com.google.gson.GsonBuilder;
 
 import sleeper.core.record.Record;
 import sleeper.io.parquet.record.ParquetRecordReader;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.python.PythonQueryTypesDriver;
 
 import java.io.IOException;
@@ -35,11 +35,11 @@ import static sleeper.configuration.properties.instance.CommonProperty.ID;
 
 public class PythonQueryDriver implements PythonQueryTypesDriver {
     private static final Gson GSON = new GsonBuilder().create();
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final PythonRunner pythonRunner;
     private final Path pythonDir;
 
-    public PythonQueryDriver(SleeperInstanceContext instance, Path pythonDir) {
+    public PythonQueryDriver(SystemTestInstanceContext instance, Path pythonDir) {
         this.instance = instance;
         this.pythonRunner = new PythonRunner(pythonDir);
         this.pythonDir = pythonDir;

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
@@ -28,7 +28,7 @@ import sleeper.core.statestore.StateStoreException;
 import sleeper.query.model.Query;
 import sleeper.query.model.QueryException;
 import sleeper.query.runner.recordretrieval.QueryExecutor;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesInParallelDriver;
 import sleeper.systemtest.dsl.query.QueryDriver;
@@ -44,13 +44,13 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class DirectQueryDriver implements QueryDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
 
-    public DirectQueryDriver(SleeperInstanceContext instance) {
+    public DirectQueryDriver(SystemTestInstanceContext instance) {
         this.instance = instance;
     }
 
-    public static QueryAllTablesDriver allTablesDriver(SleeperInstanceContext instance) {
+    public static QueryAllTablesDriver allTablesDriver(SystemTestInstanceContext instance) {
         return new QueryAllTablesInParallelDriver(instance, new DirectQueryDriver(instance));
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/S3ResultsDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/S3ResultsDriver.java
@@ -18,16 +18,16 @@ package sleeper.systemtest.drivers.query;
 
 import com.amazonaws.services.s3.AmazonS3;
 
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.QUERY_RESULTS_BUCKET;
 
 public class S3ResultsDriver implements ClearQueryResultsDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonS3 s3;
 
-    public S3ResultsDriver(SleeperInstanceContext instance, AmazonS3 s3) {
+    public S3ResultsDriver(SystemTestInstanceContext instance, AmazonS3 s3) {
         this.instance = instance;
         this.s3 = s3;
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SQSQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SQSQueryDriver.java
@@ -34,7 +34,7 @@ import sleeper.query.tracker.QueryTrackerStore;
 import sleeper.query.tracker.TrackedQuery;
 import sleeper.systemtest.drivers.util.ReadRecordsFromS3;
 import sleeper.systemtest.drivers.util.SystemTestClients;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesSendAndWaitDriver;
 import sleeper.systemtest.dsl.query.QuerySendAndWaitDriver;
@@ -49,14 +49,14 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 public class SQSQueryDriver implements QuerySendAndWaitDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(SQSQueryDriver.class);
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final AmazonSQS sqsClient;
     private final AmazonDynamoDB dynamoDBClient;
     private final AmazonS3 s3Client;
     private final PollWithRetries poll = PollWithRetries.intervalAndPollingTimeout(
             Duration.ofSeconds(2), Duration.ofMinutes(1));
 
-    public SQSQueryDriver(SleeperInstanceContext instance,
+    public SQSQueryDriver(SystemTestInstanceContext instance,
                           AmazonSQS sqsClient,
                           AmazonDynamoDB dynamoDBClient,
                           AmazonS3 s3Client) {
@@ -66,7 +66,7 @@ public class SQSQueryDriver implements QuerySendAndWaitDriver {
         this.s3Client = s3Client;
     }
 
-    public static QueryAllTablesDriver allTablesDriver(SleeperInstanceContext instance, SystemTestClients clients) {
+    public static QueryAllTablesDriver allTablesDriver(SystemTestInstanceContext instance, SystemTestClients clients) {
         return new QueryAllTablesSendAndWaitDriver(instance,
                 new SQSQueryDriver(instance, clients.getSqs(), clients.getDynamoDB(), clients.getS3()));
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SchemaLoaderFromInstanceContext.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SchemaLoaderFromInstanceContext.java
@@ -19,15 +19,15 @@ package sleeper.systemtest.drivers.query;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.schema.Schema;
 import sleeper.query.model.QuerySerDe;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.Optional;
 
 public class SchemaLoaderFromInstanceContext implements QuerySerDe.SchemaLoader {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
 
-    public SchemaLoaderFromInstanceContext(SleeperInstanceContext instance) {
+    public SchemaLoaderFromInstanceContext(SystemTestInstanceContext instance) {
         this.instance = instance;
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/sourcedata/AwsGeneratedIngestSourceFilesDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/sourcedata/AwsGeneratedIngestSourceFilesDriver.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import sleeper.configuration.properties.instance.InstanceProperties;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFiles;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 
@@ -35,10 +35,10 @@ import static java.util.function.Predicate.not;
 public class AwsGeneratedIngestSourceFilesDriver implements GeneratedIngestSourceFilesDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsGeneratedIngestSourceFilesDriver.class);
 
-    private final SystemTestDeploymentContext context;
+    private final DeployedSystemTestResources context;
     private final S3Client s3Client;
 
-    public AwsGeneratedIngestSourceFilesDriver(SystemTestDeploymentContext context, S3Client s3Client) {
+    public AwsGeneratedIngestSourceFilesDriver(DeployedSystemTestResources context, S3Client s3Client) {
         this.context = context;
         this.s3Client = s3Client;
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -57,7 +57,8 @@ import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
-import sleeper.systemtest.dsl.query.SystemTestQuery;
+import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
+import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReporting;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
@@ -138,11 +139,18 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestQuery query(SystemTestContext context) {
-        return new SystemTestQuery(context.instance(),
-                SQSQueryDriver.allTablesDriver(context.instance(), clients),
-                DirectQueryDriver.allTablesDriver(context.instance()),
-                new S3ResultsDriver(context.instance(), clients.getS3()));
+    public QueryAllTablesDriver queryByQueue(SystemTestContext context) {
+        return SQSQueryDriver.allTablesDriver(context.instance(), clients);
+    }
+
+    @Override
+    public QueryAllTablesDriver directQuery(SystemTestContext context) {
+        return DirectQueryDriver.allTablesDriver(context.instance());
+    }
+
+    @Override
+    public ClearQueryResultsDriver clearQueryResults(SystemTestContext context) {
+        return new S3ResultsDriver(context.instance(), clients.getS3());
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -45,9 +45,9 @@ import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
 import sleeper.systemtest.dsl.instance.DeployedSleeperInstances;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
@@ -69,14 +69,14 @@ import java.nio.file.Path;
 public class AwsSystemTestDrivers implements SystemTestDrivers {
     private final SystemTestClients clients = new SystemTestClients();
     private final SystemTestParameters parameters;
-    private final SystemTestDeploymentContext systemTestContext;
+    private final DeployedSystemTestResources systemTestContext;
     private final SystemTestInstanceContext instanceContext;
     private final IngestSourceFilesContext sourceFilesContext;
     private final ReportingContext reportingContext;
 
     public AwsSystemTestDrivers(SystemTestParameters parameters) {
         this.parameters = parameters;
-        systemTestContext = new SystemTestDeploymentContext(
+        systemTestContext = new DeployedSystemTestResources(
                 parameters, new AwsSystemTestDeploymentDriver(parameters, clients));
         SleeperInstanceDriver instanceDriver = new AwsSleeperInstanceDriver(parameters, clients);
         SleeperInstanceTablesDriver tablesDriver = new AwsSleeperInstanceTablesDriver(clients);
@@ -88,7 +88,7 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestDeploymentContext getSystemTestContext() {
+    public DeployedSystemTestResources getSystemTestContext() {
         return systemTestContext;
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -41,26 +41,24 @@ import sleeper.systemtest.drivers.query.S3ResultsDriver;
 import sleeper.systemtest.drivers.query.SQSQueryDriver;
 import sleeper.systemtest.drivers.sourcedata.AwsGeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.drivers.sourcedata.AwsIngestSourceFilesDriver;
+import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
-import sleeper.systemtest.dsl.instance.DeployedSleeperInstances;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
-import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
-import sleeper.systemtest.dsl.partitioning.SystemTestPartitioning;
+import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.SystemTestQuery;
-import sleeper.systemtest.dsl.reporting.ReportingContext;
 import sleeper.systemtest.dsl.reporting.SystemTestReporting;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
-import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
+import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
-import sleeper.systemtest.dsl.sourcedata.SystemTestSourceFiles;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
 import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
@@ -68,135 +66,110 @@ import java.nio.file.Path;
 
 public class AwsSystemTestDrivers implements SystemTestDrivers {
     private final SystemTestClients clients = new SystemTestClients();
-    private final SystemTestParameters parameters;
-    private final DeployedSystemTestResources systemTestContext;
-    private final SystemTestInstanceContext instanceContext;
-    private final IngestSourceFilesContext sourceFilesContext;
-    private final ReportingContext reportingContext;
 
-    public AwsSystemTestDrivers(SystemTestParameters parameters) {
-        this.parameters = parameters;
-        systemTestContext = new DeployedSystemTestResources(
-                parameters, new AwsSystemTestDeploymentDriver(parameters, clients));
-        SleeperInstanceDriver instanceDriver = new AwsSleeperInstanceDriver(parameters, clients);
-        SleeperInstanceTablesDriver tablesDriver = new AwsSleeperInstanceTablesDriver(clients);
-        DeployedSleeperInstances deployedInstances = new DeployedSleeperInstances(
-                parameters, systemTestContext, instanceDriver, tablesDriver);
-        instanceContext = new SystemTestInstanceContext(parameters, deployedInstances, instanceDriver, tablesDriver);
-        sourceFilesContext = new IngestSourceFilesContext(systemTestContext, instanceContext);
-        reportingContext = new ReportingContext(parameters);
+    @Override
+    public SystemTestDeploymentDriver systemTestDeployment(SystemTestParameters parameters) {
+        return new AwsSystemTestDeploymentDriver(parameters, clients);
     }
 
     @Override
-    public DeployedSystemTestResources getSystemTestContext() {
-        return systemTestContext;
+    public SleeperInstanceDriver instance(SystemTestParameters parameters) {
+        return new AwsSleeperInstanceDriver(parameters, clients);
     }
 
     @Override
-    public SystemTestInstanceContext getInstanceContext() {
-        return instanceContext;
+    public SleeperInstanceTablesDriver tables(SystemTestParameters parameters) {
+        return new AwsSleeperInstanceTablesDriver(clients);
     }
 
     @Override
-    public IngestSourceFilesContext getSourceFilesContext() {
-        return sourceFilesContext;
+    public GeneratedIngestSourceFilesDriver generatedSourceFiles(SystemTestParameters parameters, DeployedSystemTestResources systemTest) {
+        return new AwsGeneratedIngestSourceFilesDriver(systemTest, clients.getS3V2());
     }
 
     @Override
-    public ReportingContext getReportingContext() {
-        return reportingContext;
+    public IngestSourceFilesDriver sourceFilesDriver(SystemTestContext context) {
+        return new AwsIngestSourceFilesDriver(context.sourceFiles());
     }
 
     @Override
-    public GeneratedIngestSourceFilesDriver generatedSourceFilesDriver() {
-        return new AwsGeneratedIngestSourceFilesDriver(systemTestContext, clients.getS3V2());
+    public PartitionSplittingDriver partitionSplitting(SystemTestContext context) {
+        return new AwsPartitionSplittingDriver(context.instance(), clients.getLambda());
     }
 
     @Override
-    public SystemTestSourceFiles sourceFiles() {
-        return new SystemTestSourceFiles(instanceContext, sourceFilesContext,
-                new AwsIngestSourceFilesDriver(sourceFilesContext));
+    public SystemTestIngest ingest(SystemTestContext context) {
+        return new SystemTestIngest(context.instance(), context.sourceFiles(),
+                new AwsDirectIngestDriver(context.instance()),
+                new IngestByQueue(context.instance(), new AwsIngestByQueueDriver(clients)),
+                new DirectEmrServerlessDriver(context.instance(), clients),
+                new AwsIngestBatcherDriver(context.instance(), context.sourceFiles(), clients),
+                new AwsInvokeIngestTasksDriver(context.instance(), clients),
+                AwsWaitForJobs.forIngest(context.instance(), clients.getDynamoDB()),
+                AwsWaitForJobs.forBulkImport(context.instance(), clients.getDynamoDB()));
     }
 
     @Override
-    public SystemTestPartitioning partitioning() {
-        return new SystemTestPartitioning(instanceContext,
-                new AwsPartitionSplittingDriver(instanceContext, clients.getLambda()));
+    public SystemTestQuery query(SystemTestContext context) {
+        return new SystemTestQuery(context.instance(),
+                SQSQueryDriver.allTablesDriver(context.instance(), clients),
+                DirectQueryDriver.allTablesDriver(context.instance()),
+                new S3ResultsDriver(context.instance(), clients.getS3()));
     }
 
     @Override
-    public SystemTestIngest ingest() {
-        return new SystemTestIngest(instanceContext, sourceFilesContext,
-                new AwsDirectIngestDriver(instanceContext),
-                new IngestByQueue(instanceContext, new AwsIngestByQueueDriver(clients)),
-                new DirectEmrServerlessDriver(instanceContext, clients),
-                new AwsIngestBatcherDriver(instanceContext, sourceFilesContext, clients),
-                new AwsInvokeIngestTasksDriver(instanceContext, clients),
-                AwsWaitForJobs.forIngest(instanceContext, clients.getDynamoDB()),
-                AwsWaitForJobs.forBulkImport(instanceContext, clients.getDynamoDB()));
-    }
-
-    @Override
-    public SystemTestQuery query() {
-        return new SystemTestQuery(instanceContext,
-                SQSQueryDriver.allTablesDriver(instanceContext, clients),
-                DirectQueryDriver.allTablesDriver(instanceContext),
-                new S3ResultsDriver(instanceContext, clients.getS3()));
-    }
-
-    @Override
-    public SystemTestCompaction compaction() {
+    public SystemTestCompaction compaction(SystemTestContext context) {
         return new SystemTestCompaction(
-                new AwsCompactionDriver(instanceContext, clients),
-                AwsWaitForJobs.forCompaction(instanceContext, clients.getDynamoDB()));
+                new AwsCompactionDriver(context.instance(), clients),
+                AwsWaitForJobs.forCompaction(context.instance(), clients.getDynamoDB()));
     }
 
     @Override
-    public SystemTestReporting reporting() {
-        return new SystemTestReporting(reportingContext,
-                new AwsIngestReportsDriver(instanceContext, clients),
-                new AwsCompactionReportsDriver(instanceContext, clients.getDynamoDB()));
+    public SystemTestReporting reporting(SystemTestContext context) {
+        return new SystemTestReporting(context.reporting(),
+                new AwsIngestReportsDriver(context.instance(), clients),
+                new AwsCompactionReportsDriver(context.instance(), clients.getDynamoDB()));
     }
 
     @Override
-    public SystemTestMetrics metrics() {
-        return new SystemTestMetrics(new AwsTableMetricsDriver(instanceContext, reportingContext, clients));
+    public SystemTestMetrics metrics(SystemTestContext context) {
+        return new SystemTestMetrics(new AwsTableMetricsDriver(context.instance(), context.reporting(), clients));
     }
 
     @Override
-    public SystemTestReports.SystemTestBuilder reportsForExtension() {
-        return SystemTestReports.builder(reportingContext,
-                new AwsPartitionReportDriver(instanceContext),
-                new AwsIngestReportsDriver(instanceContext, clients),
-                new AwsCompactionReportsDriver(instanceContext, clients.getDynamoDB()));
+    public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
+        return SystemTestReports.builder(context.reporting(),
+                new AwsPartitionReportDriver(context.instance()),
+                new AwsIngestReportsDriver(context.instance(), clients),
+                new AwsCompactionReportsDriver(context.instance(), clients.getDynamoDB()));
     }
 
     @Override
-    public SystemTestCluster systemTestCluster() {
-        return new SystemTestCluster(systemTestContext,
-                new AwsDataGenerationTasksDriver(systemTestContext, instanceContext, clients.getEcs()),
-                new IngestByQueue(instanceContext, new AwsIngestByQueueDriver(clients)),
-                new AwsGeneratedIngestSourceFilesDriver(systemTestContext, clients.getS3V2()),
-                new AwsInvokeIngestTasksDriver(instanceContext, clients),
-                AwsWaitForJobs.forIngest(instanceContext, clients.getDynamoDB()),
-                AwsWaitForJobs.forBulkImport(instanceContext, clients.getDynamoDB()));
+    public SystemTestCluster systemTestCluster(SystemTestContext context) {
+        return new SystemTestCluster(context.systemTest(),
+                new AwsDataGenerationTasksDriver(context.systemTest(), context.instance(), clients.getEcs()),
+                new IngestByQueue(context.instance(), new AwsIngestByQueueDriver(clients)),
+                new AwsGeneratedIngestSourceFilesDriver(context.systemTest(), clients.getS3V2()),
+                new AwsInvokeIngestTasksDriver(context.instance(), clients),
+                AwsWaitForJobs.forIngest(context.instance(), clients.getDynamoDB()),
+                AwsWaitForJobs.forBulkImport(context.instance(), clients.getDynamoDB()));
     }
 
     @Override
-    public SystemTestPythonApi pythonApi() {
-        Path pythonDir = parameters.getPythonDirectory();
-        return new SystemTestPythonApi(instanceContext,
-                new PythonIngestDriver(instanceContext, pythonDir),
-                new PythonIngestLocalFileDriver(instanceContext, pythonDir),
-                new PythonBulkImportDriver(instanceContext, pythonDir),
-                new AwsInvokeIngestTasksDriver(instanceContext, clients),
-                AwsWaitForJobs.forIngest(instanceContext, clients.getDynamoDB()),
-                AwsWaitForJobs.forBulkImport(instanceContext, clients.getDynamoDB()),
-                new PythonQueryDriver(instanceContext, pythonDir));
+    public SystemTestPythonApi pythonApi(SystemTestContext context) {
+        Path pythonDir = context.parameters().getPythonDirectory();
+        return new SystemTestPythonApi(context.instance(),
+                new PythonIngestDriver(context.instance(), pythonDir),
+                new PythonIngestLocalFileDriver(context.instance(), pythonDir),
+                new PythonBulkImportDriver(context.instance(), pythonDir),
+                new AwsInvokeIngestTasksDriver(context.instance(), clients),
+                AwsWaitForJobs.forIngest(context.instance(), clients.getDynamoDB()),
+                AwsWaitForJobs.forBulkImport(context.instance(), clients.getDynamoDB()),
+                new PythonQueryDriver(context.instance(), pythonDir));
     }
 
     @Override
-    public PurgeQueueDriver purgeQueueDriver() {
-        return new AwsPurgeQueueDriver(instanceContext, clients.getSqs());
+    public PurgeQueueDriver purgeQueueDriver(SystemTestContext context) {
+        return new AwsPurgeQueueDriver(context.instance(), clients.getSqs());
     }
 }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -59,7 +59,8 @@ import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
-import sleeper.systemtest.dsl.reporting.SystemTestReporting;
+import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
+import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
@@ -164,10 +165,13 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestReporting reporting(SystemTestContext context) {
-        return new SystemTestReporting(context.reporting(),
-                new AwsIngestReportsDriver(context.instance(), clients),
-                new AwsCompactionReportsDriver(context.instance(), clients.getDynamoDB()));
+    public IngestReportsDriver ingestReports(SystemTestContext context) {
+        return new AwsIngestReportsDriver(context.instance(), clients);
+    }
+
+    @Override
+    public CompactionReportsDriver compactionReports(SystemTestContext context) {
+        return new AwsCompactionReportsDriver(context.instance(), clients.getDynamoDB());
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -43,8 +43,12 @@ import sleeper.systemtest.drivers.sourcedata.AwsGeneratedIngestSourceFilesDriver
 import sleeper.systemtest.drivers.sourcedata.AwsIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
+import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
+import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
+import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
-import sleeper.systemtest.dsl.ingest.SystemTestIngest;
+import sleeper.systemtest.dsl.ingest.IngestByQueueDriver;
+import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
@@ -61,6 +65,7 @@ import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
 import sleeper.systemtest.dsl.util.SystemTestDrivers;
+import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.nio.file.Path;
 
@@ -88,7 +93,7 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public IngestSourceFilesDriver sourceFilesDriver(SystemTestContext context) {
+    public IngestSourceFilesDriver sourceFiles(SystemTestContext context) {
         return new AwsIngestSourceFilesDriver(context.sourceFiles());
     }
 
@@ -98,15 +103,38 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestIngest ingest(SystemTestContext context) {
-        return new SystemTestIngest(context.instance(), context.sourceFiles(),
-                new AwsDirectIngestDriver(context.instance()),
-                new IngestByQueue(context.instance(), new AwsIngestByQueueDriver(clients)),
-                new DirectEmrServerlessDriver(context.instance(), clients),
-                new AwsIngestBatcherDriver(context.instance(), context.sourceFiles(), clients),
-                new AwsInvokeIngestTasksDriver(context.instance(), clients),
-                AwsWaitForJobs.forIngest(context.instance(), clients.getDynamoDB()),
-                AwsWaitForJobs.forBulkImport(context.instance(), clients.getDynamoDB()));
+    public DirectIngestDriver directIngest(SystemTestContext context) {
+        return new AwsDirectIngestDriver(context.instance());
+    }
+
+    @Override
+    public IngestByQueueDriver ingestByQueue(SystemTestContext context) {
+        return new AwsIngestByQueueDriver(clients);
+    }
+
+    @Override
+    public DirectBulkImportDriver directEmrServerless(SystemTestContext context) {
+        return new DirectEmrServerlessDriver(context.instance(), clients);
+    }
+
+    @Override
+    public IngestBatcherDriver ingestBatcher(SystemTestContext context) {
+        return new AwsIngestBatcherDriver(context.instance(), context.sourceFiles(), clients);
+    }
+
+    @Override
+    public InvokeIngestTasksDriver invokeIngestTasks(SystemTestContext context) {
+        return new AwsInvokeIngestTasksDriver(context.instance(), clients);
+    }
+
+    @Override
+    public WaitForJobs waitForIngest(SystemTestContext context) {
+        return AwsWaitForJobs.forIngest(context.instance(), clients.getDynamoDB());
+    }
+
+    @Override
+    public WaitForJobs waitForBulkImport(SystemTestContext context) {
+        return AwsWaitForJobs.forBulkImport(context.instance(), clients.getDynamoDB());
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -27,7 +27,7 @@ import sleeper.systemtest.drivers.ingest.AwsInvokeIngestTasksDriver;
 import sleeper.systemtest.drivers.ingest.AwsPurgeQueueDriver;
 import sleeper.systemtest.drivers.ingest.DirectEmrServerlessDriver;
 import sleeper.systemtest.drivers.instance.AwsSleeperInstanceDriver;
-import sleeper.systemtest.drivers.instance.AwsSleeperInstanceTablesDriver;
+import sleeper.systemtest.drivers.instance.AwsSleeperTablesDriver;
 import sleeper.systemtest.drivers.instance.AwsSystemTestDeploymentDriver;
 import sleeper.systemtest.drivers.metrics.AwsTableMetricsDriver;
 import sleeper.systemtest.drivers.partitioning.AwsPartitionReportDriver;
@@ -52,7 +52,7 @@ import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SleeperTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
@@ -84,8 +84,8 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SleeperInstanceTablesDriver tables(SystemTestParameters parameters) {
-        return new AwsSleeperInstanceTablesDriver(clients);
+    public SleeperTablesDriver tables(SystemTestParameters parameters) {
+        return new AwsSleeperTablesDriver(clients);
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -209,7 +209,7 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public PurgeQueueDriver purgeQueueDriver(SystemTestContext context) {
+    public PurgeQueueDriver purgeQueues(SystemTestContext context) {
         return new AwsPurgeQueueDriver(context.instance(), clients.getSqs());
     }
 }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -44,8 +44,11 @@ import sleeper.systemtest.drivers.sourcedata.AwsIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
-import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.instance.DeployedSleeperInstances;
+import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
+import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
 import sleeper.systemtest.dsl.partitioning.SystemTestPartitioning;
@@ -75,8 +78,11 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
         this.parameters = parameters;
         systemTestContext = new SystemTestDeploymentContext(
                 parameters, new AwsSystemTestDeploymentDriver(parameters, clients));
-        instanceContext = new SystemTestInstanceContext(parameters, systemTestContext,
-                new AwsSleeperInstanceDriver(parameters, clients), new AwsSleeperInstanceTablesDriver(clients));
+        SleeperInstanceDriver instanceDriver = new AwsSleeperInstanceDriver(parameters, clients);
+        SleeperInstanceTablesDriver tablesDriver = new AwsSleeperInstanceTablesDriver(clients);
+        DeployedSleeperInstances deployedInstances = new DeployedSleeperInstances(
+                parameters, systemTestContext, instanceDriver, tablesDriver);
+        instanceContext = new SystemTestInstanceContext(parameters, deployedInstances, instanceDriver, tablesDriver);
         sourceFilesContext = new IngestSourceFilesContext(systemTestContext, instanceContext);
         reportingContext = new ReportingContext(parameters);
     }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -44,7 +44,7 @@ import sleeper.systemtest.drivers.sourcedata.AwsIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
@@ -67,7 +67,7 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     private final SystemTestClients clients = new SystemTestClients();
     private final SystemTestParameters parameters;
     private final SystemTestDeploymentContext systemTestContext;
-    private final SleeperInstanceContext instanceContext;
+    private final SystemTestInstanceContext instanceContext;
     private final IngestSourceFilesContext sourceFilesContext;
     private final ReportingContext reportingContext;
 
@@ -75,7 +75,7 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
         this.parameters = parameters;
         systemTestContext = new SystemTestDeploymentContext(
                 parameters, new AwsSystemTestDeploymentDriver(parameters, clients));
-        instanceContext = new SleeperInstanceContext(parameters, systemTestContext,
+        instanceContext = new SystemTestInstanceContext(parameters, systemTestContext,
                 new AwsSleeperInstanceDriver(parameters, clients), new AwsSleeperInstanceTablesDriver(clients));
         sourceFilesContext = new IngestSourceFilesContext(systemTestContext, instanceContext);
         reportingContext = new ReportingContext(parameters);
@@ -87,7 +87,7 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SleeperInstanceContext getInstanceContext() {
+    public SystemTestInstanceContext getInstanceContext() {
         return instanceContext;
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -42,6 +42,7 @@ import sleeper.systemtest.drivers.query.SQSQueryDriver;
 import sleeper.systemtest.drivers.sourcedata.AwsGeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.drivers.sourcedata.AwsIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
@@ -67,7 +68,6 @@ import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 public class AwsSystemTestDrivers implements SystemTestDrivers {

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -54,7 +54,7 @@ import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
-import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
+import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
@@ -175,8 +175,8 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestMetrics metrics(SystemTestContext context) {
-        return new SystemTestMetrics(new AwsTableMetricsDriver(context.instance(), context.reporting(), clients));
+    public TableMetricsDriver tableMetrics(SystemTestContext context) {
+        return new AwsTableMetricsDriver(context.instance(), context.reporting(), clients);
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -62,7 +62,7 @@ import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
-import sleeper.systemtest.dsl.reporting.SystemTestReports;
+import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
 import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
@@ -179,16 +179,13 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public TableMetricsDriver tableMetrics(SystemTestContext context) {
-        return new AwsTableMetricsDriver(context.instance(), context.reporting(), clients);
+    public PartitionReportDriver partitionReports(SystemTestContext context) {
+        return new AwsPartitionReportDriver(context.instance());
     }
 
     @Override
-    public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
-        return SystemTestReports.builder(context.reporting(),
-                new AwsPartitionReportDriver(context.instance()),
-                new AwsIngestReportsDriver(context.instance(), clients),
-                new AwsCompactionReportsDriver(context.instance(), clients.getDynamoDB()));
+    public TableMetricsDriver tableMetrics(SystemTestContext context) {
+        return new AwsTableMetricsDriver(context.instance(), context.reporting(), clients);
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -42,7 +42,7 @@ import sleeper.systemtest.drivers.query.SQSQueryDriver;
 import sleeper.systemtest.drivers.sourcedata.AwsGeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.drivers.sourcedata.AwsIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
+import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
@@ -154,10 +154,13 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestCompaction compaction(SystemTestContext context) {
-        return new SystemTestCompaction(
-                new AwsCompactionDriver(context.instance(), clients),
-                AwsWaitForJobs.forCompaction(context.instance(), clients.getDynamoDB()));
+    public CompactionDriver compaction(SystemTestContext context) {
+        return new AwsCompactionDriver(context.instance(), clients);
+    }
+
+    @Override
+    public WaitForJobs waitForCompaction(SystemTestContext context) {
+        return AwsWaitForJobs.forCompaction(context.instance(), clients.getDynamoDB());
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -46,7 +46,9 @@ import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
+import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
+import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
@@ -55,7 +57,7 @@ import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
-import sleeper.systemtest.dsl.python.SystemTestPythonApi;
+import sleeper.systemtest.dsl.python.PythonQueryTypesDriver;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
@@ -67,8 +69,6 @@ import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
 import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
-
-import java.nio.file.Path;
 
 public class AwsSystemTestDrivers implements SystemTestDrivers {
     private final SystemTestClients clients = new SystemTestClients();
@@ -192,16 +192,23 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestPythonApi pythonApi(SystemTestContext context) {
-        Path pythonDir = context.parameters().getPythonDirectory();
-        return new SystemTestPythonApi(context.instance(),
-                new PythonIngestDriver(context.instance(), pythonDir),
-                new PythonIngestLocalFileDriver(context.instance(), pythonDir),
-                new PythonBulkImportDriver(context.instance(), pythonDir),
-                new AwsInvokeIngestTasksDriver(context.instance(), clients),
-                AwsWaitForJobs.forIngest(context.instance(), clients.getDynamoDB()),
-                AwsWaitForJobs.forBulkImport(context.instance(), clients.getDynamoDB()),
-                new PythonQueryDriver(context.instance(), pythonDir));
+    public IngestByAnyQueueDriver pythonIngest(SystemTestContext context) {
+        return new PythonIngestDriver(context.instance(), context.parameters().getPythonDirectory());
+    }
+
+    @Override
+    public IngestLocalFileByAnyQueueDriver pythonIngestLocalFile(SystemTestContext context) {
+        return new PythonIngestLocalFileDriver(context.instance(), context.parameters().getPythonDirectory());
+    }
+
+    @Override
+    public IngestByAnyQueueDriver pythonBulkImport(SystemTestContext context) {
+        return new PythonBulkImportDriver(context.instance(), context.parameters().getPythonDirectory());
+    }
+
+    @Override
+    public PythonQueryTypesDriver pythonQuery(SystemTestContext context) {
+        return new PythonQueryDriver(context.instance(), context.parameters().getPythonDirectory());
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsWaitForJobs.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsWaitForJobs.java
@@ -22,7 +22,7 @@ import sleeper.compaction.status.store.job.CompactionJobStatusStoreFactory;
 import sleeper.compaction.status.store.task.CompactionTaskStatusStoreFactory;
 import sleeper.ingest.status.store.job.IngestJobStatusStoreFactory;
 import sleeper.ingest.status.store.task.IngestTaskStatusStoreFactory;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 public class AwsWaitForJobs {
@@ -30,18 +30,18 @@ public class AwsWaitForJobs {
     private AwsWaitForJobs() {
     }
 
-    public static WaitForJobs forIngest(SleeperInstanceContext instance, AmazonDynamoDB dynamoDBClient) {
+    public static WaitForJobs forIngest(SystemTestInstanceContext instance, AmazonDynamoDB dynamoDBClient) {
         return WaitForJobs.forIngest(instance,
                 properties -> IngestJobStatusStoreFactory.getStatusStore(dynamoDBClient, properties),
                 properties -> IngestTaskStatusStoreFactory.getStatusStore(dynamoDBClient, properties));
     }
 
-    public static WaitForJobs forBulkImport(SleeperInstanceContext instance, AmazonDynamoDB dynamoDBClient) {
+    public static WaitForJobs forBulkImport(SystemTestInstanceContext instance, AmazonDynamoDB dynamoDBClient) {
         return WaitForJobs.forBulkImport(instance,
                 properties -> IngestJobStatusStoreFactory.getStatusStore(dynamoDBClient, properties));
     }
 
-    public static WaitForJobs forCompaction(SleeperInstanceContext instance, AmazonDynamoDB dynamoDBClient) {
+    public static WaitForJobs forCompaction(SystemTestInstanceContext instance, AmazonDynamoDB dynamoDBClient) {
         return WaitForJobs.forCompaction(instance,
                 properties -> CompactionJobStatusStoreFactory.getStatusStore(dynamoDBClient, properties),
                 properties -> CompactionTaskStatusStoreFactory.getStatusStore(dynamoDBClient, properties));

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/instance/AwsSleeperTablesDriverIT.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/instance/AwsSleeperTablesDriverIT.java
@@ -36,7 +36,7 @@ import sleeper.core.CommonTestConstants;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.statestore.dynamodb.DynamoDBStateStoreCreator;
 import sleeper.statestore.s3.S3StateStoreCreator;
-import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SleeperTablesDriver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -53,7 +53,7 @@ import static sleeper.ingest.testutils.LocalStackAwsV2ClientHelper.buildAwsV2Cli
 import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
-public class AwsSleeperInstanceTablesDriverIT {
+public class AwsSleeperTablesDriverIT {
 
     @Container
     public static LocalStackContainer localStackContainer = new LocalStackContainer(DockerImageName.parse(CommonTestConstants.LOCALSTACK_DOCKER_IMAGE))
@@ -63,7 +63,7 @@ public class AwsSleeperInstanceTablesDriverIT {
     private final S3Client s3v2 = buildAwsV2Client(localStackContainer, S3, S3Client.builder());
     private final AmazonDynamoDB dynamoDB = buildAwsV1Client(localStackContainer, DYNAMODB, AmazonDynamoDBClientBuilder.standard());
     private final Configuration hadoop = getHadoopConfiguration(localStackContainer);
-    private final SleeperInstanceTablesDriver driver = new AwsSleeperInstanceTablesDriver(s3, s3v2, dynamoDB, hadoop);
+    private final SleeperTablesDriver driver = new AwsSleeperTablesDriver(s3, s3v2, dynamoDB, hadoop);
     private final InstanceProperties instanceProperties = createTestInstanceProperties();
     private final TableProperties tableProperties = createTestTableProperties(instanceProperties, schemaWithKey("key"));
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -121,7 +121,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestCompaction compaction() {
-        return drivers.compaction(context);
+        return new SystemTestCompaction(context, drivers);
     }
 
     public SystemTestReporting reporting() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -38,7 +38,6 @@ import sleeper.systemtest.dsl.sourcedata.RecordNumbers;
 import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
 import sleeper.systemtest.dsl.sourcedata.SystemTestLocalFiles;
 import sleeper.systemtest.dsl.sourcedata.SystemTestSourceFiles;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 import java.nio.file.Path;
 import java.util.Map;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -113,7 +113,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestQuery query() {
-        return drivers.query(context);
+        return new SystemTestQuery(context, drivers);
     }
 
     public SystemTestQuery directQuery() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -137,7 +137,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestPythonApi pythonApi() {
-        return drivers.pythonApi(context);
+        return new SystemTestPythonApi(context, drivers);
     }
 
     public SystemTestLocalFiles localFiles(Path tempDir) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -125,7 +125,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestReporting reporting() {
-        return drivers.reporting(context);
+        return new SystemTestReporting(context, drivers);
     }
 
     public SystemTestMetrics metrics() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -100,12 +100,11 @@ public class SleeperSystemTest {
 
     public void connectToInstance(SystemTestInstanceConfiguration configuration) {
         instance.connectTo(configuration);
-        instance.resetPropertiesAndTables();
+        instance.addTablesFromDeployConfig();
     }
 
     public void connectToInstanceNoTables(SystemTestInstanceConfiguration configuration) {
         instance.connectTo(configuration);
-        instance.resetPropertiesAndDeleteTables();
     }
 
     public InstanceProperties instanceProperties() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -23,7 +23,7 @@ import sleeper.core.record.Record;
 import sleeper.core.schema.Schema;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceConfiguration;
 import sleeper.systemtest.dsl.instance.SystemTestOptionalStacks;
@@ -72,7 +72,7 @@ public class SleeperSystemTest {
     private final SystemTestParameters parameters;
     private final SystemTestDrivers drivers;
     private final SystemTestDeploymentContext systemTest;
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext sourceFiles;
     private final ReportingContext reportingContext;
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -75,10 +75,6 @@ public class SleeperSystemTest {
         this.context = context;
     }
 
-    public void reset() {
-        context.reset();
-    }
-
     public void connectToInstance(SystemTestInstanceConfiguration configuration) {
         context.instance().connectTo(configuration);
         context.instance().addDefaultTables();

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -129,7 +129,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestMetrics metrics() {
-        return drivers.metrics(context);
+        return new SystemTestMetrics(drivers.tableMetrics(context));
     }
 
     public SystemTestCluster systemTestCluster() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -97,7 +97,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestSourceFiles sourceFiles() {
-        return new SystemTestSourceFiles(context.instance(), context.sourceFiles(), drivers.sourceFilesDriver(context));
+        return new SystemTestSourceFiles(context.instance(), context.sourceFiles(), drivers.sourceFiles(context));
     }
 
     public SystemTestTableFiles tableFiles() {
@@ -109,7 +109,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestIngest ingest() {
-        return drivers.ingest(context);
+        return new SystemTestIngest(context, drivers);
     }
 
     public SystemTestQuery query() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -133,7 +133,7 @@ public class SleeperSystemTest {
     }
 
     public SystemTestCluster systemTestCluster() {
-        return drivers.systemTestCluster(context);
+        return new SystemTestCluster(context, drivers);
     }
 
     public SystemTestPythonApi pythonApi() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -23,9 +23,9 @@ import sleeper.core.record.Record;
 import sleeper.core.schema.Schema;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
-import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceConfiguration;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestOptionalStacks;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.instance.SystemTestTableFiles;
@@ -71,7 +71,7 @@ public class SleeperSystemTest {
 
     private final SystemTestParameters parameters;
     private final SystemTestDrivers drivers;
-    private final SystemTestDeploymentContext systemTest;
+    private final DeployedSystemTestResources systemTest;
     private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext sourceFiles;
     private final ReportingContext reportingContext;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -100,7 +100,7 @@ public class SleeperSystemTest {
 
     public void connectToInstance(SystemTestInstanceConfiguration configuration) {
         instance.connectTo(configuration);
-        instance.addTablesFromDeployConfig();
+        instance.addDefaultTables();
     }
 
     public void connectToInstanceNoTables(SystemTestInstanceConfiguration configuration) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
@@ -23,6 +23,12 @@ import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.reporting.ReportingContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
 
+/**
+ * This class tracks the context of a single running system test that will use the {@link SleeperSystemTest} DSL. This
+ * is anything that needs to be remembered from one step to the next, but not in between tests.
+ * <p>
+ * Note that deployed resources and Sleeper instances are managed separately, outside of any test.
+ */
 public class SystemTestContext {
     private final SystemTestParameters parameters;
     private final DeployedSystemTestResources systemTestResources;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
@@ -41,12 +41,6 @@ public class SystemTestContext {
         reporting = new ReportingContext(parameters);
     }
 
-    public void reset() {
-        sourceFiles.reset();
-        instance.disconnect();
-        reporting.startRecording();
-    }
-
     public SystemTestParameters parameters() {
         return parameters;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
@@ -26,33 +26,25 @@ import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 public class SystemTestContext {
     private final SystemTestParameters parameters;
-    private final SystemTestDrivers drivers;
-    private final DeployedSystemTestResources systemTest;
+    private final DeployedSystemTestResources systemTestResources;
     private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext sourceFiles;
     private final ReportingContext reporting;
 
-    public SystemTestContext(SystemTestParameters parameters, SystemTestDrivers drivers) {
+    public SystemTestContext(SystemTestParameters parameters, SystemTestDrivers drivers,
+                             DeployedSystemTestResources systemTestResources, DeployedSleeperInstances deployedInstances) {
         this.parameters = parameters;
-        this.drivers = drivers;
-        systemTest = new DeployedSystemTestResources(parameters, drivers.systemTestDeployment(parameters));
-        DeployedSleeperInstances deployedInstances = new DeployedSleeperInstances(parameters, systemTest, drivers.instance(parameters), drivers.tables(parameters));
-        instance = new SystemTestInstanceContext(parameters, deployedInstances, drivers.instance(parameters), drivers.tables(parameters));
-        sourceFiles = new IngestSourceFilesContext(systemTest, instance);
+        this.systemTestResources = systemTestResources;
+        instance = new SystemTestInstanceContext(parameters, deployedInstances,
+                drivers.instance(parameters), drivers.tables(parameters));
+        sourceFiles = new IngestSourceFilesContext(systemTestResources, instance);
         reporting = new ReportingContext(parameters);
     }
 
     public void reset() {
-        try {
-            systemTest.deployIfMissing();
-            systemTest.resetProperties();
-            sourceFiles.reset();
-            drivers.generatedSourceFiles(parameters, systemTest).emptyBucket();
-            instance.disconnect();
-            reporting.startRecording();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        sourceFiles.reset();
+        instance.disconnect();
+        reporting.startRecording();
     }
 
     public SystemTestParameters parameters() {
@@ -60,7 +52,7 @@ public class SystemTestContext {
     }
 
     public DeployedSystemTestResources systemTest() {
-        return systemTest;
+        return systemTestResources;
     }
 
     public SystemTestInstanceContext instance() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestContext.java
@@ -22,7 +22,6 @@ import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.reporting.ReportingContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 public class SystemTestContext {
     private final SystemTestParameters parameters;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestDrivers.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package sleeper.systemtest.dsl.util;
+package sleeper.systemtest.dsl;
 
-import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
@@ -41,6 +40,8 @@ import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
 import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
+import sleeper.systemtest.dsl.util.PurgeQueueDriver;
+import sleeper.systemtest.dsl.util.WaitForJobs;
 
 public interface SystemTestDrivers {
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestDrivers.java
@@ -106,5 +106,5 @@ public interface SystemTestDrivers {
 
     TableMetricsDriver tableMetrics(SystemTestContext context);
 
-    PurgeQueueDriver purgeQueueDriver(SystemTestContext context);
+    PurgeQueueDriver purgeQueues(SystemTestContext context);
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SystemTestDrivers.java
@@ -43,6 +43,13 @@ import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
+/**
+ * This is the interface that {@link SleeperSystemTest} will use to communicate with instances of Sleeper and the
+ * deployed environment.
+ * <p>
+ * Where {@link SleeperSystemTest} defines the language for interacting with Sleeper, the implementation is defined
+ * by drivers that can be accessed through an implementation of this interface.
+ */
 public interface SystemTestDrivers {
 
     SystemTestDeploymentDriver systemTestDeployment(SystemTestParameters parameters);

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
@@ -18,7 +18,7 @@ package sleeper.systemtest.dsl.compaction;
 
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.time.Duration;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
@@ -17,6 +17,8 @@
 package sleeper.systemtest.dsl.compaction;
 
 import sleeper.core.util.PollWithRetries;
+import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.time.Duration;
@@ -28,9 +30,9 @@ public class SystemTestCompaction {
     private final WaitForJobs waitForJobs;
     private List<String> lastJobIds;
 
-    public SystemTestCompaction(CompactionDriver driver, WaitForJobs waitForJobs) {
-        this.driver = driver;
-        this.waitForJobs = waitForJobs;
+    public SystemTestCompaction(SystemTestContext context, SystemTestDrivers drivers) {
+        this.driver = drivers.compaction(context);
+        this.waitForJobs = drivers.waitForCompaction(context);
     }
 
     public SystemTestCompaction createJobs() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/IngestByQueue.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/IngestByQueue.java
@@ -17,17 +17,17 @@
 package sleeper.systemtest.dsl.ingest;
 
 import sleeper.configuration.properties.instance.InstanceProperty;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class IngestByQueue {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestByQueueDriver driver;
 
-    public IngestByQueue(SleeperInstanceContext instance, IngestByQueueDriver driver) {
+    public IngestByQueue(SystemTestInstanceContext instance, IngestByQueueDriver driver) {
         this.instance = instance;
         this.driver = driver;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestDirectBulkImport.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestDirectBulkImport.java
@@ -18,7 +18,7 @@ package sleeper.systemtest.dsl.ingest;
 
 import sleeper.bulkimport.job.BulkImportJob;
 import sleeper.core.util.PollWithRetries;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
@@ -29,13 +29,13 @@ import java.util.stream.Stream;
 
 public class SystemTestDirectBulkImport {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext sourceFiles;
     private final DirectBulkImportDriver driver;
     private final WaitForJobs waitForJobs;
     private final List<String> sentJobIds = new ArrayList<>();
 
-    public SystemTestDirectBulkImport(SleeperInstanceContext instance,
+    public SystemTestDirectBulkImport(SystemTestInstanceContext instance,
                                       IngestSourceFilesContext sourceFiles,
                                       DirectBulkImportDriver driver,
                                       WaitForJobs waitForJobs) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestDirectIngest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestDirectIngest.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.dsl.ingest;
 
 import sleeper.core.record.Record;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -25,11 +25,11 @@ import java.util.stream.LongStream;
 
 public class SystemTestDirectIngest {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final DirectIngestDriver driver;
     private final Path tempDir;
 
-    public SystemTestDirectIngest(SleeperInstanceContext instance, DirectIngestDriver driver, Path tempDir) {
+    public SystemTestDirectIngest(SystemTestInstanceContext instance, DirectIngestDriver driver, Path tempDir) {
         this.instance = instance;
         this.driver = driver;
         this.tempDir = tempDir;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
@@ -73,7 +73,7 @@ public class SystemTestIngest {
     }
 
     private IngestByQueue ingestByQueue() {
-        return new IngestByQueue(context.instance(), drivers.ingestByQueue(context));
+        return drivers.ingestByQueue(context);
     }
 
     private InvokeIngestTasksDriver tasksDriver() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
@@ -16,64 +16,75 @@
 
 package sleeper.systemtest.dsl.ingest;
 
+import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
+import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.nio.file.Path;
 
 public class SystemTestIngest {
-    private final SystemTestInstanceContext instance;
-    private final IngestSourceFilesContext sourceFiles;
-    private final DirectIngestDriver directDriver;
-    private final IngestByQueue byQueue;
-    private final DirectBulkImportDriver directEmrServerlessDriver;
-    private final IngestBatcherDriver batcherDriver;
-    private final InvokeIngestTasksDriver tasksDriver;
-    private final WaitForJobs waitForIngest;
-    private final WaitForJobs waitForBulkImport;
+    private final SystemTestContext context;
+    private final SystemTestDrivers drivers;
 
-    public SystemTestIngest(SystemTestInstanceContext instance, IngestSourceFilesContext sourceFiles,
-                            DirectIngestDriver directDriver, IngestByQueue byQueue,
-                            DirectBulkImportDriver directEmrServerlessDriver, IngestBatcherDriver batcherDriver,
-                            InvokeIngestTasksDriver tasksDriver, WaitForJobs waitForIngest, WaitForJobs waitForBulkImport) {
-        this.instance = instance;
-        this.sourceFiles = sourceFiles;
-        this.directDriver = directDriver;
-        this.byQueue = byQueue;
-        this.directEmrServerlessDriver = directEmrServerlessDriver;
-        this.batcherDriver = batcherDriver;
-        this.tasksDriver = tasksDriver;
-        this.waitForIngest = waitForIngest;
-        this.waitForBulkImport = waitForBulkImport;
+    public SystemTestIngest(SystemTestContext context, SystemTestDrivers drivers) {
+        this.context = context;
+        this.drivers = drivers;
     }
 
     public SystemTestIngest setType(SystemTestIngestType type) {
-        type.applyTo(instance);
+        type.applyTo(instance());
         return this;
     }
 
     public SystemTestIngestBatcher batcher() {
-        return new SystemTestIngestBatcher(batcherDriver, tasksDriver, waitForIngest, waitForBulkImport);
+        return new SystemTestIngestBatcher(
+                drivers.ingestBatcher(context), tasksDriver(), waitForIngest(), waitForBulkImport());
     }
 
     public SystemTestDirectIngest direct(Path tempDir) {
-        return new SystemTestDirectIngest(instance, directDriver, tempDir);
+        return new SystemTestDirectIngest(instance(), drivers.directIngest(context), tempDir);
     }
 
     public SystemTestIngestToStateStore toStateStore() {
-        return new SystemTestIngestToStateStore(instance, sourceFiles);
+        return new SystemTestIngestToStateStore(instance(), sourceFiles());
     }
 
     public SystemTestIngestByQueue byQueue() {
-        return new SystemTestIngestByQueue(sourceFiles, byQueue, tasksDriver, waitForIngest);
+        return new SystemTestIngestByQueue(sourceFiles(), ingestByQueue(), tasksDriver(), waitForIngest());
     }
 
     public SystemTestIngestByQueue bulkImportByQueue() {
-        return new SystemTestIngestByQueue(sourceFiles, byQueue, tasksDriver, waitForBulkImport);
+        return new SystemTestIngestByQueue(sourceFiles(), ingestByQueue(), tasksDriver(), waitForBulkImport());
     }
 
     public SystemTestDirectBulkImport directEmrServerless() {
-        return new SystemTestDirectBulkImport(instance, sourceFiles, directEmrServerlessDriver, waitForBulkImport);
+        return new SystemTestDirectBulkImport(
+                instance(), sourceFiles(), drivers.directEmrServerless(context), waitForBulkImport());
+    }
+
+    private SystemTestInstanceContext instance() {
+        return context.instance();
+    }
+
+    private IngestSourceFilesContext sourceFiles() {
+        return context.sourceFiles();
+    }
+
+    private IngestByQueue ingestByQueue() {
+        return new IngestByQueue(context.instance(), drivers.ingestByQueue(context));
+    }
+
+    private InvokeIngestTasksDriver tasksDriver() {
+        return drivers.invokeIngestTasks(context);
+    }
+
+    private WaitForJobs waitForIngest() {
+        return drivers.waitForIngest(context);
+    }
+
+    private WaitForJobs waitForBulkImport() {
+        return drivers.waitForBulkImport(context);
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
@@ -16,14 +16,14 @@
 
 package sleeper.systemtest.dsl.ingest;
 
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.nio.file.Path;
 
 public class SystemTestIngest {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext sourceFiles;
     private final DirectIngestDriver directDriver;
     private final IngestByQueue byQueue;
@@ -33,7 +33,7 @@ public class SystemTestIngest {
     private final WaitForJobs waitForIngest;
     private final WaitForJobs waitForBulkImport;
 
-    public SystemTestIngest(SleeperInstanceContext instance, IngestSourceFilesContext sourceFiles,
+    public SystemTestIngest(SystemTestInstanceContext instance, IngestSourceFilesContext sourceFiles,
                             DirectIngestDriver directDriver, IngestByQueue byQueue,
                             DirectBulkImportDriver directEmrServerlessDriver, IngestBatcherDriver batcherDriver,
                             InvokeIngestTasksDriver tasksDriver, WaitForJobs waitForIngest, WaitForJobs waitForBulkImport) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngest.java
@@ -17,9 +17,9 @@
 package sleeper.systemtest.dsl.ingest;
 
 import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.nio.file.Path;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngestToStateStore.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngestToStateStore.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.dsl.ingest;
 
 import sleeper.core.statestore.FileReference;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
 
 import java.util.Map;
@@ -25,10 +25,10 @@ import java.util.stream.Collectors;
 
 public class SystemTestIngestToStateStore {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext ingestSource;
 
-    public SystemTestIngestToStateStore(SleeperInstanceContext instance, IngestSourceFilesContext ingestSource) {
+    public SystemTestIngestToStateStore(SystemTestInstanceContext instance, IngestSourceFilesContext ingestSource) {
         this.instance = instance;
         this.ingestSource = ingestSource;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngestType.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/SystemTestIngestType.java
@@ -16,7 +16,7 @@
 
 package sleeper.systemtest.dsl.ingest;
 
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.Map;
 
@@ -33,7 +33,7 @@ public class SystemTestIngestType {
         this.recordBatchType = recordBatchType;
     }
 
-    public void applyTo(SleeperInstanceContext instance) {
+    public void applyTo(SystemTestInstanceContext instance) {
         instance.updateTableProperties(Map.of(
                 INGEST_RECORD_BATCH_TYPE, recordBatchType,
                 INGEST_PARTITION_FILE_WRITER_TYPE, fileWriterType));

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
@@ -37,14 +37,14 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.CommonProperty.TAGS;
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_ROLE;
 
-public final class SystemTestDeployedInstance {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SystemTestDeployedInstance.class);
+public final class DeployedSleeperInstance {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeployedSleeperInstance.class);
 
     private final String instanceId;
     private final DeployInstanceConfiguration configuration;
     private final InstanceProperties instanceProperties = new InstanceProperties();
 
-    public SystemTestDeployedInstance(String instanceId, DeployInstanceConfiguration configuration) {
+    public DeployedSleeperInstance(String instanceId, DeployInstanceConfiguration configuration) {
         this.instanceId = instanceId;
         this.configuration = configuration;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
@@ -54,7 +54,7 @@ public final class DeployedSleeperInstance {
     }
 
     public void loadOrDeployIfNeeded(
-            SystemTestParameters parameters, SystemTestDeploymentContext systemTest,
+            SystemTestParameters parameters, DeployedSystemTestResources systemTest,
             SleeperInstanceDriver driver, SleeperInstanceTablesDriver tablesDriver) {
         boolean newInstance = driver.deployInstanceIfNotPresent(instanceId, configuration);
         driver.loadInstanceProperties(instanceProperties, instanceId);
@@ -78,7 +78,7 @@ public final class DeployedSleeperInstance {
     }
 
     private boolean isRedeployNeeded(SystemTestParameters parameters,
-                                     SystemTestDeploymentContext systemTest) {
+                                     DeployedSystemTestResources systemTest) {
         boolean redeployNeeded = false;
 
         Set<String> ingestRoles = new LinkedHashSet<>(instanceProperties.getList(INGEST_SOURCE_ROLE));

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
@@ -55,7 +55,7 @@ public final class DeployedSleeperInstance {
 
     public void loadOrDeployIfNeeded(
             SystemTestParameters parameters, DeployedSystemTestResources systemTest,
-            SleeperInstanceDriver driver, SleeperInstanceTablesDriver tablesDriver) {
+            SleeperInstanceDriver driver, SleeperTablesDriver tablesDriver) {
         boolean newInstance = driver.deployInstanceIfNotPresent(instanceId, configuration);
         driver.loadInstanceProperties(instanceProperties, instanceId);
         if (!newInstance && isRedeployNeeded(parameters, systemTest)) {
@@ -63,7 +63,7 @@ public final class DeployedSleeperInstance {
         }
     }
 
-    public void redeploy(SleeperInstanceDriver driver, SleeperInstanceTablesDriver tablesDriver) {
+    public void redeploy(SleeperInstanceDriver driver, SleeperTablesDriver tablesDriver) {
         driver.redeploy(instanceProperties, tablesDriver.createTablePropertiesProvider(instanceProperties)
                 .streamAllTables().collect(toUnmodifiableList()));
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
@@ -25,14 +25,14 @@ public class DeployedSleeperInstances {
     private final SystemTestParameters parameters;
     private final DeployedSystemTestResources systemTest;
     private final SleeperInstanceDriver instanceDriver;
-    private final SleeperInstanceTablesDriver tablesDriver;
+    private final SleeperTablesDriver tablesDriver;
     private final Map<String, Exception> failureById = new HashMap<>();
     private final Map<String, DeployedSleeperInstance> instanceByShortName = new HashMap<>();
 
     public DeployedSleeperInstances(SystemTestParameters parameters,
                                     DeployedSystemTestResources systemTest,
                                     SleeperInstanceDriver instanceDriver,
-                                    SleeperInstanceTablesDriver tablesDriver) {
+                                    SleeperTablesDriver tablesDriver) {
         this.parameters = parameters;
         this.systemTest = systemTest;
         this.instanceDriver = instanceDriver;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
@@ -27,7 +27,7 @@ class DeployedSleeperInstances {
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
     private final Map<String, Exception> failureById = new HashMap<>();
-    private final Map<String, DeployedSleeperInstance> instanceById = new HashMap<>();
+    private final Map<String, DeployedSleeperInstance> instanceByShortName = new HashMap<>();
 
     public DeployedSleeperInstances(SystemTestParameters parameters,
                                     SystemTestDeploymentContext systemTest,
@@ -40,15 +40,15 @@ class DeployedSleeperInstances {
     }
 
     public DeployedSleeperInstance connectTo(SystemTestInstanceConfiguration configuration) {
-        String instanceName = configuration.getShortName();
-        if (failureById.containsKey(instanceName)) {
-            throw new InstanceDidNotDeployException(instanceName, failureById.get(instanceName));
+        String instanceShortName = configuration.getShortName();
+        if (failureById.containsKey(instanceShortName)) {
+            throw new InstanceDidNotDeployException(instanceShortName, failureById.get(instanceShortName));
         }
         try {
-            return instanceById.computeIfAbsent(instanceName,
-                    id -> createInstanceIfMissingAndReset(id, configuration));
+            return instanceByShortName.computeIfAbsent(instanceShortName,
+                    name -> createInstanceIfMissingAndReset(name, configuration));
         } catch (RuntimeException e) {
-            failureById.put(instanceName, e);
+            failureById.put(instanceShortName, e);
             throw e;
         }
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
@@ -23,14 +23,14 @@ import java.util.Map;
 
 public class DeployedSleeperInstances {
     private final SystemTestParameters parameters;
-    private final SystemTestDeploymentContext systemTest;
+    private final DeployedSystemTestResources systemTest;
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
     private final Map<String, Exception> failureById = new HashMap<>();
     private final Map<String, DeployedSleeperInstance> instanceByShortName = new HashMap<>();
 
     public DeployedSleeperInstances(SystemTestParameters parameters,
-                                    SystemTestDeploymentContext systemTest,
+                                    DeployedSystemTestResources systemTest,
                                     SleeperInstanceDriver instanceDriver,
                                     SleeperInstanceTablesDriver tablesDriver) {
         this.parameters = parameters;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
@@ -21,7 +21,7 @@ import sleeper.configuration.deploy.DeployInstanceConfiguration;
 import java.util.HashMap;
 import java.util.Map;
 
-class DeployedSleeperInstances {
+public class DeployedSleeperInstances {
     private final SystemTestParameters parameters;
     private final SystemTestDeploymentContext systemTest;
     private final SleeperInstanceDriver instanceDriver;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstances.java
@@ -21,25 +21,25 @@ import sleeper.configuration.deploy.DeployInstanceConfiguration;
 import java.util.HashMap;
 import java.util.Map;
 
-class SystemTestDeployedInstances {
+class DeployedSleeperInstances {
     private final SystemTestParameters parameters;
     private final SystemTestDeploymentContext systemTest;
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
     private final Map<String, Exception> failureById = new HashMap<>();
-    private final Map<String, SystemTestDeployedInstance> instanceById = new HashMap<>();
+    private final Map<String, DeployedSleeperInstance> instanceById = new HashMap<>();
 
-    public SystemTestDeployedInstances(SystemTestParameters parameters,
-                                       SystemTestDeploymentContext systemTest,
-                                       SleeperInstanceDriver instanceDriver,
-                                       SleeperInstanceTablesDriver tablesDriver) {
+    public DeployedSleeperInstances(SystemTestParameters parameters,
+                                    SystemTestDeploymentContext systemTest,
+                                    SleeperInstanceDriver instanceDriver,
+                                    SleeperInstanceTablesDriver tablesDriver) {
         this.parameters = parameters;
         this.systemTest = systemTest;
         this.instanceDriver = instanceDriver;
         this.tablesDriver = tablesDriver;
     }
 
-    public SystemTestDeployedInstance connectTo(SystemTestInstanceConfiguration configuration) {
+    public DeployedSleeperInstance connectTo(SystemTestInstanceConfiguration configuration) {
         String instanceName = configuration.getShortName();
         if (failureById.containsKey(instanceName)) {
             throw new InstanceDidNotDeployException(instanceName, failureById.get(instanceName));
@@ -53,11 +53,11 @@ class SystemTestDeployedInstances {
         }
     }
 
-    private SystemTestDeployedInstance createInstanceIfMissingAndReset(String identifier, SystemTestInstanceConfiguration configuration) {
+    private DeployedSleeperInstance createInstanceIfMissingAndReset(String identifier, SystemTestInstanceConfiguration configuration) {
         String instanceId = parameters.buildInstanceId(identifier);
         OutputInstanceIds.addInstanceIdToOutput(instanceId, parameters);
         DeployInstanceConfiguration deployConfig = configuration.buildDeployConfig(parameters, systemTest);
-        SystemTestDeployedInstance instance = new SystemTestDeployedInstance(instanceId, deployConfig);
+        DeployedSleeperInstance instance = new DeployedSleeperInstance(instanceId, deployConfig);
         instance.loadOrDeployIfNeeded(parameters, systemTest, instanceDriver, tablesDriver);
         instance.resetInstanceProperties(instanceDriver);
         tablesDriver.deleteAllTables(instance.getInstanceProperties());

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperTablesForTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperTablesForTest.java
@@ -34,16 +34,16 @@ import java.util.stream.Stream;
 import static sleeper.configuration.properties.instance.CommonProperty.ID;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
-public final class SleeperInstanceTables {
+public final class DeployedSleeperTablesForTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SleeperInstanceTables.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeployedSleeperTablesForTest.class);
     private final InstanceProperties instanceProperties;
     private final Map<String, TableProperties> tableByName = new TreeMap<>();
     private final TablePropertiesProvider tablePropertiesProvider;
     private final StateStoreProvider stateStoreProvider;
     private TableProperties currentTable = null;
 
-    public SleeperInstanceTables(InstanceProperties instanceProperties, SleeperInstanceTablesDriver driver) {
+    public DeployedSleeperTablesForTest(InstanceProperties instanceProperties, SleeperInstanceTablesDriver driver) {
         this.instanceProperties = instanceProperties;
         tablePropertiesProvider = driver.createTablePropertiesProvider(instanceProperties);
         stateStoreProvider = driver.createStateStoreProvider(instanceProperties);

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperTablesForTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperTablesForTest.java
@@ -43,13 +43,13 @@ public final class DeployedSleeperTablesForTest {
     private final StateStoreProvider stateStoreProvider;
     private TableProperties currentTable = null;
 
-    public DeployedSleeperTablesForTest(InstanceProperties instanceProperties, SleeperInstanceTablesDriver driver) {
+    public DeployedSleeperTablesForTest(InstanceProperties instanceProperties, SleeperTablesDriver driver) {
         this.instanceProperties = instanceProperties;
         tablePropertiesProvider = driver.createTablePropertiesProvider(instanceProperties);
         stateStoreProvider = driver.createStateStoreProvider(instanceProperties);
     }
 
-    public void addTables(SleeperInstanceTablesDriver driver, List<TableProperties> tables) {
+    public void addTables(SleeperTablesDriver driver, List<TableProperties> tables) {
         LOGGER.info("Adding {} tables with instance ID: {}", tables.size(), instanceProperties.get(ID));
         tables.stream().parallel().forEach(tableProperties ->
                 driver.addTable(instanceProperties, tableProperties));

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSystemTestResources.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSystemTestResources.java
@@ -41,15 +41,15 @@ import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_RE
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_VPC_ID;
 import static sleeper.systemtest.configuration.SystemTestProperty.WRITE_DATA_ROLE_NAME;
 
-public class SystemTestDeploymentContext {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SystemTestDeploymentContext.class);
+public class DeployedSystemTestResources {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeployedSystemTestResources.class);
 
     private final SystemTestParameters parameters;
     private final SystemTestDeploymentDriver driver;
     private SystemTestStandaloneProperties properties;
     private InstanceDidNotDeployException failure;
 
-    public SystemTestDeploymentContext(SystemTestParameters parameters, SystemTestDeploymentDriver driver) {
+    public DeployedSystemTestResources(SystemTestParameters parameters, SystemTestDeploymentDriver driver) {
         this.parameters = parameters;
         this.driver = driver;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstance.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstance.java
@@ -26,18 +26,12 @@ import sleeper.configuration.properties.instance.SleeperProperty;
 import sleeper.configuration.properties.instance.UserDefinedInstanceProperty;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.SleeperVersion;
-import sleeper.core.record.Record;
-import sleeper.core.schema.Schema;
-import sleeper.systemtest.dsl.sourcedata.GenerateNumberedRecords;
-import sleeper.systemtest.dsl.sourcedata.GenerateNumberedValueOverrides;
 
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.VERSION;
@@ -52,7 +46,6 @@ public final class SleeperInstance {
     private final DeployInstanceConfiguration configuration;
     private final InstanceProperties instanceProperties = new InstanceProperties();
     private final SleeperInstanceTables tables;
-    private GenerateNumberedValueOverrides generatorOverrides = GenerateNumberedValueOverrides.none();
 
     public SleeperInstance(String instanceId, DeployInstanceConfiguration configuration) {
         this.instanceId = instanceId;
@@ -62,14 +55,6 @@ public final class SleeperInstance {
 
     public InstanceProperties getInstanceProperties() {
         return instanceProperties;
-    }
-
-    public Stream<Record> generateNumberedRecords(Schema schema, LongStream numbers) {
-        return GenerateNumberedRecords.from(schema, generatorOverrides, numbers);
-    }
-
-    public void setGeneratorOverrides(GenerateNumberedValueOverrides overrides) {
-        this.generatorOverrides = overrides;
     }
 
     public void loadOrDeployIfNeeded(

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
@@ -28,15 +28,18 @@ import sleeper.statestore.StateStoreProvider;
 import sleeper.systemtest.dsl.sourcedata.GenerateNumberedRecords;
 import sleeper.systemtest.dsl.sourcedata.GenerateNumberedValueOverrides;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
 public class SleeperInstanceContext {
@@ -44,7 +47,9 @@ public class SleeperInstanceContext {
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
     private final SystemTestDeployedInstances deployed;
+    private final Map<String, SleeperInstanceTables> tablesByInstanceName = new HashMap<>();
     private SleeperInstance currentInstance = null;
+    private SleeperInstanceTables currentTables = null;
     private GenerateNumberedValueOverrides generatorOverrides = null;
 
     public SleeperInstanceContext(SystemTestParameters parameters, SystemTestDeploymentContext systemTest,
@@ -57,19 +62,29 @@ public class SleeperInstanceContext {
 
     public void connectTo(SystemTestInstanceConfiguration configuration) {
         currentInstance = deployed.connectTo(configuration);
+        currentTables = tablesByInstanceName.computeIfAbsent(configuration.getShortName(),
+                name -> new SleeperInstanceTables(currentInstance.getInstanceProperties(), tablesDriver));
         generatorOverrides = GenerateNumberedValueOverrides.none();
     }
 
     public void disconnect() {
         currentInstance = null;
+        currentTables = null;
+        tablesByInstanceName.clear();
     }
 
-    public void addTablesFromDeployConfig() {
-        currentInstance.addTablesFromDeployConfig(tablesDriver);
+    public void addDefaultTables() {
+        currentTables.addTables(tablesDriver, currentInstance.getDefaultTables().stream()
+                .map(deployProperties -> {
+                    TableProperties properties = TableProperties.copyOf(deployProperties);
+                    properties.set(TABLE_NAME, UUID.randomUUID().toString());
+                    return properties;
+                })
+                .collect(toUnmodifiableList()));
     }
 
     public void redeploy() {
-        currentInstance.redeploy(instanceDriver);
+        currentInstance.redeploy(instanceDriver, tablesDriver);
     }
 
     public InstanceProperties getInstanceProperties() {
@@ -77,15 +92,15 @@ public class SleeperInstanceContext {
     }
 
     public TableProperties getTableProperties() {
-        return currentInstance.tables().getTableProperties();
+        return currentTables.getTableProperties();
     }
 
     public Optional<TableProperties> getTablePropertiesByName(String tableName) {
-        return currentInstance.tables().getTablePropertiesByName(tableName);
+        return currentTables.getTablePropertiesByName(tableName);
     }
 
     public TablePropertiesProvider getTablePropertiesProvider() {
-        return currentInstance.tables().getTablePropertiesProvider();
+        return currentTables.getTablePropertiesProvider();
     }
 
     public void updateTableProperties(Map<TableProperty, String> values) {
@@ -102,11 +117,11 @@ public class SleeperInstanceContext {
     }
 
     public StateStoreProvider getStateStoreProvider() {
-        return currentInstance.tables().getStateStoreProvider();
+        return currentTables.getStateStoreProvider();
     }
 
     public Stream<Record> generateNumberedRecords(LongStream numbers) {
-        return generateNumberedRecords(currentInstance.tables().getSchema(), numbers);
+        return generateNumberedRecords(currentTables.getSchema(), numbers);
     }
 
     public Stream<Record> generateNumberedRecords(Schema schema, LongStream numbers) {
@@ -135,7 +150,7 @@ public class SleeperInstanceContext {
 
     public void createTables(int numberOfTables, Schema schema, Map<TableProperty, String> setProperties) {
         InstanceProperties instanceProperties = getInstanceProperties();
-        currentInstance.tables().addTables(tablesDriver, IntStream.range(0, numberOfTables)
+        currentTables.addTables(tablesDriver, IntStream.range(0, numberOfTables)
                 .mapToObj(i -> {
                     TableProperties tableProperties = parameters.createTableProperties(instanceProperties, schema);
                     setProperties.forEach(tableProperties::set);
@@ -150,11 +165,11 @@ public class SleeperInstanceContext {
     }
 
     public Stream<String> streamTableNames() {
-        return currentInstance.tables().streamTableNames();
+        return currentTables.streamTableNames();
     }
 
     public Stream<TableProperties> streamTableProperties() {
-        return currentInstance.tables().streamTableProperties();
+        return currentTables.streamTableProperties();
     }
 
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
@@ -53,7 +53,7 @@ public class SleeperInstanceContext {
         this.parameters = parameters;
         this.instanceDriver = instanceDriver;
         this.tablesDriver = tablesDriver;
-        this.deployed = new SystemTestDeployedInstances(parameters, systemTest, instanceDriver);
+        this.deployed = new SystemTestDeployedInstances(parameters, systemTest, instanceDriver, tablesDriver);
     }
 
     public void connectTo(SystemTestInstanceConfiguration configuration) {
@@ -65,15 +65,8 @@ public class SleeperInstanceContext {
         currentInstance = null;
     }
 
-    public void resetPropertiesAndTables() {
-        currentInstance.resetInstanceProperties(instanceDriver);
-        currentInstance.deleteTables(tablesDriver);
+    public void addTablesFromDeployConfig() {
         currentInstance.addTablesFromDeployConfig(tablesDriver);
-    }
-
-    public void resetPropertiesAndDeleteTables() {
-        currentInstance.resetInstanceProperties(instanceDriver);
-        currentInstance.deleteTables(tablesDriver);
     }
 
     public void redeploy() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
@@ -26,6 +26,7 @@ import sleeper.core.schema.Schema;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.table.TableIdentity;
 import sleeper.statestore.StateStoreProvider;
+import sleeper.systemtest.dsl.sourcedata.GenerateNumberedRecords;
 import sleeper.systemtest.dsl.sourcedata.GenerateNumberedValueOverrides;
 
 import java.util.List;
@@ -44,19 +45,20 @@ public class SleeperInstanceContext {
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
     private final SystemTestDeployedInstances deployed;
-    private SleeperInstance currentInstance;
+    private SleeperInstance currentInstance = null;
+    private GenerateNumberedValueOverrides generatorOverrides = null;
 
     public SleeperInstanceContext(SystemTestParameters parameters, SystemTestDeploymentContext systemTest,
                                   SleeperInstanceDriver instanceDriver, SleeperInstanceTablesDriver tablesDriver) {
         this.parameters = parameters;
         this.instanceDriver = instanceDriver;
         this.tablesDriver = tablesDriver;
-        deployed = new SystemTestDeployedInstances(parameters, systemTest, instanceDriver);
+        this.deployed = new SystemTestDeployedInstances(parameters, systemTest, instanceDriver);
     }
 
     public void connectTo(SystemTestInstanceConfiguration configuration) {
         currentInstance = deployed.connectTo(configuration);
-        currentInstance.setGeneratorOverrides(GenerateNumberedValueOverrides.none());
+        generatorOverrides = GenerateNumberedValueOverrides.none();
     }
 
     public void disconnect() {
@@ -122,7 +124,7 @@ public class SleeperInstanceContext {
     }
 
     public Stream<Record> generateNumberedRecords(Schema schema, LongStream numbers) {
-        return currentInstance.generateNumberedRecords(schema, numbers);
+        return GenerateNumberedRecords.from(schema, generatorOverrides, numbers);
     }
 
     public StateStore getStateStore() {
@@ -142,7 +144,7 @@ public class SleeperInstanceContext {
     }
 
     public void setGeneratorOverrides(GenerateNumberedValueOverrides overrides) {
-        currentInstance.setGeneratorOverrides(overrides);
+        generatorOverrides = overrides;
     }
 
     public void createTables(int numberOfTables, Schema schema, Map<TableProperty, String> setProperties) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceContext.java
@@ -48,7 +48,7 @@ public class SleeperInstanceContext {
     private final SleeperInstanceTablesDriver tablesDriver;
     private final SystemTestDeployedInstances deployed;
     private final Map<String, SleeperInstanceTables> tablesByInstanceName = new HashMap<>();
-    private SleeperInstance currentInstance = null;
+    private SystemTestDeployedInstance currentInstance = null;
     private SleeperInstanceTables currentTables = null;
     private GenerateNumberedValueOverrides generatorOverrides = null;
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceTables.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperInstanceTables.java
@@ -39,22 +39,14 @@ public final class SleeperInstanceTables {
     private static final Logger LOGGER = LoggerFactory.getLogger(SleeperInstanceTables.class);
     private final InstanceProperties instanceProperties;
     private final Map<String, TableProperties> tableByName = new TreeMap<>();
-    private TablePropertiesProvider tablePropertiesProvider = null;
-    private StateStoreProvider stateStoreProvider = null;
+    private final TablePropertiesProvider tablePropertiesProvider;
+    private final StateStoreProvider stateStoreProvider;
     private TableProperties currentTable = null;
 
-    public SleeperInstanceTables(InstanceProperties instanceProperties) {
+    public SleeperInstanceTables(InstanceProperties instanceProperties, SleeperInstanceTablesDriver driver) {
         this.instanceProperties = instanceProperties;
-    }
-
-    public void deleteAll(SleeperInstanceTablesDriver driver) {
-        String instanceId = instanceProperties.get(ID);
-        LOGGER.info("Deleting all tables with instance ID: {}", instanceId);
-        driver.deleteAllTables(instanceProperties);
         tablePropertiesProvider = driver.createTablePropertiesProvider(instanceProperties);
         stateStoreProvider = driver.createStateStoreProvider(instanceProperties);
-        tableByName.clear();
-        currentTable = null;
     }
 
     public void addTables(SleeperInstanceTablesDriver driver, List<TableProperties> tables) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperTablesDriver.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SleeperTablesDriver.java
@@ -22,7 +22,7 @@ import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.table.TableIndex;
 import sleeper.statestore.StateStoreProvider;
 
-public interface SleeperInstanceTablesDriver {
+public interface SleeperTablesDriver {
 
     void saveTableProperties(InstanceProperties instanceProperties, TableProperties tableProperties);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstance.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstance.java
@@ -37,14 +37,14 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.CommonProperty.TAGS;
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_ROLE;
 
-public final class SleeperInstance {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SleeperInstance.class);
+public final class SystemTestDeployedInstance {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SystemTestDeployedInstance.class);
 
     private final String instanceId;
     private final DeployInstanceConfiguration configuration;
     private final InstanceProperties instanceProperties = new InstanceProperties();
 
-    public SleeperInstance(String instanceId, DeployInstanceConfiguration configuration) {
+    public SystemTestDeployedInstance(String instanceId, DeployInstanceConfiguration configuration) {
         this.instanceId = instanceId;
         this.configuration = configuration;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstances.java
@@ -27,7 +27,7 @@ class SystemTestDeployedInstances {
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
     private final Map<String, Exception> failureById = new HashMap<>();
-    private final Map<String, SleeperInstance> instanceById = new HashMap<>();
+    private final Map<String, SystemTestDeployedInstance> instanceById = new HashMap<>();
 
     public SystemTestDeployedInstances(SystemTestParameters parameters,
                                        SystemTestDeploymentContext systemTest,
@@ -39,7 +39,7 @@ class SystemTestDeployedInstances {
         this.tablesDriver = tablesDriver;
     }
 
-    public SleeperInstance connectTo(SystemTestInstanceConfiguration configuration) {
+    public SystemTestDeployedInstance connectTo(SystemTestInstanceConfiguration configuration) {
         String instanceName = configuration.getShortName();
         if (failureById.containsKey(instanceName)) {
             throw new InstanceDidNotDeployException(instanceName, failureById.get(instanceName));
@@ -53,11 +53,11 @@ class SystemTestDeployedInstances {
         }
     }
 
-    private SleeperInstance createInstanceIfMissingAndReset(String identifier, SystemTestInstanceConfiguration configuration) {
+    private SystemTestDeployedInstance createInstanceIfMissingAndReset(String identifier, SystemTestInstanceConfiguration configuration) {
         String instanceId = parameters.buildInstanceId(identifier);
         OutputInstanceIds.addInstanceIdToOutput(instanceId, parameters);
         DeployInstanceConfiguration deployConfig = configuration.buildDeployConfig(parameters, systemTest);
-        SleeperInstance instance = new SleeperInstance(instanceId, deployConfig);
+        SystemTestDeployedInstance instance = new SystemTestDeployedInstance(instanceId, deployConfig);
         instance.loadOrDeployIfNeeded(parameters, systemTest, instanceDriver, tablesDriver);
         instance.resetInstanceProperties(instanceDriver);
         tablesDriver.deleteAllTables(instance.getInstanceProperties());

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstances.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.dsl.instance;
+
+import sleeper.configuration.deploy.DeployInstanceConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class SystemTestDeployedInstances {
+    private final SystemTestParameters parameters;
+    private final SystemTestDeploymentContext systemTest;
+    private final SleeperInstanceDriver instanceDriver;
+    private final Map<String, Exception> failureById = new HashMap<>();
+    private final Map<String, SleeperInstance> instanceById = new HashMap<>();
+
+    public SystemTestDeployedInstances(SystemTestParameters parameters,
+                                       SystemTestDeploymentContext systemTest,
+                                       SleeperInstanceDriver instanceDriver) {
+        this.parameters = parameters;
+        this.systemTest = systemTest;
+        this.instanceDriver = instanceDriver;
+    }
+
+    public SleeperInstance connectTo(SystemTestInstanceConfiguration configuration) {
+        String identifier = configuration.getIdentifier();
+        if (failureById.containsKey(identifier)) {
+            throw new InstanceDidNotDeployException(identifier, failureById.get(identifier));
+        }
+        try {
+            return instanceById.computeIfAbsent(identifier,
+                    id -> createInstanceIfMissing(id, configuration));
+        } catch (RuntimeException e) {
+            failureById.put(identifier, e);
+            throw e;
+        }
+    }
+
+    private SleeperInstance createInstanceIfMissing(String identifier, SystemTestInstanceConfiguration configuration) {
+        String instanceId = parameters.buildInstanceId(identifier);
+        OutputInstanceIds.addInstanceIdToOutput(instanceId, parameters);
+        DeployInstanceConfiguration deployConfig = configuration.buildDeployConfig(parameters, systemTest);
+        SleeperInstance instance = new SleeperInstance(instanceId, deployConfig);
+        instance.loadOrDeployIfNeeded(parameters, systemTest, instanceDriver);
+        return instance;
+    }
+}

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstances.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestDeployedInstances.java
@@ -40,15 +40,15 @@ class SystemTestDeployedInstances {
     }
 
     public SleeperInstance connectTo(SystemTestInstanceConfiguration configuration) {
-        String identifier = configuration.getIdentifier();
-        if (failureById.containsKey(identifier)) {
-            throw new InstanceDidNotDeployException(identifier, failureById.get(identifier));
+        String instanceName = configuration.getShortName();
+        if (failureById.containsKey(instanceName)) {
+            throw new InstanceDidNotDeployException(instanceName, failureById.get(instanceName));
         }
         try {
-            return instanceById.computeIfAbsent(identifier,
+            return instanceById.computeIfAbsent(instanceName,
                     id -> createInstanceIfMissingAndReset(id, configuration));
         } catch (RuntimeException e) {
-            failureById.put(identifier, e);
+            failureById.put(instanceName, e);
             throw e;
         }
     }
@@ -58,9 +58,9 @@ class SystemTestDeployedInstances {
         OutputInstanceIds.addInstanceIdToOutput(instanceId, parameters);
         DeployInstanceConfiguration deployConfig = configuration.buildDeployConfig(parameters, systemTest);
         SleeperInstance instance = new SleeperInstance(instanceId, deployConfig);
-        instance.loadOrDeployIfNeeded(parameters, systemTest, instanceDriver);
+        instance.loadOrDeployIfNeeded(parameters, systemTest, instanceDriver, tablesDriver);
         instance.resetInstanceProperties(instanceDriver);
-        instance.deleteTables(tablesDriver);
+        tablesDriver.deleteAllTables(instance.getInstanceProperties());
         return instance;
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
@@ -25,12 +25,12 @@ import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SO
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_ROLE;
 
 public class SystemTestInstanceConfiguration {
-    private final String identifier;
+    private final String shortName;
     private final Supplier<DeployInstanceConfiguration> deployConfig;
     private final boolean useSystemTestIngestSourceBucket;
 
     private SystemTestInstanceConfiguration(Builder builder) {
-        identifier = builder.identifier;
+        shortName = builder.shortName;
         deployConfig = builder.deployConfig;
         useSystemTestIngestSourceBucket = builder.useSystemTestIngestSourceBucket;
     }
@@ -40,13 +40,13 @@ public class SystemTestInstanceConfiguration {
     }
 
     public static SystemTestInstanceConfiguration usingSystemTestDefaults(
-            String identifier, Supplier<DeployInstanceConfiguration> deployConfig) {
-        return builder().identifier(identifier).deployConfig(deployConfig).build();
+            String shortName, Supplier<DeployInstanceConfiguration> deployConfig) {
+        return builder().shortName(shortName).deployConfig(deployConfig).build();
     }
 
     public static SystemTestInstanceConfiguration noSourceBucket(
-            String identifier, Supplier<DeployInstanceConfiguration> deployConfig) {
-        return builder().identifier(identifier).deployConfig(deployConfig)
+            String shortName, Supplier<DeployInstanceConfiguration> deployConfig) {
+        return builder().shortName(shortName).deployConfig(deployConfig)
                 .useSystemTestIngestSourceBucket(false).build();
     }
 
@@ -67,8 +67,8 @@ public class SystemTestInstanceConfiguration {
         return configuration;
     }
 
-    public String getIdentifier() {
-        return identifier;
+    public String getShortName() {
+        return shortName;
     }
 
     public boolean shouldUseSystemTestIngestSourceBucket() {
@@ -78,13 +78,13 @@ public class SystemTestInstanceConfiguration {
     public static final class Builder {
         private Supplier<DeployInstanceConfiguration> deployConfig;
         private boolean useSystemTestIngestSourceBucket = true;
-        private String identifier;
+        private String shortName;
 
         private Builder() {
         }
 
-        public Builder identifier(String identifier) {
-            this.identifier = identifier;
+        public Builder shortName(String shortName) {
+            this.shortName = shortName;
             return this;
         }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
@@ -51,7 +51,7 @@ public class SystemTestInstanceConfiguration {
     }
 
     public DeployInstanceConfiguration buildDeployConfig(
-            SystemTestParameters parameters, SystemTestDeploymentContext systemTest) {
+            SystemTestParameters parameters, DeployedSystemTestResources systemTest) {
         DeployInstanceConfiguration configuration = buildDeployConfig(parameters);
         InstanceProperties properties = configuration.getInstanceProperties();
         if (shouldUseSystemTestIngestSourceBucket()) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -50,7 +50,7 @@ public class SystemTestInstanceContext {
     private final Map<String, DeployedSleeperTablesForTest> tablesByInstanceShortName = new HashMap<>();
     private DeployedSleeperInstance currentInstance = null;
     private DeployedSleeperTablesForTest currentTables = null;
-    private GenerateNumberedValueOverrides generatorOverrides = null;
+    private GenerateNumberedValueOverrides generatorOverrides = GenerateNumberedValueOverrides.none();
 
     public SystemTestInstanceContext(SystemTestParameters parameters,
                                      DeployedSleeperInstances deployedInstances,

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -46,7 +46,7 @@ public class SystemTestInstanceContext {
     private final SystemTestParameters parameters;
     private final DeployedSleeperInstances deployedInstances;
     private final SleeperInstanceDriver instanceDriver;
-    private final SleeperInstanceTablesDriver tablesDriver;
+    private final SleeperTablesDriver tablesDriver;
     private final Map<String, DeployedSleeperTablesForTest> tablesByInstanceShortName = new HashMap<>();
     private DeployedSleeperInstance currentInstance = null;
     private DeployedSleeperTablesForTest currentTables = null;
@@ -55,7 +55,7 @@ public class SystemTestInstanceContext {
     public SystemTestInstanceContext(SystemTestParameters parameters,
                                      DeployedSleeperInstances deployedInstances,
                                      SleeperInstanceDriver instanceDriver,
-                                     SleeperInstanceTablesDriver tablesDriver) {
+                                     SleeperTablesDriver tablesDriver) {
         this.parameters = parameters;
         this.deployedInstances = deployedInstances;
         this.instanceDriver = instanceDriver;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -66,7 +66,6 @@ public class SystemTestInstanceContext {
         currentInstance = deployedInstances.connectToAndReset(configuration);
         currentTables = tablesByInstanceShortName.computeIfAbsent(configuration.getShortName(),
                 name -> new DeployedSleeperTablesForTest(currentInstance.getInstanceProperties(), tablesDriver));
-        generatorOverrides = GenerateNumberedValueOverrides.none();
     }
 
     public void addDefaultTables() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -47,7 +47,7 @@ public class SystemTestInstanceContext {
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
     private final DeployedSleeperInstances deployed;
-    private final Map<String, DeployedSleeperTablesForTest> tablesByInstanceName = new HashMap<>();
+    private final Map<String, DeployedSleeperTablesForTest> tablesByInstanceShortName = new HashMap<>();
     private DeployedSleeperInstance currentInstance = null;
     private DeployedSleeperTablesForTest currentTables = null;
     private GenerateNumberedValueOverrides generatorOverrides = null;
@@ -62,7 +62,7 @@ public class SystemTestInstanceContext {
 
     public void connectTo(SystemTestInstanceConfiguration configuration) {
         currentInstance = deployed.connectTo(configuration);
-        currentTables = tablesByInstanceName.computeIfAbsent(configuration.getShortName(),
+        currentTables = tablesByInstanceShortName.computeIfAbsent(configuration.getShortName(),
                 name -> new DeployedSleeperTablesForTest(currentInstance.getInstanceProperties(), tablesDriver));
         generatorOverrides = GenerateNumberedValueOverrides.none();
     }
@@ -70,7 +70,7 @@ public class SystemTestInstanceContext {
     public void disconnect() {
         currentInstance = null;
         currentTables = null;
-        tablesByInstanceName.clear();
+        tablesByInstanceShortName.clear();
     }
 
     public void addDefaultTables() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -69,12 +69,6 @@ public class SystemTestInstanceContext {
         generatorOverrides = GenerateNumberedValueOverrides.none();
     }
 
-    public void disconnect() {
-        currentInstance = null;
-        currentTables = null;
-        tablesByInstanceShortName.clear();
-    }
-
     public void addDefaultTables() {
         currentTables.addTables(tablesDriver, currentInstance.getDefaultTables().stream()
                 .map(deployProperties -> {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -42,28 +42,28 @@ import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
-public class SleeperInstanceContext {
+public class SystemTestInstanceContext {
     private final SystemTestParameters parameters;
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
-    private final SystemTestDeployedInstances deployed;
-    private final Map<String, SleeperInstanceTables> tablesByInstanceName = new HashMap<>();
-    private SystemTestDeployedInstance currentInstance = null;
-    private SleeperInstanceTables currentTables = null;
+    private final DeployedSleeperInstances deployed;
+    private final Map<String, DeployedSleeperTablesForTest> tablesByInstanceName = new HashMap<>();
+    private DeployedSleeperInstance currentInstance = null;
+    private DeployedSleeperTablesForTest currentTables = null;
     private GenerateNumberedValueOverrides generatorOverrides = null;
 
-    public SleeperInstanceContext(SystemTestParameters parameters, SystemTestDeploymentContext systemTest,
-                                  SleeperInstanceDriver instanceDriver, SleeperInstanceTablesDriver tablesDriver) {
+    public SystemTestInstanceContext(SystemTestParameters parameters, SystemTestDeploymentContext systemTest,
+                                     SleeperInstanceDriver instanceDriver, SleeperInstanceTablesDriver tablesDriver) {
         this.parameters = parameters;
         this.instanceDriver = instanceDriver;
         this.tablesDriver = tablesDriver;
-        this.deployed = new SystemTestDeployedInstances(parameters, systemTest, instanceDriver, tablesDriver);
+        this.deployed = new DeployedSleeperInstances(parameters, systemTest, instanceDriver, tablesDriver);
     }
 
     public void connectTo(SystemTestInstanceConfiguration configuration) {
         currentInstance = deployed.connectTo(configuration);
         currentTables = tablesByInstanceName.computeIfAbsent(configuration.getShortName(),
-                name -> new SleeperInstanceTables(currentInstance.getInstanceProperties(), tablesDriver));
+                name -> new DeployedSleeperTablesForTest(currentInstance.getInstanceProperties(), tablesDriver));
         generatorOverrides = GenerateNumberedValueOverrides.none();
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -44,24 +44,26 @@ import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
 public class SystemTestInstanceContext {
     private final SystemTestParameters parameters;
+    private final DeployedSleeperInstances deployedInstances;
     private final SleeperInstanceDriver instanceDriver;
     private final SleeperInstanceTablesDriver tablesDriver;
-    private final DeployedSleeperInstances deployed;
     private final Map<String, DeployedSleeperTablesForTest> tablesByInstanceShortName = new HashMap<>();
     private DeployedSleeperInstance currentInstance = null;
     private DeployedSleeperTablesForTest currentTables = null;
     private GenerateNumberedValueOverrides generatorOverrides = null;
 
-    public SystemTestInstanceContext(SystemTestParameters parameters, SystemTestDeploymentContext systemTest,
-                                     SleeperInstanceDriver instanceDriver, SleeperInstanceTablesDriver tablesDriver) {
+    public SystemTestInstanceContext(SystemTestParameters parameters,
+                                     DeployedSleeperInstances deployedInstances,
+                                     SleeperInstanceDriver instanceDriver,
+                                     SleeperInstanceTablesDriver tablesDriver) {
         this.parameters = parameters;
+        this.deployedInstances = deployedInstances;
         this.instanceDriver = instanceDriver;
         this.tablesDriver = tablesDriver;
-        this.deployed = new DeployedSleeperInstances(parameters, systemTest, instanceDriver, tablesDriver);
     }
 
     public void connectTo(SystemTestInstanceConfiguration configuration) {
-        currentInstance = deployed.connectTo(configuration);
+        currentInstance = deployedInstances.connectTo(configuration);
         currentTables = tablesByInstanceShortName.computeIfAbsent(configuration.getShortName(),
                 name -> new DeployedSleeperTablesForTest(currentInstance.getInstanceProperties(), tablesDriver));
         generatorOverrides = GenerateNumberedValueOverrides.none();
@@ -83,7 +85,7 @@ public class SystemTestInstanceContext {
                 .collect(toUnmodifiableList()));
     }
 
-    public void redeploy() {
+    public void redeployCurrentInstance() {
         currentInstance.redeploy(instanceDriver, tablesDriver);
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -63,7 +63,7 @@ public class SystemTestInstanceContext {
     }
 
     public void connectTo(SystemTestInstanceConfiguration configuration) {
-        currentInstance = deployedInstances.connectTo(configuration);
+        currentInstance = deployedInstances.connectToAndReset(configuration);
         currentTables = tablesByInstanceShortName.computeIfAbsent(configuration.getShortName(),
                 name -> new DeployedSleeperTablesForTest(currentInstance.getInstanceProperties(), tablesDriver));
         generatorOverrides = GenerateNumberedValueOverrides.none();

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
@@ -30,9 +30,9 @@ import static sleeper.configuration.properties.instance.CommonProperty.OPTIONAL_
 public class SystemTestOptionalStacks {
     private static final Logger LOGGER = LoggerFactory.getLogger(SystemTestOptionalStacks.class);
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
 
-    public SystemTestOptionalStacks(SleeperInstanceContext instance) {
+    public SystemTestOptionalStacks(SystemTestInstanceContext instance) {
         this.instance = instance;
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
@@ -56,6 +56,6 @@ public class SystemTestOptionalStacks {
             return;
         }
         properties.set(OPTIONAL_STACKS, String.join(",", optionalStacks));
-        instance.redeploy();
+        instance.redeployCurrentInstance();
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestTableFiles.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestTableFiles.java
@@ -30,9 +30,9 @@ import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 
 public class SystemTestTableFiles {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
 
-    public SystemTestTableFiles(SleeperInstanceContext instance) {
+    public SystemTestTableFiles(SystemTestInstanceContext instance) {
         this.instance = instance;
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestTables.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestTables.java
@@ -25,9 +25,9 @@ import java.util.Map;
 
 public class SystemTestTables {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
 
-    public SystemTestTables(SleeperInstanceContext instance) {
+    public SystemTestTables(SystemTestInstanceContext instance) {
         this.instance = instance;
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/partitioning/SystemTestPartitioning.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/partitioning/SystemTestPartitioning.java
@@ -21,7 +21,7 @@ import sleeper.core.partition.Partition;
 import sleeper.core.partition.PartitionTree;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.List;
 import java.util.Map;
@@ -31,10 +31,10 @@ import static java.util.Map.entry;
 
 public class SystemTestPartitioning {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final PartitionSplittingDriver splittingDriver;
 
-    public SystemTestPartitioning(SleeperInstanceContext instance, PartitionSplittingDriver splittingDriver) {
+    public SystemTestPartitioning(SystemTestInstanceContext instance, PartitionSplittingDriver splittingDriver) {
         this.instance = instance;
         this.splittingDriver = splittingDriver;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonApi.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonApi.java
@@ -17,11 +17,11 @@
 package sleeper.systemtest.dsl.python;
 
 import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.nio.file.Path;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonApi.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonApi.java
@@ -19,13 +19,13 @@ package sleeper.systemtest.dsl.python;
 import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.nio.file.Path;
 
 public class SystemTestPythonApi {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestByAnyQueueDriver ingestDriver;
     private final IngestLocalFileByAnyQueueDriver ingestLocalFileDriver;
     private final IngestByAnyQueueDriver bulkImportDriver;
@@ -34,7 +34,7 @@ public class SystemTestPythonApi {
     private final WaitForJobs waitForBulkImport;
     private final PythonQueryTypesDriver queryDriver;
 
-    public SystemTestPythonApi(SleeperInstanceContext instance,
+    public SystemTestPythonApi(SystemTestInstanceContext instance,
                                IngestByAnyQueueDriver ingestDriver,
                                IngestLocalFileByAnyQueueDriver ingestLocalFileDriver,
                                IngestByAnyQueueDriver bulkImportDriver,

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonApi.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonApi.java
@@ -16,10 +16,12 @@
 
 package sleeper.systemtest.dsl.python;
 
+import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.nio.file.Path;
@@ -34,21 +36,15 @@ public class SystemTestPythonApi {
     private final WaitForJobs waitForBulkImport;
     private final PythonQueryTypesDriver queryDriver;
 
-    public SystemTestPythonApi(SystemTestInstanceContext instance,
-                               IngestByAnyQueueDriver ingestDriver,
-                               IngestLocalFileByAnyQueueDriver ingestLocalFileDriver,
-                               IngestByAnyQueueDriver bulkImportDriver,
-                               InvokeIngestTasksDriver tasksDriver,
-                               WaitForJobs waitForIngest, WaitForJobs waitForBulkImport,
-                               PythonQueryTypesDriver queryDriver) {
-        this.instance = instance;
-        this.ingestDriver = ingestDriver;
-        this.ingestLocalFileDriver = ingestLocalFileDriver;
-        this.bulkImportDriver = bulkImportDriver;
-        this.tasksDriver = tasksDriver;
-        this.waitForIngest = waitForIngest;
-        this.waitForBulkImport = waitForBulkImport;
-        this.queryDriver = queryDriver;
+    public SystemTestPythonApi(SystemTestContext context, SystemTestDrivers drivers) {
+        instance = context.instance();
+        ingestDriver = drivers.pythonIngest(context);
+        ingestLocalFileDriver = drivers.pythonIngestLocalFile(context);
+        bulkImportDriver = drivers.pythonBulkImport(context);
+        tasksDriver = drivers.invokeIngestTasks(context);
+        waitForIngest = drivers.waitForIngest(context);
+        waitForBulkImport = drivers.waitForBulkImport(context);
+        queryDriver = drivers.pythonQuery(context);
     }
 
     public SystemTestPythonIngest ingestByQueue() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonQuery.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/python/SystemTestPythonQuery.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.dsl.python;
 
 import sleeper.core.record.Record;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -26,12 +26,12 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 public class SystemTestPythonQuery {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final PythonQueryTypesDriver driver;
     private final Path outputDir;
     private final List<String> queryIds = new ArrayList<>();
 
-    public SystemTestPythonQuery(SleeperInstanceContext instance, PythonQueryTypesDriver driver, Path outputDir) {
+    public SystemTestPythonQuery(SystemTestInstanceContext instance, PythonQueryTypesDriver driver, Path outputDir) {
         this.instance = instance;
         this.driver = driver;
         this.outputDir = outputDir;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/QueryAllTablesInParallelDriver.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/QueryAllTablesInParallelDriver.java
@@ -18,7 +18,7 @@ package sleeper.systemtest.dsl.query;
 
 import sleeper.core.record.Record;
 import sleeper.query.model.Query;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.List;
 import java.util.Map;
@@ -29,10 +29,10 @@ import static java.util.Map.entry;
 
 public class QueryAllTablesInParallelDriver implements QueryAllTablesDriver {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final QueryDriver driver;
 
-    public QueryAllTablesInParallelDriver(SleeperInstanceContext instance, QueryDriver driver) {
+    public QueryAllTablesInParallelDriver(SystemTestInstanceContext instance, QueryDriver driver) {
         this.instance = instance;
         this.driver = driver;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/QueryAllTablesSendAndWaitDriver.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/QueryAllTablesSendAndWaitDriver.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import sleeper.core.record.Record;
 import sleeper.query.model.Query;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.List;
 import java.util.Map;
@@ -33,10 +33,10 @@ import static java.util.Map.entry;
 public class QueryAllTablesSendAndWaitDriver implements QueryAllTablesDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(QueryAllTablesSendAndWaitDriver.class);
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final QuerySendAndWaitDriver driver;
 
-    public QueryAllTablesSendAndWaitDriver(SleeperInstanceContext instance, QuerySendAndWaitDriver driver) {
+    public QueryAllTablesSendAndWaitDriver(SystemTestInstanceContext instance, QuerySendAndWaitDriver driver) {
         this.instance = instance;
         this.driver = driver;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/QueryCreator.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/QueryCreator.java
@@ -25,7 +25,7 @@ import sleeper.core.schema.Schema;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.query.model.Query;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.List;
 import java.util.UUID;
@@ -37,18 +37,18 @@ public class QueryCreator {
     private final String tableName;
     private final StateStore stateStore;
 
-    public QueryCreator(SleeperInstanceContext instance) {
+    public QueryCreator(SystemTestInstanceContext instance) {
         this(instance, instance.getTableProperties());
     }
 
-    private QueryCreator(SleeperInstanceContext instance, TableProperties tableProperties) {
+    private QueryCreator(SystemTestInstanceContext instance, TableProperties tableProperties) {
         this.schema = tableProperties.getSchema();
         this.tableName = tableProperties.get(TableProperty.TABLE_NAME);
         this.stateStore = instance.getStateStore(tableProperties);
     }
 
     public static List<Query> forAllTables(
-            SleeperInstanceContext instance, Function<QueryCreator, Query> queryFactory) {
+            SystemTestInstanceContext instance, Function<QueryCreator, Query> queryFactory) {
         return instance.streamTableProperties()
                 .map(properties -> new QueryCreator(instance, properties))
                 .map(queryFactory)

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/SystemTestQuery.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/SystemTestQuery.java
@@ -17,19 +17,19 @@
 package sleeper.systemtest.dsl.query;
 
 import sleeper.core.record.Record;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.List;
 import java.util.Map;
 
 public class SystemTestQuery {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final QueryAllTablesDriver byQueueDriver;
     private final QueryAllTablesDriver directDriver;
     private final ClearQueryResultsDriver clearResultsDriver;
     private QueryAllTablesDriver driver = null;
 
-    public SystemTestQuery(SleeperInstanceContext instance,
+    public SystemTestQuery(SystemTestInstanceContext instance,
                            QueryAllTablesDriver byQueueDriver,
                            QueryAllTablesDriver directDriver,
                            ClearQueryResultsDriver clearResultsDriver) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/SystemTestQuery.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/SystemTestQuery.java
@@ -18,7 +18,7 @@ package sleeper.systemtest.dsl.query;
 
 import sleeper.core.record.Record;
 import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 
 import java.util.List;
 import java.util.Map;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/SystemTestQuery.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/query/SystemTestQuery.java
@@ -17,35 +17,29 @@
 package sleeper.systemtest.dsl.query;
 
 import sleeper.core.record.Record;
-import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 import java.util.List;
 import java.util.Map;
 
 public class SystemTestQuery {
-    private final SystemTestInstanceContext instance;
-    private final QueryAllTablesDriver byQueueDriver;
-    private final QueryAllTablesDriver directDriver;
-    private final ClearQueryResultsDriver clearResultsDriver;
+    private final SystemTestContext context;
+    private final SystemTestDrivers drivers;
     private QueryAllTablesDriver driver = null;
 
-    public SystemTestQuery(SystemTestInstanceContext instance,
-                           QueryAllTablesDriver byQueueDriver,
-                           QueryAllTablesDriver directDriver,
-                           ClearQueryResultsDriver clearResultsDriver) {
-        this.instance = instance;
-        this.byQueueDriver = byQueueDriver;
-        this.directDriver = directDriver;
-        this.clearResultsDriver = clearResultsDriver;
+    public SystemTestQuery(SystemTestContext context, SystemTestDrivers drivers) {
+        this.context = context;
+        this.drivers = drivers;
     }
 
     public SystemTestQuery byQueue() {
-        driver = byQueueDriver;
+        driver = drivers.queryByQueue(context);
         return this;
     }
 
     public SystemTestQuery direct() {
-        driver = directDriver;
+        driver = drivers.directQuery(context);
         return this;
     }
 
@@ -62,10 +56,10 @@ public class SystemTestQuery {
     }
 
     public void emptyResultsBucket() {
-        clearResultsDriver.deleteAllQueryResults();
+        drivers.clearQueryResults(context).deleteAllQueryResults();
     }
 
     private QueryCreator queryCreator() {
-        return new QueryCreator(instance);
+        return new QueryCreator(context.instance());
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/ReportingContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/ReportingContext.java
@@ -39,7 +39,7 @@ public class ReportingContext {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReportingContext.class);
 
     private final Path outputDirectory;
-    private Instant recordingStartTime = Instant.now();
+    private final Instant recordingStartTime = Instant.now();
 
     public ReportingContext(SystemTestParameters parameters) {
         this(parameters.getOutputDirectory());
@@ -47,10 +47,6 @@ public class ReportingContext {
 
     public ReportingContext(Path outputDirectory) {
         this.outputDirectory = outputDirectory;
-    }
-
-    public void startRecording() {
-        recordingStartTime = Instant.now();
         LOGGER.info("Reports recording window started at {}", recordingStartTime);
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/SystemTestReporting.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/SystemTestReporting.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.dsl.reporting;
 
 import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 
 public class SystemTestReporting {
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/SystemTestReporting.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/SystemTestReporting.java
@@ -16,18 +16,19 @@
 
 package sleeper.systemtest.dsl.reporting;
 
+import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.util.SystemTestDrivers;
+
 public class SystemTestReporting {
 
     private final ReportingContext context;
     private final IngestReportsDriver ingestDriver;
     private final CompactionReportsDriver compactionDriver;
 
-    public SystemTestReporting(ReportingContext context,
-                               IngestReportsDriver ingestDriver,
-                               CompactionReportsDriver compactionDriver) {
-        this.context = context;
-        this.ingestDriver = ingestDriver;
-        this.compactionDriver = compactionDriver;
+    public SystemTestReporting(SystemTestContext context, SystemTestDrivers drivers) {
+        this.context = context.reporting();
+        this.ingestDriver = drivers.ingestReports(context);
+        this.compactionDriver = drivers.compactionReports(context);
     }
 
     public SystemTestIngestJobsReport ingestJobs() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/IngestSourceFilesContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/IngestSourceFilesContext.java
@@ -16,7 +16,7 @@
 
 package sleeper.systemtest.dsl.sourcedata;
 
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 
 import java.util.List;
@@ -31,11 +31,11 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 public class IngestSourceFilesContext {
 
     private final SystemTestDeploymentContext systemTest;
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final Map<String, String> filenameToPath = new TreeMap<>();
     private Supplier<String> bucketName;
 
-    public IngestSourceFilesContext(SystemTestDeploymentContext systemTest, SleeperInstanceContext instance) {
+    public IngestSourceFilesContext(SystemTestDeploymentContext systemTest, SystemTestInstanceContext instance) {
         this.systemTest = systemTest;
         this.instance = instance;
         bucketName = systemTest::getSystemTestBucketName;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/IngestSourceFilesContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/IngestSourceFilesContext.java
@@ -30,28 +30,17 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 
 public class IngestSourceFilesContext {
 
-    private final DeployedSystemTestResources systemTest;
     private final SystemTestInstanceContext instance;
     private final Map<String, String> filenameToPath = new TreeMap<>();
     private Supplier<String> bucketName;
 
     public IngestSourceFilesContext(DeployedSystemTestResources systemTest, SystemTestInstanceContext instance) {
-        this.systemTest = systemTest;
         this.instance = instance;
         bucketName = systemTest::getSystemTestBucketName;
     }
 
     public void useDataBucket() {
         bucketName = () -> instance.getInstanceProperties().get(DATA_BUCKET);
-    }
-
-    public void useSystemTestBucket() {
-        bucketName = systemTest::getSystemTestBucketName;
-    }
-
-    public void reset() {
-        useSystemTestBucket();
-        filenameToPath.clear();
     }
 
     public void wroteFile(String name, String path) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/IngestSourceFilesContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/IngestSourceFilesContext.java
@@ -16,8 +16,8 @@
 
 package sleeper.systemtest.dsl.sourcedata;
 
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 
 import java.util.List;
 import java.util.Map;
@@ -30,12 +30,12 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 
 public class IngestSourceFilesContext {
 
-    private final SystemTestDeploymentContext systemTest;
+    private final DeployedSystemTestResources systemTest;
     private final SystemTestInstanceContext instance;
     private final Map<String, String> filenameToPath = new TreeMap<>();
     private Supplier<String> bucketName;
 
-    public IngestSourceFilesContext(SystemTestDeploymentContext systemTest, SystemTestInstanceContext instance) {
+    public IngestSourceFilesContext(DeployedSystemTestResources systemTest, SystemTestInstanceContext instance) {
         this.systemTest = systemTest;
         this.instance = instance;
         bucketName = systemTest::getSystemTestBucketName;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestCluster.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestCluster.java
@@ -19,9 +19,11 @@ package sleeper.systemtest.dsl.sourcedata;
 import sleeper.configuration.properties.instance.InstanceProperty;
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
+import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
+import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.time.Duration;
@@ -41,20 +43,14 @@ public class SystemTestCluster {
     private GeneratedIngestSourceFiles lastGeneratedFiles = null;
     private final List<String> jobIds = new ArrayList<>();
 
-    public SystemTestCluster(DeployedSystemTestResources context,
-                             DataGenerationTasksDriver driver,
-                             IngestByQueue ingestByQueue,
-                             GeneratedIngestSourceFilesDriver sourceFiles,
-                             InvokeIngestTasksDriver tasksDriver,
-                             WaitForJobs waitForIngestJobs,
-                             WaitForJobs waitForBulkImportJobs) {
-        this.context = context;
-        this.driver = driver;
-        this.ingestByQueue = ingestByQueue;
-        this.sourceFiles = sourceFiles;
-        this.tasksDriver = tasksDriver;
-        this.waitForIngestJobs = waitForIngestJobs;
-        this.waitForBulkImportJobs = waitForBulkImportJobs;
+    public SystemTestCluster(SystemTestContext context, SystemTestDrivers drivers) {
+        this.context = context.systemTest();
+        driver = drivers.dataGenerationTasks(context);
+        ingestByQueue = drivers.ingestByQueue(context);
+        sourceFiles = drivers.generatedSourceFiles(context.parameters(), context.systemTest());
+        tasksDriver = drivers.invokeIngestTasks(context);
+        waitForIngestJobs = drivers.waitForIngest(context);
+        waitForBulkImportJobs = drivers.waitForBulkImport(context);
     }
 
     public SystemTestCluster updateProperties(Consumer<SystemTestStandaloneProperties> config) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestCluster.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestCluster.java
@@ -20,10 +20,10 @@ import sleeper.configuration.properties.instance.InstanceProperty;
 import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
 import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.time.Duration;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestCluster.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestCluster.java
@@ -21,7 +21,7 @@ import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.util.WaitForJobs;
 
 import java.time.Duration;
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
 
 public class SystemTestCluster {
 
-    private final SystemTestDeploymentContext context;
+    private final DeployedSystemTestResources context;
     private final DataGenerationTasksDriver driver;
     private final IngestByQueue ingestByQueue;
     private final GeneratedIngestSourceFilesDriver sourceFiles;
@@ -41,7 +41,7 @@ public class SystemTestCluster {
     private GeneratedIngestSourceFiles lastGeneratedFiles = null;
     private final List<String> jobIds = new ArrayList<>();
 
-    public SystemTestCluster(SystemTestDeploymentContext context,
+    public SystemTestCluster(DeployedSystemTestResources context,
                              DataGenerationTasksDriver driver,
                              IngestByQueue ingestByQueue,
                              GeneratedIngestSourceFilesDriver sourceFiles,

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestLocalFiles.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestLocalFiles.java
@@ -22,7 +22,7 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.record.Record;
 import sleeper.io.parquet.record.ParquetRecordWriterFactory;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -32,10 +32,10 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 public class SystemTestLocalFiles {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final Path tempDir;
 
-    public SystemTestLocalFiles(SleeperInstanceContext instance, Path tempDir) {
+    public SystemTestLocalFiles(SystemTestInstanceContext instance, Path tempDir) {
         this.instance = instance;
         this.tempDir = tempDir;
     }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestSourceFiles.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/sourcedata/SystemTestSourceFiles.java
@@ -20,18 +20,18 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.record.Record;
 import sleeper.core.schema.Schema;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 public class SystemTestSourceFiles {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final IngestSourceFilesContext context;
     private final IngestSourceFilesDriver driver;
     private boolean writeSketches = false;
 
-    public SystemTestSourceFiles(SleeperInstanceContext instance,
+    public SystemTestSourceFiles(SystemTestInstanceContext instance,
                                  IngestSourceFilesContext context,
                                  IngestSourceFilesDriver driver) {
         this.instance = instance;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -37,7 +37,7 @@ import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
-import sleeper.systemtest.dsl.reporting.SystemTestReports;
+import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
 import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
@@ -94,9 +94,9 @@ public interface SystemTestDrivers {
 
     CompactionReportsDriver compactionReports(SystemTestContext context);
 
-    TableMetricsDriver tableMetrics(SystemTestContext context);
+    PartitionReportDriver partitionReports(SystemTestContext context);
 
-    SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context);
+    TableMetricsDriver tableMetrics(SystemTestContext context);
 
     PurgeQueueDriver purgeQueueDriver(SystemTestContext context);
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -27,7 +27,7 @@ import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SleeperTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
@@ -48,7 +48,7 @@ public interface SystemTestDrivers {
 
     SleeperInstanceDriver instance(SystemTestParameters parameters);
 
-    SleeperInstanceTablesDriver tables(SystemTestParameters parameters);
+    SleeperTablesDriver tables(SystemTestParameters parameters);
 
     GeneratedIngestSourceFilesDriver generatedSourceFiles(SystemTestParameters parameters, DeployedSystemTestResources systemTest);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -21,7 +21,7 @@ import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
-import sleeper.systemtest.dsl.ingest.IngestByQueueDriver;
+import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
@@ -36,9 +36,9 @@ import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
+import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
-import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
 
 public interface SystemTestDrivers {
 
@@ -56,7 +56,7 @@ public interface SystemTestDrivers {
 
     DirectIngestDriver directIngest(SystemTestContext context);
 
-    IngestByQueueDriver ingestByQueue(SystemTestContext context);
+    IngestByQueue ingestByQueue(SystemTestContext context);
 
     DirectBulkImportDriver directEmrServerless(SystemTestContext context);
 
@@ -78,6 +78,8 @@ public interface SystemTestDrivers {
 
     WaitForJobs waitForCompaction(SystemTestContext context);
 
+    DataGenerationTasksDriver dataGenerationTasks(SystemTestContext context);
+
     IngestReportsDriver ingestReports(SystemTestContext context);
 
     CompactionReportsDriver compactionReports(SystemTestContext context);
@@ -85,8 +87,6 @@ public interface SystemTestDrivers {
     TableMetricsDriver tableMetrics(SystemTestContext context);
 
     SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context);
-
-    SystemTestCluster systemTestCluster(SystemTestContext context);
 
     SystemTestPythonApi pythonApi(SystemTestContext context);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -33,7 +33,8 @@ import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
-import sleeper.systemtest.dsl.reporting.SystemTestReporting;
+import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
+import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
@@ -77,7 +78,9 @@ public interface SystemTestDrivers {
 
     WaitForJobs waitForCompaction(SystemTestContext context);
 
-    SystemTestReporting reporting(SystemTestContext context);
+    IngestReportsDriver ingestReports(SystemTestContext context);
+
+    CompactionReportsDriver compactionReports(SystemTestContext context);
 
     SystemTestMetrics metrics(SystemTestContext context);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -16,53 +16,53 @@
 
 package sleeper.systemtest.dsl.util;
 
+import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
-import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
+import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
+import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
-import sleeper.systemtest.dsl.partitioning.SystemTestPartitioning;
+import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.SystemTestQuery;
-import sleeper.systemtest.dsl.reporting.ReportingContext;
 import sleeper.systemtest.dsl.reporting.SystemTestReporting;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
-import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesContext;
+import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
-import sleeper.systemtest.dsl.sourcedata.SystemTestSourceFiles;
 
 public interface SystemTestDrivers {
 
-    DeployedSystemTestResources getSystemTestContext();
+    SystemTestDeploymentDriver systemTestDeployment(SystemTestParameters parameters);
 
-    SystemTestInstanceContext getInstanceContext();
+    SleeperInstanceDriver instance(SystemTestParameters parameters);
 
-    IngestSourceFilesContext getSourceFilesContext();
+    SleeperInstanceTablesDriver tables(SystemTestParameters parameters);
 
-    ReportingContext getReportingContext();
+    GeneratedIngestSourceFilesDriver generatedSourceFiles(SystemTestParameters parameters, DeployedSystemTestResources systemTest);
 
-    GeneratedIngestSourceFilesDriver generatedSourceFilesDriver();
+    IngestSourceFilesDriver sourceFilesDriver(SystemTestContext context);
 
-    SystemTestSourceFiles sourceFiles();
+    PartitionSplittingDriver partitionSplitting(SystemTestContext context);
 
-    SystemTestPartitioning partitioning();
+    SystemTestIngest ingest(SystemTestContext context);
 
-    SystemTestIngest ingest();
+    SystemTestQuery query(SystemTestContext context);
 
-    SystemTestQuery query();
+    SystemTestCompaction compaction(SystemTestContext context);
 
-    SystemTestCompaction compaction();
+    SystemTestReporting reporting(SystemTestContext context);
 
-    SystemTestReporting reporting();
+    SystemTestMetrics metrics(SystemTestContext context);
 
-    SystemTestMetrics metrics();
+    SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context);
 
-    SystemTestReports.SystemTestBuilder reportsForExtension();
+    SystemTestCluster systemTestCluster(SystemTestContext context);
 
-    SystemTestCluster systemTestCluster();
+    SystemTestPythonApi pythonApi(SystemTestContext context);
 
-    SystemTestPythonApi pythonApi();
-
-    PurgeQueueDriver purgeQueueDriver();
+    PurgeQueueDriver purgeQueueDriver(SystemTestContext context);
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -18,7 +18,11 @@ package sleeper.systemtest.dsl.util;
 
 import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
-import sleeper.systemtest.dsl.ingest.SystemTestIngest;
+import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
+import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
+import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
+import sleeper.systemtest.dsl.ingest.IngestByQueueDriver;
+import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
@@ -44,11 +48,23 @@ public interface SystemTestDrivers {
 
     GeneratedIngestSourceFilesDriver generatedSourceFiles(SystemTestParameters parameters, DeployedSystemTestResources systemTest);
 
-    IngestSourceFilesDriver sourceFilesDriver(SystemTestContext context);
+    IngestSourceFilesDriver sourceFiles(SystemTestContext context);
 
     PartitionSplittingDriver partitionSplitting(SystemTestContext context);
 
-    SystemTestIngest ingest(SystemTestContext context);
+    DirectIngestDriver directIngest(SystemTestContext context);
+
+    IngestByQueueDriver ingestByQueue(SystemTestContext context);
+
+    DirectBulkImportDriver directEmrServerless(SystemTestContext context);
+
+    IngestBatcherDriver ingestBatcher(SystemTestContext context);
+
+    InvokeIngestTasksDriver invokeIngestTasks(SystemTestContext context);
+
+    WaitForJobs waitForIngest(SystemTestContext context);
+
+    WaitForJobs waitForBulkImport(SystemTestContext context);
 
     SystemTestQuery query(SystemTestContext context);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -28,7 +28,7 @@ import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
-import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
+import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
@@ -82,7 +82,7 @@ public interface SystemTestDrivers {
 
     CompactionReportsDriver compactionReports(SystemTestContext context);
 
-    SystemTestMetrics metrics(SystemTestContext context);
+    TableMetricsDriver tableMetrics(SystemTestContext context);
 
     SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -18,7 +18,7 @@ package sleeper.systemtest.dsl.util;
 
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
 import sleeper.systemtest.dsl.partitioning.SystemTestPartitioning;
@@ -36,7 +36,7 @@ public interface SystemTestDrivers {
 
     SystemTestDeploymentContext getSystemTestContext();
 
-    SleeperInstanceContext getInstanceContext();
+    SystemTestInstanceContext getInstanceContext();
 
     IngestSourceFilesContext getSourceFilesContext();
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.dsl.util;
 
 import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
+import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
@@ -73,7 +73,9 @@ public interface SystemTestDrivers {
 
     ClearQueryResultsDriver clearQueryResults(SystemTestContext context);
 
-    SystemTestCompaction compaction(SystemTestContext context);
+    CompactionDriver compaction(SystemTestContext context);
+
+    WaitForJobs waitForCompaction(SystemTestContext context);
 
     SystemTestReporting reporting(SystemTestContext context);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -21,7 +21,9 @@ import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
+import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
+import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
@@ -30,7 +32,7 @@ import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
-import sleeper.systemtest.dsl.python.SystemTestPythonApi;
+import sleeper.systemtest.dsl.python.PythonQueryTypesDriver;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
@@ -80,6 +82,14 @@ public interface SystemTestDrivers {
 
     DataGenerationTasksDriver dataGenerationTasks(SystemTestContext context);
 
+    IngestByAnyQueueDriver pythonIngest(SystemTestContext context);
+
+    IngestLocalFileByAnyQueueDriver pythonIngestLocalFile(SystemTestContext context);
+
+    IngestByAnyQueueDriver pythonBulkImport(SystemTestContext context);
+
+    PythonQueryTypesDriver pythonQuery(SystemTestContext context);
+
     IngestReportsDriver ingestReports(SystemTestContext context);
 
     CompactionReportsDriver compactionReports(SystemTestContext context);
@@ -87,8 +97,6 @@ public interface SystemTestDrivers {
     TableMetricsDriver tableMetrics(SystemTestContext context);
 
     SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context);
-
-    SystemTestPythonApi pythonApi(SystemTestContext context);
 
     PurgeQueueDriver purgeQueueDriver(SystemTestContext context);
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -31,7 +31,8 @@ import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
-import sleeper.systemtest.dsl.query.SystemTestQuery;
+import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
+import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReporting;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
@@ -66,7 +67,11 @@ public interface SystemTestDrivers {
 
     WaitForJobs waitForBulkImport(SystemTestContext context);
 
-    SystemTestQuery query(SystemTestContext context);
+    QueryAllTablesDriver queryByQueue(SystemTestContext context);
+
+    QueryAllTablesDriver directQuery(SystemTestContext context);
+
+    ClearQueryResultsDriver clearQueryResults(SystemTestContext context);
 
     SystemTestCompaction compaction(SystemTestContext context);
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDrivers.java
@@ -18,8 +18,8 @@ package sleeper.systemtest.dsl.util;
 
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
 import sleeper.systemtest.dsl.partitioning.SystemTestPartitioning;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
@@ -34,7 +34,7 @@ import sleeper.systemtest.dsl.sourcedata.SystemTestSourceFiles;
 
 public interface SystemTestDrivers {
 
-    SystemTestDeploymentContext getSystemTestContext();
+    DeployedSystemTestResources getSystemTestContext();
 
     SystemTestInstanceContext getInstanceContext();
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
@@ -32,7 +32,7 @@ import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
-import sleeper.systemtest.dsl.reporting.SystemTestReports;
+import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
 import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 
@@ -144,12 +144,12 @@ public abstract class SystemTestDriversBase implements SystemTestDrivers {
     }
 
     @Override
-    public TableMetricsDriver tableMetrics(SystemTestContext context) {
+    public PartitionReportDriver partitionReports(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
+    public TableMetricsDriver tableMetrics(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
@@ -17,6 +17,7 @@
 package sleeper.systemtest.dsl.util;
 
 import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
@@ -42,7 +42,7 @@ import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 
-public class SystemTestDriversUnimplemented implements SystemTestDrivers {
+public abstract class SystemTestDriversBase implements SystemTestDrivers {
     @Override
     public SystemTestDeploymentDriver systemTestDeployment(SystemTestParameters parameters) {
         throw new UnsupportedOperationException();

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversBase.java
@@ -25,11 +25,6 @@ import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
-import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
-import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
-import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.PythonQueryTypesDriver;
@@ -39,29 +34,9 @@ import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
-import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 
 public abstract class SystemTestDriversBase implements SystemTestDrivers {
-    @Override
-    public SystemTestDeploymentDriver systemTestDeployment(SystemTestParameters parameters) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SleeperInstanceDriver instance(SystemTestParameters parameters) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SleeperInstanceTablesDriver tables(SystemTestParameters parameters) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public GeneratedIngestSourceFilesDriver generatedSourceFiles(SystemTestParameters parameters, DeployedSystemTestResources systemTest) {
-        throw new UnsupportedOperationException();
-    }
 
     @Override
     public IngestSourceFilesDriver sourceFiles(SystemTestContext context) {
@@ -175,11 +150,6 @@ public abstract class SystemTestDriversBase implements SystemTestDrivers {
 
     @Override
     public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public PurgeQueueDriver purgeQueueDriver(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
@@ -21,7 +21,9 @@ import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
+import sleeper.systemtest.dsl.ingest.IngestByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.IngestByQueue;
+import sleeper.systemtest.dsl.ingest.IngestLocalFileByAnyQueueDriver;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
@@ -30,7 +32,7 @@ import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
-import sleeper.systemtest.dsl.python.SystemTestPythonApi;
+import sleeper.systemtest.dsl.python.PythonQueryTypesDriver;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
@@ -137,6 +139,26 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     }
 
     @Override
+    public IngestByAnyQueueDriver pythonIngest(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IngestLocalFileByAnyQueueDriver pythonIngestLocalFile(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IngestByAnyQueueDriver pythonBulkImport(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PythonQueryTypesDriver pythonQuery(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public IngestReportsDriver ingestReports(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
@@ -153,11 +175,6 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
 
     @Override
     public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestPythonApi pythonApi(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
@@ -33,7 +33,8 @@ import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
-import sleeper.systemtest.dsl.reporting.SystemTestReporting;
+import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
+import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
@@ -131,7 +132,12 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestReporting reporting(SystemTestContext context) {
+    public IngestReportsDriver ingestReports(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompactionReportsDriver compactionReports(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.systemtest.dsl.util;
+
+import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
+import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
+import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
+import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
+import sleeper.systemtest.dsl.ingest.IngestByQueueDriver;
+import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
+import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
+import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
+import sleeper.systemtest.dsl.instance.SystemTestParameters;
+import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
+import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
+import sleeper.systemtest.dsl.python.SystemTestPythonApi;
+import sleeper.systemtest.dsl.query.SystemTestQuery;
+import sleeper.systemtest.dsl.reporting.SystemTestReporting;
+import sleeper.systemtest.dsl.reporting.SystemTestReports;
+import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
+import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
+import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
+
+public class SystemTestDriversUnimplemented implements SystemTestDrivers {
+    @Override
+    public SystemTestDeploymentDriver systemTestDeployment(SystemTestParameters parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SleeperInstanceDriver instance(SystemTestParameters parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SleeperInstanceTablesDriver tables(SystemTestParameters parameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GeneratedIngestSourceFilesDriver generatedSourceFiles(SystemTestParameters parameters, DeployedSystemTestResources systemTest) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IngestSourceFilesDriver sourceFiles(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PartitionSplittingDriver partitionSplitting(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DirectIngestDriver directIngest(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IngestByQueueDriver ingestByQueue(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DirectBulkImportDriver directEmrServerless(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IngestBatcherDriver ingestBatcher(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InvokeIngestTasksDriver invokeIngestTasks(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WaitForJobs waitForIngest(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WaitForJobs waitForBulkImport(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SystemTestQuery query(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SystemTestCompaction compaction(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SystemTestReporting reporting(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SystemTestMetrics metrics(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SystemTestCluster systemTestCluster(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SystemTestPythonApi pythonApi(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PurgeQueueDriver purgeQueueDriver(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
@@ -31,7 +31,8 @@ import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
-import sleeper.systemtest.dsl.query.SystemTestQuery;
+import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
+import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReporting;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
@@ -105,7 +106,17 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestQuery query(SystemTestContext context) {
+    public QueryAllTablesDriver queryByQueue(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public QueryAllTablesDriver directQuery(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ClearQueryResultsDriver clearQueryResults(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
@@ -28,7 +28,7 @@ import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
-import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
+import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.ClearQueryResultsDriver;
@@ -142,7 +142,7 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestMetrics metrics(SystemTestContext context) {
+    public TableMetricsDriver tableMetrics(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
@@ -17,7 +17,7 @@
 package sleeper.systemtest.dsl.util;
 
 import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
+import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
@@ -121,7 +121,12 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     }
 
     @Override
-    public SystemTestCompaction compaction(SystemTestContext context) {
+    public CompactionDriver compaction(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WaitForJobs waitForCompaction(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/SystemTestDriversUnimplemented.java
@@ -21,7 +21,7 @@ import sleeper.systemtest.dsl.compaction.CompactionDriver;
 import sleeper.systemtest.dsl.ingest.DirectBulkImportDriver;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.ingest.IngestBatcherDriver;
-import sleeper.systemtest.dsl.ingest.IngestByQueueDriver;
+import sleeper.systemtest.dsl.ingest.IngestByQueue;
 import sleeper.systemtest.dsl.ingest.InvokeIngestTasksDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
@@ -36,9 +36,9 @@ import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
+import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
-import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
 
 public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     @Override
@@ -77,7 +77,7 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     }
 
     @Override
-    public IngestByQueueDriver ingestByQueue(SystemTestContext context) {
+    public IngestByQueue ingestByQueue(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 
@@ -132,6 +132,11 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
     }
 
     @Override
+    public DataGenerationTasksDriver dataGenerationTasks(SystemTestContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public IngestReportsDriver ingestReports(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
@@ -148,11 +153,6 @@ public class SystemTestDriversUnimplemented implements SystemTestDrivers {
 
     @Override
     public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestCluster systemTestCluster(SystemTestContext context) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/WaitForJobs.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/util/WaitForJobs.java
@@ -25,7 +25,7 @@ import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.core.util.PollWithRetries;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.ingest.task.IngestTaskStatusStore;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -35,12 +35,12 @@ import java.util.function.Function;
 public class WaitForJobs {
     private static final Logger LOGGER = LoggerFactory.getLogger(WaitForJobs.class);
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final String typeDescription;
     private final Function<InstanceProperties, JobStatusStore> getJobsStore;
     private final Function<InstanceProperties, TaskStatusStore> getTasksStore;
 
-    private WaitForJobs(SleeperInstanceContext instance,
+    private WaitForJobs(SystemTestInstanceContext instance,
                         String typeDescription,
                         Function<InstanceProperties, JobStatusStore> getJobsStore,
                         Function<InstanceProperties, TaskStatusStore> getTasksStore) {
@@ -50,7 +50,7 @@ public class WaitForJobs {
         this.getTasksStore = getTasksStore;
     }
 
-    public static WaitForJobs forIngest(SleeperInstanceContext instance,
+    public static WaitForJobs forIngest(SystemTestInstanceContext instance,
                                         Function<InstanceProperties, IngestJobStatusStore> getJobsStore,
                                         Function<InstanceProperties, IngestTaskStatusStore> getTasksStore) {
         return new WaitForJobs(instance, "ingest",
@@ -58,14 +58,14 @@ public class WaitForJobs {
                 properties -> TaskStatusStore.forIngest(getTasksStore.apply(properties)));
     }
 
-    public static WaitForJobs forBulkImport(SleeperInstanceContext instance,
+    public static WaitForJobs forBulkImport(SystemTestInstanceContext instance,
                                             Function<InstanceProperties, IngestJobStatusStore> getJobsStore) {
         return new WaitForJobs(instance, "bulk import",
                 properties -> JobStatusStore.forIngest(getJobsStore.apply(properties)),
                 properties -> () -> true);
     }
 
-    public static WaitForJobs forCompaction(SleeperInstanceContext instance,
+    public static WaitForJobs forCompaction(SystemTestInstanceContext instance,
                                             Function<InstanceProperties, CompactionJobStatusStore> getJobsStore,
                                             Function<InstanceProperties, CompactionTaskStatusStore> getTasksStore) {
         return new WaitForJobs(instance, "ingest",

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReports.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReports.java
@@ -17,8 +17,8 @@
 package sleeper.systemtest.dsl.extension;
 
 import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 public class AfterTestReports extends AfterTestReportsBase<SystemTestReports.SystemTestBuilder> {
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReports.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReports.java
@@ -23,6 +23,10 @@ import sleeper.systemtest.dsl.util.SystemTestDrivers;
 public class AfterTestReports extends AfterTestReportsBase<SystemTestReports.SystemTestBuilder> {
 
     AfterTestReports(SystemTestDrivers drivers, SystemTestContext context) {
-        super(() -> drivers.reportsForExtension(context));
+        super(() -> SystemTestReports.builder(
+                context.reporting(),
+                drivers.partitionReports(context),
+                drivers.ingestReports(context),
+                drivers.compactionReports(context)));
     }
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReports.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReports.java
@@ -16,12 +16,13 @@
 
 package sleeper.systemtest.dsl.extension;
 
+import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 public class AfterTestReports extends AfterTestReportsBase<SystemTestReports.SystemTestBuilder> {
 
-    AfterTestReports(SystemTestDrivers drivers) {
-        super(drivers::reportsForExtension);
+    AfterTestReports(SystemTestDrivers drivers, SystemTestContext context) {
+        super(() -> drivers.reportsForExtension(context));
     }
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
@@ -40,19 +40,17 @@ public class SleeperSystemTestExtension implements ParameterResolver, BeforeAllC
     private final SystemTestParameters parameters;
     private final SystemTestDrivers drivers;
     private final DeployedSystemTestResources deployedResources;
-    private final SystemTestContext testContext;
-    private final SleeperSystemTest dsl;
-    private AfterTestReports reporting;
-    private AfterTestPurgeQueues queuePurging;
+    private final DeployedSleeperInstances deployedInstances;
+    private SleeperSystemTest dsl = null;
+    private AfterTestReports reporting = null;
+    private AfterTestPurgeQueues queuePurging = null;
 
     protected SleeperSystemTestExtension(SystemTestParameters parameters, SystemTestDrivers drivers) {
         this.parameters = parameters;
         this.drivers = drivers;
         deployedResources = new DeployedSystemTestResources(parameters, drivers.systemTestDeployment(parameters));
-        DeployedSleeperInstances deployedInstances = new DeployedSleeperInstances(
+        deployedInstances = new DeployedSleeperInstances(
                 parameters, deployedResources, drivers.instance(parameters), drivers.tables(parameters));
-        testContext = new SystemTestContext(parameters, drivers, deployedResources, deployedInstances);
-        dsl = new SleeperSystemTest(parameters, drivers, testContext);
     }
 
     @Override
@@ -84,7 +82,8 @@ public class SleeperSystemTestExtension implements ParameterResolver, BeforeAllC
 
     @Override
     public void beforeEach(ExtensionContext context) {
-        dsl.reset();
+        SystemTestContext testContext = new SystemTestContext(parameters, drivers, deployedResources, deployedInstances);
+        dsl = new SleeperSystemTest(parameters, drivers, testContext);
         reporting = new AfterTestReports(drivers, testContext);
         queuePurging = new AfterTestPurgeQueues(drivers.purgeQueueDriver(testContext));
     }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
@@ -97,5 +97,8 @@ public class SleeperSystemTestExtension implements ParameterResolver, BeforeAllC
             reporting.afterTestPassed(testContext(context));
             queuePurging.testPassed();
         }
+        dsl = null;
+        reporting = null;
+        queuePurging = null;
     }
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 
 import sleeper.systemtest.dsl.SleeperSystemTest;
+import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
@@ -34,13 +35,15 @@ import static sleeper.systemtest.dsl.extension.TestContextFactory.testContext;
 public class SleeperSystemTestExtension implements ParameterResolver, BeforeEachCallback, AfterEachCallback {
 
     private final SystemTestDrivers drivers;
+    private final SystemTestContext testContext;
     private final SleeperSystemTest dsl;
     private AfterTestReports reporting;
     private AfterTestPurgeQueues queuePurging;
 
     protected SleeperSystemTestExtension(SystemTestParameters parameters, SystemTestDrivers drivers) {
         this.drivers = drivers;
-        this.dsl = new SleeperSystemTest(parameters, drivers);
+        this.testContext = new SystemTestContext(parameters, drivers);
+        this.dsl = new SleeperSystemTest(parameters, drivers, testContext);
     }
 
     @Override
@@ -66,8 +69,8 @@ public class SleeperSystemTestExtension implements ParameterResolver, BeforeEach
     @Override
     public void beforeEach(ExtensionContext context) {
         dsl.reset();
-        reporting = new AfterTestReports(drivers);
-        queuePurging = new AfterTestPurgeQueues(drivers.purgeQueueDriver());
+        reporting = new AfterTestReports(drivers, testContext);
+        queuePurging = new AfterTestPurgeQueues(drivers.purgeQueueDriver(testContext));
     }
 
     @Override

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
@@ -85,7 +85,7 @@ public class SleeperSystemTestExtension implements ParameterResolver, BeforeAllC
         SystemTestContext testContext = new SystemTestContext(parameters, drivers, deployedResources, deployedInstances);
         dsl = new SleeperSystemTest(parameters, drivers, testContext);
         reporting = new AfterTestReports(drivers, testContext);
-        queuePurging = new AfterTestPurgeQueues(drivers.purgeQueueDriver(testContext));
+        queuePurging = new AfterTestPurgeQueues(drivers.purgeQueues(testContext));
     }
 
     @Override

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
@@ -77,11 +77,11 @@ public class SleeperSystemTestExtension implements ParameterResolver, BeforeAllC
     public void beforeAll(ExtensionContext context) throws Exception {
         deployedResources.deployIfMissing();
         deployedResources.resetProperties();
-        drivers.generatedSourceFiles(parameters, deployedResources).emptyBucket();
     }
 
     @Override
     public void beforeEach(ExtensionContext context) {
+        drivers.generatedSourceFiles(parameters, deployedResources).emptyBucket();
         SystemTestContext testContext = new SystemTestContext(parameters, drivers, deployedResources, deployedInstances);
         dsl = new SleeperSystemTest(parameters, drivers, testContext);
         reporting = new AfterTestReports(drivers, testContext);

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/SleeperSystemTestExtension.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 
 import sleeper.systemtest.dsl.SleeperSystemTest;
 import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.instance.DeployedSleeperInstances;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 import java.util.Set;
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -19,8 +19,9 @@ package sleeper.systemtest.dsl.testutil;
 import sleeper.query.runner.recordretrieval.InMemoryDataStore;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
+import sleeper.systemtest.dsl.instance.DeployedSleeperInstances;
+import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
-import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
 import sleeper.systemtest.dsl.partitioning.SystemTestPartitioning;
@@ -43,23 +44,24 @@ import sleeper.systemtest.dsl.util.PurgeQueueDriver;
 import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 public class InMemorySystemTestDrivers implements SystemTestDrivers {
-    private final SystemTestDeploymentContext systemTestContext;
+    private final DeployedSystemTestResources systemTestContext;
     private final SystemTestInstanceContext instanceContext;
     private final IngestSourceFilesContext sourceFilesContext;
     private final ReportingContext reportingContext;
     private final InMemoryDataStore data = new InMemoryDataStore();
 
     public InMemorySystemTestDrivers(SystemTestParameters parameters) {
-        systemTestContext = new SystemTestDeploymentContext(parameters, new InMemorySystemTestDeploymentDriver());
+        systemTestContext = new DeployedSystemTestResources(parameters, new InMemorySystemTestDeploymentDriver());
         InMemorySleeperInstanceTablesDriver tablesDriver = new InMemorySleeperInstanceTablesDriver();
-        instanceContext = new SystemTestInstanceContext(parameters, systemTestContext,
-                new InMemorySleeperInstanceDriver(tablesDriver), tablesDriver);
+        InMemorySleeperInstanceDriver instanceDriver = new InMemorySleeperInstanceDriver(tablesDriver);
+        DeployedSleeperInstances deployedInstances = new DeployedSleeperInstances(parameters, systemTestContext, instanceDriver, tablesDriver);
+        instanceContext = new SystemTestInstanceContext(parameters, deployedInstances, instanceDriver, tablesDriver);
         sourceFilesContext = new IngestSourceFilesContext(systemTestContext, instanceContext);
         reportingContext = new ReportingContext(parameters);
     }
 
     @Override
-    public SystemTestDeploymentContext getSystemTestContext() {
+    public DeployedSystemTestResources getSystemTestContext() {
         return systemTestContext;
     }
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -21,7 +21,7 @@ import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SleeperTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
@@ -30,7 +30,7 @@ import sleeper.systemtest.dsl.testutil.drivers.InMemoryDirectIngestDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryGeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryQueryDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperInstanceDriver;
-import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperTablesDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
 import sleeper.systemtest.dsl.util.SystemTestDriversBase;
@@ -38,7 +38,7 @@ import sleeper.systemtest.dsl.util.SystemTestDriversBase;
 public class InMemorySystemTestDrivers extends SystemTestDriversBase {
 
     private final SystemTestDeploymentDriver systemTestDeploymentDriver = new InMemorySystemTestDeploymentDriver();
-    private final InMemorySleeperInstanceTablesDriver tablesDriver = new InMemorySleeperInstanceTablesDriver();
+    private final InMemorySleeperTablesDriver tablesDriver = new InMemorySleeperTablesDriver();
     private final SleeperInstanceDriver instanceDriver = new InMemorySleeperInstanceDriver(tablesDriver);
     private final InMemoryDataStore data = new InMemoryDataStore();
 
@@ -53,7 +53,7 @@ public class InMemorySystemTestDrivers extends SystemTestDriversBase {
     }
 
     @Override
-    public SleeperInstanceTablesDriver tables(SystemTestParameters parameters) {
+    public SleeperTablesDriver tables(SystemTestParameters parameters) {
         return tablesDriver;
     }
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -33,9 +33,9 @@ import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperInstanceDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
-import sleeper.systemtest.dsl.util.SystemTestDriversUnimplemented;
+import sleeper.systemtest.dsl.util.SystemTestDriversBase;
 
-public class InMemorySystemTestDrivers extends SystemTestDriversUnimplemented {
+public class InMemorySystemTestDrivers extends SystemTestDriversBase {
 
     private final SystemTestDeploymentDriver systemTestDeploymentDriver = new InMemorySystemTestDeploymentDriver();
     private final InMemorySleeperInstanceTablesDriver tablesDriver = new InMemorySleeperInstanceTablesDriver();

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -73,7 +73,7 @@ public class InMemorySystemTestDrivers extends SystemTestDriversBase {
     }
 
     @Override
-    public PurgeQueueDriver purgeQueueDriver(SystemTestContext context) {
+    public PurgeQueueDriver purgeQueues(SystemTestContext context) {
         return properties -> {
         };
     }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -18,22 +18,14 @@ package sleeper.systemtest.dsl.testutil;
 
 import sleeper.query.runner.recordretrieval.InMemoryDataStore;
 import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
-import sleeper.systemtest.dsl.ingest.SystemTestIngest;
+import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
 import sleeper.systemtest.dsl.instance.DeployedSystemTestResources;
 import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
-import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
-import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
-import sleeper.systemtest.dsl.python.SystemTestPythonApi;
 import sleeper.systemtest.dsl.query.SystemTestQuery;
-import sleeper.systemtest.dsl.reporting.SystemTestReporting;
-import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
-import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
-import sleeper.systemtest.dsl.sourcedata.SystemTestCluster;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryDirectIngestDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryGeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryQueryDriver;
@@ -41,9 +33,9 @@ import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperInstanceDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.util.PurgeQueueDriver;
-import sleeper.systemtest.dsl.util.SystemTestDrivers;
+import sleeper.systemtest.dsl.util.SystemTestDriversUnimplemented;
 
-public class InMemorySystemTestDrivers implements SystemTestDrivers {
+public class InMemorySystemTestDrivers extends SystemTestDriversUnimplemented {
 
     private final SystemTestDeploymentDriver systemTestDeploymentDriver = new InMemorySystemTestDeploymentDriver();
     private final InMemorySleeperInstanceTablesDriver tablesDriver = new InMemorySleeperInstanceTablesDriver();
@@ -71,20 +63,8 @@ public class InMemorySystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public IngestSourceFilesDriver sourceFilesDriver(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public PartitionSplittingDriver partitionSplitting(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestIngest ingest(SystemTestContext context) {
-        return new SystemTestIngest(context.instance(), null,
-                new InMemoryDirectIngestDriver(context.instance(), data),
-                null, null, null, null, null, null);
+    public DirectIngestDriver directIngest(SystemTestContext context) {
+        return new InMemoryDirectIngestDriver(context.instance(), data);
     }
 
     @Override
@@ -92,36 +72,6 @@ public class InMemorySystemTestDrivers implements SystemTestDrivers {
         return new SystemTestQuery(context.instance(), null,
                 InMemoryQueryDriver.allTablesDriver(context.instance(), data),
                 null);
-    }
-
-    @Override
-    public SystemTestCompaction compaction(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestReporting reporting(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestMetrics metrics(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestReports.SystemTestBuilder reportsForExtension(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestCluster systemTestCluster(SystemTestContext context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SystemTestPythonApi pythonApi(SystemTestContext context) {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -19,7 +19,7 @@ package sleeper.systemtest.dsl.testutil;
 import sleeper.query.runner.recordretrieval.InMemoryDataStore;
 import sleeper.systemtest.dsl.compaction.SystemTestCompaction;
 import sleeper.systemtest.dsl.ingest.SystemTestIngest;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentContext;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.SystemTestMetrics;
@@ -44,7 +44,7 @@ import sleeper.systemtest.dsl.util.SystemTestDrivers;
 
 public class InMemorySystemTestDrivers implements SystemTestDrivers {
     private final SystemTestDeploymentContext systemTestContext;
-    private final SleeperInstanceContext instanceContext;
+    private final SystemTestInstanceContext instanceContext;
     private final IngestSourceFilesContext sourceFilesContext;
     private final ReportingContext reportingContext;
     private final InMemoryDataStore data = new InMemoryDataStore();
@@ -52,7 +52,7 @@ public class InMemorySystemTestDrivers implements SystemTestDrivers {
     public InMemorySystemTestDrivers(SystemTestParameters parameters) {
         systemTestContext = new SystemTestDeploymentContext(parameters, new InMemorySystemTestDeploymentDriver());
         InMemorySleeperInstanceTablesDriver tablesDriver = new InMemorySleeperInstanceTablesDriver();
-        instanceContext = new SleeperInstanceContext(parameters, systemTestContext,
+        instanceContext = new SystemTestInstanceContext(parameters, systemTestContext,
                 new InMemorySleeperInstanceDriver(tablesDriver), tablesDriver);
         sourceFilesContext = new IngestSourceFilesContext(systemTestContext, instanceContext);
         reportingContext = new ReportingContext(parameters);
@@ -64,7 +64,7 @@ public class InMemorySystemTestDrivers implements SystemTestDrivers {
     }
 
     @Override
-    public SleeperInstanceContext getInstanceContext() {
+    public SystemTestInstanceContext getInstanceContext() {
         return instanceContext;
     }
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -24,7 +24,7 @@ import sleeper.systemtest.dsl.instance.SleeperInstanceDriver;
 import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
 import sleeper.systemtest.dsl.instance.SystemTestDeploymentDriver;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
-import sleeper.systemtest.dsl.query.SystemTestQuery;
+import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryDirectIngestDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryGeneratedIngestSourceFilesDriver;
@@ -68,10 +68,8 @@ public class InMemorySystemTestDrivers extends SystemTestDriversUnimplemented {
     }
 
     @Override
-    public SystemTestQuery query(SystemTestContext context) {
-        return new SystemTestQuery(context.instance(), null,
-                InMemoryQueryDriver.allTablesDriver(context.instance(), data),
-                null);
+    public QueryAllTablesDriver directQuery(SystemTestContext context) {
+        return InMemoryQueryDriver.allTablesDriver(context.instance(), data);
     }
 
     @Override

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestExtension.java
@@ -20,15 +20,17 @@ import sleeper.systemtest.dsl.extension.SleeperSystemTestExtension;
 import sleeper.systemtest.dsl.instance.SystemTestParameters;
 
 public class InMemorySystemTestExtension extends SleeperSystemTestExtension {
+
+    private static final SystemTestParameters PARAMETERS = SystemTestParameters.builder()
+            .shortTestId("test-id")
+            .account("test-account")
+            .region("test-region")
+            .vpcId("test-vpc")
+            .subnetIds("test-subnet")
+            .findDirectories()
+            .build();
+
     public InMemorySystemTestExtension() {
-        super(SystemTestParameters.builder()
-                        .shortTestId("test-id")
-                        .account("test-account")
-                        .region("test-region")
-                        .vpcId("test-vpc")
-                        .subnetIds("test-subnet")
-                        .findDirectories()
-                        .build(),
-                new InMemorySystemTestDrivers());
+        super(PARAMETERS, new InMemorySystemTestDrivers());
     }
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestExtension.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestExtension.java
@@ -21,17 +21,14 @@ import sleeper.systemtest.dsl.instance.SystemTestParameters;
 
 public class InMemorySystemTestExtension extends SleeperSystemTestExtension {
     public InMemorySystemTestExtension() {
-        this(SystemTestParameters.builder()
-                .shortTestId("test-id")
-                .account("test-account")
-                .region("test-region")
-                .vpcId("test-vpc")
-                .subnetIds("test-subnet")
-                .findDirectories()
-                .build());
-    }
-
-    private InMemorySystemTestExtension(SystemTestParameters parameters) {
-        super(parameters, new InMemorySystemTestDrivers(parameters));
+        super(SystemTestParameters.builder()
+                        .shortTestId("test-id")
+                        .account("test-account")
+                        .region("test-region")
+                        .vpcId("test-vpc")
+                        .subnetIds("test-subnet")
+                        .findDirectories()
+                        .build(),
+                new InMemorySystemTestDrivers());
     }
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryDirectIngestDriver.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryDirectIngestDriver.java
@@ -26,7 +26,7 @@ import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.query.runner.recordretrieval.InMemoryDataStore;
 import sleeper.systemtest.dsl.ingest.DirectIngestDriver;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 
 import java.nio.file.Path;
 import java.util.Iterator;
@@ -45,10 +45,10 @@ import static sleeper.configuration.properties.instance.CommonProperty.FILE_SYST
 import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
 
 public class InMemoryDirectIngestDriver implements DirectIngestDriver {
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final InMemoryDataStore data;
 
-    public InMemoryDirectIngestDriver(SleeperInstanceContext instance, InMemoryDataStore data) {
+    public InMemoryDirectIngestDriver(SystemTestInstanceContext instance, InMemoryDataStore data) {
         this.instance = instance;
         this.data = data;
     }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryQueryDriver.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryQueryDriver.java
@@ -26,7 +26,7 @@ import sleeper.query.model.Query;
 import sleeper.query.model.QueryException;
 import sleeper.query.runner.recordretrieval.InMemoryDataStore;
 import sleeper.query.runner.recordretrieval.QueryExecutor;
-import sleeper.systemtest.dsl.instance.SleeperInstanceContext;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesInParallelDriver;
 import sleeper.systemtest.dsl.query.QueryDriver;
@@ -38,15 +38,15 @@ import java.util.List;
 
 public class InMemoryQueryDriver implements QueryDriver {
 
-    private final SleeperInstanceContext instance;
+    private final SystemTestInstanceContext instance;
     private final InMemoryDataStore dataStore;
 
-    private InMemoryQueryDriver(SleeperInstanceContext instance, InMemoryDataStore dataStore) {
+    private InMemoryQueryDriver(SystemTestInstanceContext instance, InMemoryDataStore dataStore) {
         this.instance = instance;
         this.dataStore = dataStore;
     }
 
-    public static QueryAllTablesDriver allTablesDriver(SleeperInstanceContext instance, InMemoryDataStore dataStore) {
+    public static QueryAllTablesDriver allTablesDriver(SystemTestInstanceContext instance, InMemoryDataStore dataStore) {
         return new QueryAllTablesInParallelDriver(instance, new InMemoryQueryDriver(instance, dataStore));
     }
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemorySleeperInstanceDriver.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemorySleeperInstanceDriver.java
@@ -29,10 +29,10 @@ import static sleeper.configuration.properties.instance.CommonProperty.ID;
 
 public class InMemorySleeperInstanceDriver implements SleeperInstanceDriver {
 
-    private final InMemorySleeperInstanceTablesDriver tablesDriver;
+    private final InMemorySleeperTablesDriver tablesDriver;
     private final Map<String, InstanceProperties> instancePropertiesById = new TreeMap<>();
 
-    public InMemorySleeperInstanceDriver(InMemorySleeperInstanceTablesDriver tablesDriver) {
+    public InMemorySleeperInstanceDriver(InMemorySleeperTablesDriver tablesDriver) {
         this.tablesDriver = tablesDriver;
     }
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemorySleeperTablesDriver.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemorySleeperTablesDriver.java
@@ -27,7 +27,7 @@ import sleeper.core.table.InMemoryTableIndex;
 import sleeper.core.table.TableIndex;
 import sleeper.statestore.FixedStateStoreProvider;
 import sleeper.statestore.StateStoreProvider;
-import sleeper.systemtest.dsl.instance.SleeperInstanceTablesDriver;
+import sleeper.systemtest.dsl.instance.SleeperTablesDriver;
 
 import java.time.Instant;
 import java.util.Map;
@@ -37,7 +37,7 @@ import static sleeper.configuration.properties.instance.CommonProperty.ID;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.core.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreUninitialised;
 
-public class InMemorySleeperInstanceTablesDriver implements SleeperInstanceTablesDriver {
+public class InMemorySleeperTablesDriver implements SleeperTablesDriver {
 
     private final Map<String, TableIndex> tableIndexByInstanceId = new TreeMap<>();
     private final Map<String, TablePropertiesStore> propertiesStoreByInstanceId = new TreeMap<>();

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/fixtures/SystemTestInstanceTest.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/fixtures/SystemTestInstanceTest.java
@@ -45,7 +45,7 @@ public class SystemTestInstanceTest {
                 .shortTestId("mvn-10110302") // Contains month, day, hour, minute
                 .build();
         assertThat(instances)
-                .extracting(instance -> parameters.buildInstanceId(instance.getIdentifier()))
+                .extracting(instance -> parameters.buildInstanceId(instance.getShortName()))
                 .allMatch(CommonProperty.ID.validationPredicate());
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/AwsSleeperSystemTestExtension.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/testutil/AwsSleeperSystemTestExtension.java
@@ -19,14 +19,9 @@ package sleeper.systemtest.suite.testutil;
 import sleeper.systemtest.drivers.instance.AwsSystemTestParameters;
 import sleeper.systemtest.drivers.util.AwsSystemTestDrivers;
 import sleeper.systemtest.dsl.extension.SleeperSystemTestExtension;
-import sleeper.systemtest.dsl.instance.SystemTestParameters;
 
 public class AwsSleeperSystemTestExtension extends SleeperSystemTestExtension {
     public AwsSleeperSystemTestExtension() {
-        this(AwsSystemTestParameters.loadFromSystemProperties());
-    }
-
-    private AwsSleeperSystemTestExtension(SystemTestParameters parameters) {
-        super(parameters, new AwsSystemTestDrivers(parameters));
+        super(AwsSystemTestParameters.loadFromSystemProperties(), new AwsSystemTestDrivers());
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1844

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests
    - Will run in AWS against top of stack:
      - https://github.com/gchq/sleeper/pull/1840

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.