### PR TITLE
Revert "Issue 2111 - Update spotbugs plugin version in common-task module "

### DIFF
--- a/java/common-task/pom.xml
+++ b/java/common-task/pom.xml
@@ -94,13 +94,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>${spotbugs.plugin.latest.version}</version>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/common-task/src/main/java/sleeper/task/common/EC2InstanceDetails.java
+++ b/java/common-task/src/main/java/sleeper/task/common/EC2InstanceDetails.java
@@ -78,7 +78,6 @@ public class EC2InstanceDetails {
 
     /**
      * The number of ECS container instances to retrieve in one API call.
-     * Must be > 0.
      */
     public static final int INSTANCE_PAGE_SIZE = 75;
 
@@ -196,6 +195,9 @@ public class EC2InstanceDetails {
             private Queue<EC2InstanceDetails> instanceQueue = new ArrayDeque<>();
 
             InstanceDetailsIterator(int pageSize) {
+                if (pageSize < 1) {
+                    throw new IllegalArgumentException("pageSize must be > 0");
+                }
                 this.pageSize = pageSize;
                 this.req = new ListContainerInstancesRequest()
                         .withCluster(ecsClusterName)


### PR DESCRIPTION
Reverts gchq/sleeper#2116

See issue:
- https://github.com/gchq/sleeper/issues/2133https://github.com/gchq/sleeper/issues/2133