### PR TITLE
Issue 1869 - Truncate table name in EKS state machine execution name

### DIFF
--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Crown Copyright
+ * Copyright 2022-2024 Crown Copyright
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
         stepFunctions.startExecution(
                 new StartExecutionRequest()
                         .withStateMachineArn(stateMachineArn)
-                        .withName(String.join("-", bulkImportJob.getTableName(), bulkImportJob.getId()))
+                        .withName(jobExecutionName(bulkImportJob))
                         .withInput(new Gson().toJson(input)));
     }
 
@@ -145,5 +145,15 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
         } else {
             return "job-" + job.getId();
         }
+    }
+
+    private static String jobExecutionName(BulkImportJob job) {
+        String tableName = job.getTableName();
+        String jobId = job.getId();
+        int spaceForTableName = 80 - jobId.length() - 1;
+        if (tableName.length() > spaceForTableName) {
+            tableName = tableName.substring(0, spaceForTableName);
+        }
+        return String.join("-", tableName, jobId);
     }
 }

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutor.java
@@ -150,6 +150,8 @@ public class StateMachinePlatformExecutor implements PlatformExecutor {
     private static String jobExecutionName(BulkImportJob job) {
         String tableName = job.getTableName();
         String jobId = job.getId();
+        // See maximum length restriction in AWS documentation:
+        // https://docs.aws.amazon.com/step-functions/latest/apireference/API_StartExecution.html#API_StartExecution_RequestParameters
         int spaceForTableName = 80 - jobId.length() - 1;
         if (tableName.length() > spaceForTableName) {
             tableName = tableName.substring(0, spaceForTableName);

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutorTest.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutorTest.java
@@ -29,7 +29,6 @@ import sleeper.bulkimport.job.BulkImportJob;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.FixedTablePropertiesProvider;
 import sleeper.configuration.properties.table.TableProperties;
-import sleeper.core.table.TableIdentity;
 import sleeper.ingest.job.status.InMemoryIngestJobStatusStore;
 import sleeper.ingest.job.status.IngestJobStatusStore;
 import sleeper.statestore.FixedStateStoreProvider;
@@ -53,6 +52,7 @@ import static sleeper.configuration.properties.instance.CdkDefinedInstanceProper
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_BULK_IMPORT_MIN_LEAF_PARTITION_COUNT;
 import static sleeper.configuration.properties.table.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.configuration.properties.table.TableProperty.BULK_IMPORT_MIN_LEAF_PARTITION_COUNT;
+import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 import static sleeper.core.statestore.inmemory.StateStoreTestHelper.inMemoryStateStoreWithFixedSinglePartition;
 import static sleeper.ingest.job.status.IngestJobStatusTestData.jobStatus;
@@ -64,7 +64,6 @@ class StateMachinePlatformExecutorTest {
     private final AtomicReference<StartExecutionRequest> requested = new AtomicReference<>();
     private final InstanceProperties instanceProperties = createTestInstanceProperties();
     private final TableProperties tableProperties = createTestTableProperties(instanceProperties, schemaWithKey("key"));
-    private final TableIdentity tableId = tableProperties.getId();
     private final StateStoreProvider stateStoreProvider = new FixedStateStoreProvider(tableProperties,
             inMemoryStateStoreWithFixedSinglePartition(tableProperties.getSchema()));
     private final IngestJobStatusStore ingestJobStatusStore = new InMemoryIngestJobStatusStore();
@@ -149,7 +148,7 @@ class StateMachinePlatformExecutorTest {
         stateMachineExecutor.runJob(myJob);
 
         // Then
-        assertThat(ingestJobStatusStore.getAllJobs(tableId))
+        assertThat(ingestJobStatusStore.getAllJobs(tableProperties.getId()))
                 .containsExactly(jobStatus(myJob.toIngestJob(),
                         rejectedRun(myJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"),
                                 "The input files must be set to a non-null and non-empty value.")));
@@ -254,6 +253,40 @@ class StateMachinePlatformExecutorTest {
     }
 
     @Test
+    void shouldTruncateTableNameInStateMachineExecutionName() {
+        // Given
+        tableProperties.set(TABLE_NAME, "this-is-a-long-table-name-that-will-not-fit-in-an-execution-name-when-combined-with-the-job-id");
+        BulkImportJob myJob = jobForTable()
+                .id("my-job")
+                .files(Lists.newArrayList("file1.parquet"))
+                .build();
+
+        // When
+        createExecutorWithDefaults().runJob(myJob);
+
+        // Then
+        assertThat(requested.get().getName())
+                .isEqualTo("this-is-a-long-table-name-that-will-not-fit-in-an-execution-name-when-com-my-job");
+    }
+
+    @Test
+    void shouldNotTruncateTableNameInStateMachineExecutionNameWhenItFits() {
+        // Given
+        tableProperties.set(TABLE_NAME, "short-table-name");
+        BulkImportJob myJob = jobForTable()
+                .id("my-job")
+                .files(Lists.newArrayList("file1.parquet"))
+                .build();
+
+        // When
+        createExecutorWithDefaults().runJob(myJob);
+
+        // Then
+        assertThat(requested.get().getName())
+                .isEqualTo("short-table-name-my-job");
+    }
+
+    @Test
     void shouldFailValidationIfMinimumPartitionCountNotReached() {
         // Given
         tableProperties.set(BULK_IMPORT_MIN_LEAF_PARTITION_COUNT, "5");
@@ -268,7 +301,7 @@ class StateMachinePlatformExecutorTest {
         stateMachineExecutor.runJob(myJob);
 
         // Then
-        assertThat(ingestJobStatusStore.getAllJobs(tableId))
+        assertThat(ingestJobStatusStore.getAllJobs(tableProperties.getId()))
                 .containsExactly(jobStatus(myJob.toIngestJob(),
                         rejectedRun(myJob.toIngestJob(), Instant.parse("2023-06-02T15:41:00Z"),
                                 "The minimum partition count was not reached")));
@@ -290,6 +323,6 @@ class StateMachinePlatformExecutorTest {
 
     private BulkImportJob.Builder jobForTable() {
         return BulkImportJob.builder()
-                .tableId(tableId);
+                .tableId(tableProperties.getId());
     }
 }

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutorTest.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/StateMachinePlatformExecutorTest.java
@@ -266,7 +266,8 @@ class StateMachinePlatformExecutorTest {
 
         // Then
         assertThat(requested.get().getName())
-                .isEqualTo("this-is-a-long-table-name-that-will-not-fit-in-an-execution-name-when-com-my-job");
+                .isEqualTo("this-is-a-long-table-name-that-will-not-fit-in-an-execution-name-when-com-my-job")
+                .hasSize(80);
     }
 
     @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/1869

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated StateMachinePlatformExecutorTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.