### PR TITLE
Issue 2296 - Run workflows to refresh/check Maven cache

### DIFF
--- a/.github/workflows/dependency-check-nightly.yaml
+++ b/.github/workflows/dependency-check-nightly.yaml
@@ -1,5 +1,6 @@
 name: Dependency Check Nightly
 on:
+  workflow_dispatch: # Allow manual running to refresh/check cache
   schedule:
     - cron: '0 2 * * *'
 

--- a/.github/workflows/maven-full.yaml
+++ b/.github/workflows/maven-full.yaml
@@ -1,5 +1,8 @@
 name: Full Maven Compile
 on:
+  workflow_dispatch: # Allow manual running to refresh/check cache
+  schedule: # Cache will never be created unless this is run on develop, so run it once per day
+    - cron: '0 2 * * *'
   pull_request:
     paths:
       - '.github/workflows/maven-full.yaml'


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2296

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Just workflow changes

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.