### PR TITLE
Issue 2327 - Log bad JSON when web socket message is missing a required field

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/QueryWebSocketClient.java
+++ b/java/clients/src/main/java/sleeper/clients/QueryWebSocketClient.java
@@ -279,12 +279,12 @@ public class QueryWebSocketClient {
                 JsonObject message = serde.fromJson(json, JsonObject.class);
                 if (!message.has("queryId")) {
                     queryFailed = true;
-                    future.completeExceptionally(new MessageMissingFieldException("queryId"));
+                    future.completeExceptionally(new MessageMissingFieldException("queryId", json));
                     return Optional.empty();
                 }
                 if (!message.has("message")) {
                     queryFailed = true;
-                    future.completeExceptionally(new MessageMissingFieldException("message"));
+                    future.completeExceptionally(new MessageMissingFieldException("message", json));
                     return Optional.empty();
                 }
                 return Optional.of(message);

--- a/java/clients/src/main/java/sleeper/clients/exception/MessageMissingFieldException.java
+++ b/java/clients/src/main/java/sleeper/clients/exception/MessageMissingFieldException.java
@@ -16,7 +16,7 @@
 package sleeper.clients.exception;
 
 public class MessageMissingFieldException extends WebSocketException {
-    public MessageMissingFieldException(String field) {
-        super("Message missing required field: " + field);
+    public MessageMissingFieldException(String field, String json) {
+        super("Message missing required field " + field + ": " + json);
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/QueryWebSocketCommandLineClientTest.java
+++ b/java/clients/src/test/java/sleeper/clients/QueryWebSocketCommandLineClientTest.java
@@ -394,7 +394,7 @@ public class QueryWebSocketCommandLineClientTest {
                             PROMPT_QUERY_TYPE +
                             PROMPT_EXACT_KEY_LONG_TYPE +
                             "Submitting query with ID: test-query-id\n" +
-                            "Query failed: Message missing required field: queryId\n" +
+                            "Query failed: Message missing required field queryId: {\"message\":\"error\"}\n" +
                             "Query took 1 second to return 0 records\n" +
                             PROMPT_QUERY_TYPE);
             assertThat(client.isConnected()).isFalse();
@@ -421,7 +421,7 @@ public class QueryWebSocketCommandLineClientTest {
                             PROMPT_QUERY_TYPE +
                             PROMPT_EXACT_KEY_LONG_TYPE +
                             "Submitting query with ID: test-query-id\n" +
-                            "Query failed: Message missing required field: message\n" +
+                            "Query failed: Message missing required field message: {\"queryId\":\"test-query-id\"}\n" +
                             "Query took 1 second to return 0 records\n" +
                             PROMPT_QUERY_TYPE);
             assertThat(client.isConnected()).isFalse();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2327

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.