### PR TITLE
Issue 2160 - Limit tables to show in DashboardStack

### DIFF
--- a/java/cdk/src/main/java/sleeper/cdk/stack/DashboardStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/DashboardStack.java
@@ -76,7 +76,7 @@ public class DashboardStack extends NestedStack {
         instanceId = instanceProperties.get(ID);
         tableNames = Utils.getAllTableProperties(instanceProperties, this)
                 .map(tableProperties -> tableProperties.get(TableProperty.TABLE_NAME))
-                .sorted()
+                .sorted().limit(10)
                 .collect(Collectors.toList());
         metricsNamespace = instanceProperties.get(METRICS_NAMESPACE);
         int timeWindowInMinutes = instanceProperties.getInt(DASHBOARD_TIME_WINDOW_MINUTES);

--- a/java/cdk/src/main/java/sleeper/cdk/stack/DashboardStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/DashboardStack.java
@@ -76,7 +76,9 @@ public class DashboardStack extends NestedStack {
         instanceId = instanceProperties.get(ID);
         tableNames = Utils.getAllTableProperties(instanceProperties, this)
                 .map(tableProperties -> tableProperties.get(TableProperty.TABLE_NAME))
-                .sorted().limit(10)
+                .sorted()
+                // There's a limit of 500 widgets in a dashboard, including the widgets not associated with a table
+                .limit(50)
                 .collect(Collectors.toList());
         metricsNamespace = instanceProperties.get(METRICS_NAMESPACE);
         int timeWindowInMinutes = instanceProperties.getInt(DASHBOARD_TIME_WINDOW_MINUTES);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2160

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - This doesn't seem worth a system test, and we can't test it any other way

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.