### PR TITLE
Issue 1860 - Assign job IDs to files for a batch of multiple jobs in DynamoDB state store

### DIFF
--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStore.java
@@ -295,11 +295,11 @@ class DynamoDBFileReferenceStore implements FileReferenceStore {
         List<String> filenames = fileReferences.stream()
                 .map(FileReference::getFilename)
                 .collect(toUnmodifiableList());
-        atomicallyAssignJobIdsToFileReferences(List.of(AssignJobIdRequest.assignJobOnPartitionToFiles(jobId, partitionId, filenames)));
+        assignJobIds(List.of(AssignJobIdRequest.assignJobOnPartitionToFiles(jobId, partitionId, filenames)));
     }
 
     @Override
-    public void atomicallyAssignJobIdsToFileReferences(List<AssignJobIdRequest> requests)
+    public void assignJobIds(List<AssignJobIdRequest> requests)
             throws StateStoreException {
         long updateTime = clock.millis();
         for (AssignJobIdRequest request : requests) {

--- a/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStore.java
@@ -39,6 +39,7 @@ import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TableProperty;
 import sleeper.core.statestore.AllReferencesToAFile;
 import sleeper.core.statestore.AllReferencesToAllFiles;
+import sleeper.core.statestore.AssignJobIdRequest;
 import sleeper.core.statestore.FileReference;
 import sleeper.core.statestore.FileReferenceStore;
 import sleeper.core.statestore.SplitFileReferenceRequest;
@@ -64,6 +65,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.ACTIVE_FILES_TABLELENAME;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.FILE_REFERENCE_COUNT_TABLENAME;
 import static sleeper.configuration.properties.table.TableProperty.DYNAMODB_STRONGLY_CONSISTENT_READS;
@@ -288,21 +290,36 @@ class DynamoDBFileReferenceStore implements FileReferenceStore {
      * the compactionJob field is currently null.
      */
     @Override
-    public void atomicallyAssignJobIdToFileReferences(String jobId, List<FileReference> files)
+    public void atomicallyAssignJobIdToFileReferences(String jobId, List<FileReference> fileReferences) throws StateStoreException {
+        String partitionId = fileReferences.stream().map(FileReference::getPartitionId).findAny().orElseThrow();
+        List<String> filenames = fileReferences.stream()
+                .map(FileReference::getFilename)
+                .collect(toUnmodifiableList());
+        atomicallyAssignJobIdsToFileReferences(List.of(AssignJobIdRequest.assignJobOnPartitionToFiles(jobId, partitionId, filenames)));
+    }
+
+    @Override
+    public void atomicallyAssignJobIdsToFileReferences(List<AssignJobIdRequest> requests)
             throws StateStoreException {
-        // Create Puts for each of the files, conditional on the compactionJob field being not present
         long updateTime = clock.millis();
-        List<TransactWriteItem> writes = files.stream().map(file ->
+        for (AssignJobIdRequest request : requests) {
+            assignJobId(request, updateTime);
+        }
+    }
+
+    private void assignJobId(AssignJobIdRequest request, long updateTime) throws StateStoreException {
+        // Create Puts for each of the files, conditional on the compactionJob field being not present
+        List<TransactWriteItem> writes = request.getFilenames().stream().map(file ->
                         new TransactWriteItem().withUpdate(new Update()
                                 .withTableName(activeTableName)
-                                .withKey(fileReferenceFormat.createActiveFileKey(file))
+                                .withKey(fileReferenceFormat.createActiveFileKey(request.getPartitionId(), file))
                                 .withUpdateExpression("SET #jobid = :jobid, #time = :time")
                                 .withConditionExpression("attribute_exists(#time) and attribute_not_exists(#jobid)")
                                 .withExpressionAttributeNames(Map.of(
                                         "#jobid", JOB_ID,
                                         "#time", LAST_UPDATE_TIME))
                                 .withExpressionAttributeValues(Map.of(
-                                        ":jobid", createStringAttribute(jobId),
+                                        ":jobid", createStringAttribute(request.getJobId()),
                                         ":time", createNumberAttribute(updateTime)))
                                 .withReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD)))
                 .collect(Collectors.toUnmodifiableList());
@@ -314,22 +331,22 @@ class DynamoDBFileReferenceStore implements FileReferenceStore {
             List<ConsumedCapacity> consumedCapacity = transactWriteItemsResult.getConsumedCapacity();
             double totalConsumed = consumedCapacity.stream().mapToDouble(ConsumedCapacity::getCapacityUnits).sum();
             LOGGER.debug("Updated job status of {} files, read capacity consumed = {}",
-                    files.size(), totalConsumed);
+                    request.getFilenames().size(), totalConsumed);
         } catch (TransactionCanceledException e) {
-            throw buildAssignJobIdStateStoreException(e, files);
+            throw buildAssignJobIdStateStoreException(e, request);
         } catch (AmazonDynamoDBException e) {
             throw new StateStoreException("Failed to assign files to job", e);
         }
     }
 
     private StateStoreException buildAssignJobIdStateStoreException(
-            TransactionCanceledException e, List<FileReference> files) {
+            TransactionCanceledException e, AssignJobIdRequest request) {
         List<CancellationReason> reasons = e.getCancellationReasons();
-        for (int i = 0; i < files.size(); i++) {
+        for (int i = 0; i < request.getFilenames().size(); i++) {
             CancellationReason reason = reasons.get(i);
-            FileReference fileReference = files.get(i);
+            String filename = request.getFilenames().get(i);
             if (isConditionCheckFailure(reason)) {
-                return getFileReferenceExceptionFromReason(fileReference.getFilename(), fileReference.getPartitionId(), reason, item -> {
+                return getFileReferenceExceptionFromReason(filename, request.getPartitionId(), reason, item -> {
                     FileReference failedUpdate = fileReferenceFormat.getFileReferenceFromAttributeValues(reason.getItem());
                     if (failedUpdate.getJobId() != null) {
                         return new FileReferenceAssignedToJobException(failedUpdate, e);

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStoreIT.java
@@ -458,7 +458,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(file);
 
             // When
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job", "root", List.of("file"))));
 
             // Then
@@ -476,7 +476,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFiles(List.of(left, right));
 
             // When
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job", "L", List.of("file"))));
 
             // Then
@@ -492,7 +492,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFiles(List.of(file1, file2));
 
             // When
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("file1")),
                     assignJobOnPartitionToFiles("job2", "root", List.of("file2"))));
 
@@ -511,7 +511,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFiles(List.of(file1, file2));
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+            assertThatThrownBy(() -> store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("file1")),
                     assignJobOnPartitionToFiles("job2", "root", List.of("file1")))))
                     .isInstanceOf(FileReferenceAssignedToJobException.class);
@@ -526,11 +526,11 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             // Given
             FileReference file = factory.rootFile("file", 100L);
             store.addFile(file);
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("file"))));
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+            assertThatThrownBy(() -> store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job2", "root", List.of("file")))))
                     .isInstanceOf(FileReferenceAssignedToJobException.class);
             assertThat(store.getFileReferences()).containsExactly(withJobId("job1", file));
@@ -544,11 +544,11 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference file2 = factory.rootFile("file2", 100L);
             FileReference file3 = factory.rootFile("file3", 100L);
             store.addFiles(List.of(file1, file2, file3));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("file2"))));
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+            assertThatThrownBy(() -> store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job2", "root", List.of("file1", "file2", "file3")))))
                     .isInstanceOf(FileReferenceAssignedToJobException.class);
             assertThat(store.getFileReferences()).containsExactlyInAnyOrder(
@@ -563,7 +563,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(file);
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+            assertThatThrownBy(() -> store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("requestedFile")))))
                     .isInstanceOf(FileReferenceNotFoundException.class);
             assertThat(store.getFileReferences()).containsExactly(file);
@@ -573,7 +573,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
         @Test
         public void shouldNotMarkFileWithJobIdWhenFileDoesNotExistAndStoreIsEmpty() throws Exception {
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+            assertThatThrownBy(() -> store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("file")))))
                     .isInstanceOf(FileReferenceNotFoundException.class);
             assertThat(store.getFileReferences()).isEmpty();
@@ -589,7 +589,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(existingReference);
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+            assertThatThrownBy(() -> store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("file")))))
                     .isInstanceOf(FileReferenceNotFoundException.class);
             assertThat(store.getFileReferences()).containsExactly(existingReference);
@@ -609,7 +609,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(oldFile);
 
             // When
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("oldFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "root", List.of("oldFile"), newFile);
 
@@ -632,7 +632,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(oldFile);
 
             // When
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("oldFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "root", List.of("oldFile"), newFile);
 
@@ -681,7 +681,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference oldFile1 = factory.rootFile("oldFile1", 100L);
             FileReference newFile = factory.rootFile("newFile", 100L);
             store.addFile(oldFile1);
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("oldFile1"))));
 
             // When / Then
@@ -714,7 +714,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             // Given
             FileReference file = factory.rootFile("file1", 100L);
             store.addFile(file);
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("file1"))));
 
             // When / Then
@@ -734,7 +734,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference existingReference = splitFile(file, "L");
             FileReference newReference = factory.partitionFile("L", "newFile", 100L);
             store.addFiles(List.of(existingReference, newReference));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "L", List.of("oldFile"))));
 
             // When / Then
@@ -789,7 +789,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference compactionOutputFile = factory.partitionFile("L", "compactedFile", 100L);
             store.fixTime(updateTime);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "L", List.of("splitFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("splitFile"), compactionOutputFile);
 
@@ -811,7 +811,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference rightOutputFile = factory.partitionFile("R", "rightOutput", 100L);
             store.fixTime(updateTime);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "L", List.of("readyForGc")),
                     assignJobOnPartitionToFiles("job2", "R", List.of("readyForGc"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("readyForGc"), leftOutputFile);
@@ -841,7 +841,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             // And ingest and compactions happened at the expected times
             store.fixTime(ingestTime);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "L", List.of("readyForGc")),
                     assignJobOnPartitionToFiles("job2", "R", List.of("readyForGc"))));
             store.fixTime(firstCompactionTime);
@@ -865,7 +865,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference oldFile = factory.rootFile("oldFile", 100L);
             FileReference newFile = factory.rootFile("newFile", 100L);
             store.addFile(oldFile);
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("oldFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "root", List.of("oldFile"), newFile);
 
@@ -888,7 +888,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
 
             // And the file was ingested as two references, then compacted into each partition
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "L", List.of("file")),
                     assignJobOnPartitionToFiles("job2", "R", List.of("file"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("file"), leftOutputFile);
@@ -930,7 +930,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference rightFile = splitFile(rootFile, "R");
             FileReference leftOutputFile = factory.partitionFile("L", "leftOutput", 100L);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "L", List.of("file"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("file"), leftOutputFile);
 
@@ -946,7 +946,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference oldFile2 = factory.rootFile("oldFile2", 100L);
             FileReference newFile = factory.rootFile("newFile", 100L);
             store.addFiles(List.of(oldFile1, oldFile2));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "root", List.of("oldFile1", "oldFile2"))));
             store.atomicallyReplaceFileReferencesWithNewOne(
                     "job1", "root", List.of("oldFile1", "oldFile2"), newFile);
@@ -1047,7 +1047,7 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference rightFile = splitFile(rootFile, "R");
             FileReference outputFile = factory.partitionFile("L", 50L);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdsToFileReferences(List.of(
+            store.assignJobIds(List.of(
                     assignJobOnPartitionToFiles("job1", "L", List.of("file"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("file"), outputFile);
 

--- a/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/dynamodb/DynamoDBFileReferenceStoreIT.java
@@ -39,8 +39,6 @@ import sleeper.core.statestore.exception.NewReferenceSameAsOldReferenceException
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 import static sleeper.core.statestore.AllReferencesToAFileTestHelper.fileWithNoReferences;
 import static sleeper.core.statestore.AllReferencesToAFileTestHelper.fileWithReferences;
+import static sleeper.core.statestore.AssignJobIdRequest.assignJobOnPartitionToFiles;
 import static sleeper.core.statestore.FilesReportTestHelper.activeFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.noFilesReport;
 import static sleeper.core.statestore.FilesReportTestHelper.partialReadyForGCFilesReport;
@@ -459,7 +458,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(file);
 
             // When
-            store.atomicallyAssignJobIdToFileReferences("job", Collections.singletonList(file));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job", "root", List.of("file"))));
 
             // Then
             assertThat(store.getFileReferences()).containsExactly(withJobId("job", file));
@@ -476,7 +476,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFiles(List.of(left, right));
 
             // When
-            store.atomicallyAssignJobIdToFileReferences("job", Collections.singletonList(left));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job", "L", List.of("file"))));
 
             // Then
             assertThat(store.getFileReferences()).containsExactlyInAnyOrder(withJobId("job", left), right);
@@ -484,14 +485,53 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
         }
 
         @Test
+        public void shouldMarkMultipleFilesWithJobIds() throws Exception {
+            // Given
+            FileReference file1 = factory.rootFile("file1", 100L);
+            FileReference file2 = factory.rootFile("file2", 100L);
+            store.addFiles(List.of(file1, file2));
+
+            // When
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("file1")),
+                    assignJobOnPartitionToFiles("job2", "root", List.of("file2"))));
+
+            // Then
+            assertThat(store.getFileReferences()).containsExactly(
+                    withJobId("job1", file1),
+                    withJobId("job2", file2));
+            assertThat(store.getFileReferencesWithNoJobId()).isEmpty();
+        }
+
+        @Test
+        public void shouldFailWhenSameFileIsAssignedInDifferentRequests() throws Exception {
+            // Given
+            FileReference file1 = factory.rootFile("file1", 100L);
+            FileReference file2 = factory.rootFile("file2", 100L);
+            store.addFiles(List.of(file1, file2));
+
+            // When / Then
+            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("file1")),
+                    assignJobOnPartitionToFiles("job2", "root", List.of("file1")))))
+                    .isInstanceOf(FileReferenceAssignedToJobException.class);
+            assertThat(store.getFileReferences()).containsExactly(
+                    withJobId("job1", file1),
+                    file2);
+            assertThat(store.getFileReferencesWithNoJobId()).containsExactly(file2);
+        }
+
+        @Test
         public void shouldNotMarkFileWithJobIdWhenOneIsAlreadySet() throws Exception {
             // Given
             FileReference file = factory.rootFile("file", 100L);
             store.addFile(file);
-            store.atomicallyAssignJobIdToFileReferences("job1", Collections.singletonList(file));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("file"))));
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdToFileReferences("job2", Collections.singletonList(file)))
+            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job2", "root", List.of("file")))))
                     .isInstanceOf(FileReferenceAssignedToJobException.class);
             assertThat(store.getFileReferences()).containsExactly(withJobId("job1", file));
             assertThat(store.getFileReferencesWithNoJobId()).isEmpty();
@@ -503,11 +543,13 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference file1 = factory.rootFile("file1", 100L);
             FileReference file2 = factory.rootFile("file2", 100L);
             FileReference file3 = factory.rootFile("file3", 100L);
-            store.addFiles(Arrays.asList(file1, file2, file3));
-            store.atomicallyAssignJobIdToFileReferences("job1", Collections.singletonList(file2));
+            store.addFiles(List.of(file1, file2, file3));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("file2"))));
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdToFileReferences("job2", Arrays.asList(file1, file2, file3)))
+            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job2", "root", List.of("file1", "file2", "file3")))))
                     .isInstanceOf(FileReferenceAssignedToJobException.class);
             assertThat(store.getFileReferences()).containsExactlyInAnyOrder(
                     file1, withJobId("job1", file2), file3);
@@ -518,11 +560,11 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
         public void shouldNotMarkFileWithJobIdWhenFileDoesNotExist() throws Exception {
             // Given
             FileReference file = factory.rootFile("existingFile", 100L);
-            FileReference requested = factory.rootFile("requestedFile", 100L);
             store.addFile(file);
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdToFileReferences("job", List.of(requested)))
+            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("requestedFile")))))
                     .isInstanceOf(FileReferenceNotFoundException.class);
             assertThat(store.getFileReferences()).containsExactly(file);
             assertThat(store.getFileReferencesWithNoJobId()).containsExactly(file);
@@ -530,11 +572,9 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
 
         @Test
         public void shouldNotMarkFileWithJobIdWhenFileDoesNotExistAndStoreIsEmpty() throws Exception {
-            // Given
-            FileReference file = factory.rootFile("file", 100L);
-
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdToFileReferences("job", List.of(file)))
+            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("file")))))
                     .isInstanceOf(FileReferenceNotFoundException.class);
             assertThat(store.getFileReferences()).isEmpty();
             assertThat(store.getFileReferencesWithNoJobId()).isEmpty();
@@ -549,7 +589,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(existingReference);
 
             // When / Then
-            assertThatThrownBy(() -> store.atomicallyAssignJobIdToFileReferences("job", List.of(file)))
+            assertThatThrownBy(() -> store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("file")))))
                     .isInstanceOf(FileReferenceNotFoundException.class);
             assertThat(store.getFileReferences()).containsExactly(existingReference);
             assertThat(store.getFileReferencesWithNoJobId()).containsExactly(existingReference);
@@ -568,7 +609,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(oldFile);
 
             // When
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(oldFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("oldFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "root", List.of("oldFile"), newFile);
 
             // Then
@@ -590,7 +632,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             store.addFile(oldFile);
 
             // When
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(oldFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("oldFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "root", List.of("oldFile"), newFile);
 
             // Then
@@ -638,7 +681,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference oldFile1 = factory.rootFile("oldFile1", 100L);
             FileReference newFile = factory.rootFile("newFile", 100L);
             store.addFile(oldFile1);
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(oldFile1));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("oldFile1"))));
 
             // When / Then
             assertThatThrownBy(() -> store.atomicallyReplaceFileReferencesWithNewOne(
@@ -670,7 +714,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             // Given
             FileReference file = factory.rootFile("file1", 100L);
             store.addFile(file);
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(file));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("file1"))));
 
             // When / Then
             assertThatThrownBy(() -> store.atomicallyReplaceFileReferencesWithNewOne(
@@ -689,7 +734,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference existingReference = splitFile(file, "L");
             FileReference newReference = factory.partitionFile("L", "newFile", 100L);
             store.addFiles(List.of(existingReference, newReference));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(existingReference));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "L", List.of("oldFile"))));
 
             // When / Then
             assertThatThrownBy(() -> store.atomicallyReplaceFileReferencesWithNewOne(
@@ -743,7 +789,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference compactionOutputFile = factory.partitionFile("L", "compactedFile", 100L);
             store.fixTime(updateTime);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(leftFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "L", List.of("splitFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("splitFile"), compactionOutputFile);
 
             // When / Then
@@ -764,9 +811,10 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference rightOutputFile = factory.partitionFile("R", "rightOutput", 100L);
             store.fixTime(updateTime);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(leftFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "L", List.of("readyForGc")),
+                    assignJobOnPartitionToFiles("job2", "R", List.of("readyForGc"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("readyForGc"), leftOutputFile);
-            store.atomicallyAssignJobIdToFileReferences("job2", List.of(rightFile));
             store.atomicallyReplaceFileReferencesWithNewOne("job2", "R", List.of("readyForGc"), rightOutputFile);
 
             // When / Then
@@ -793,8 +841,9 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             // And ingest and compactions happened at the expected times
             store.fixTime(ingestTime);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(leftFile));
-            store.atomicallyAssignJobIdToFileReferences("job2", List.of(rightFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "L", List.of("readyForGc")),
+                    assignJobOnPartitionToFiles("job2", "R", List.of("readyForGc"))));
             store.fixTime(firstCompactionTime);
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("readyForGc"), leftOutputFile);
             store.fixTime(secondCompactionTime);
@@ -816,7 +865,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference oldFile = factory.rootFile("oldFile", 100L);
             FileReference newFile = factory.rootFile("newFile", 100L);
             store.addFile(oldFile);
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(oldFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("oldFile"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "root", List.of("oldFile"), newFile);
 
             // When
@@ -838,9 +888,10 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
 
             // And the file was ingested as two references, then compacted into each partition
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(leftFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "L", List.of("file")),
+                    assignJobOnPartitionToFiles("job2", "R", List.of("file"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("file"), leftOutputFile);
-            store.atomicallyAssignJobIdToFileReferences("job2", List.of(rightFile));
             store.atomicallyReplaceFileReferencesWithNewOne("job2", "R", List.of("file"), rightOutputFile);
 
             // When
@@ -879,7 +930,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference rightFile = splitFile(rootFile, "R");
             FileReference leftOutputFile = factory.partitionFile("L", "leftOutput", 100L);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(leftFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "L", List.of("file"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("file"), leftOutputFile);
 
             // When / Then
@@ -894,7 +946,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference oldFile2 = factory.rootFile("oldFile2", 100L);
             FileReference newFile = factory.rootFile("newFile", 100L);
             store.addFiles(List.of(oldFile1, oldFile2));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(oldFile1, oldFile2));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "root", List.of("oldFile1", "oldFile2"))));
             store.atomicallyReplaceFileReferencesWithNewOne(
                     "job1", "root", List.of("oldFile1", "oldFile2"), newFile);
 
@@ -994,7 +1047,8 @@ public class DynamoDBFileReferenceStoreIT extends DynamoDBStateStoreOneTableTest
             FileReference rightFile = splitFile(rootFile, "R");
             FileReference outputFile = factory.partitionFile("L", 50L);
             store.addFiles(List.of(leftFile, rightFile));
-            store.atomicallyAssignJobIdToFileReferences("job1", List.of(leftFile));
+            store.atomicallyAssignJobIdsToFileReferences(List.of(
+                    assignJobOnPartitionToFiles("job1", "L", List.of("file"))));
             store.atomicallyReplaceFileReferencesWithNewOne("job1", "L", List.of("file"), outputFile);
 
             // When


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1860

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated DynamoDBFileReferenceStoreIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.