### PR TITLE
Issue 2223 - Raise limit of open Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
     schedule:
       interval: "daily"
       time: "03:00"
+    open-pull-requests-limit: 10
   - package-ecosystem: "pip"
     directory: "/python"
     schedule:
       interval: "daily"
       time: "03:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2223

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Just Dependabot configuration

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.