### PR TITLE
Issue 2369 - Report on whether partitions will be split

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/status/report/partitions/PartitionsStatus.java
+++ b/java/clients/src/main/java/sleeper/clients/status/report/partitions/PartitionsStatus.java
@@ -65,10 +65,10 @@ public class PartitionsStatus {
         return partitions.stream().filter(PartitionStatus::isLeafPartition).count();
     }
 
-    public long getNumLeafPartitionsThatNeedSplitting() {
+    public long getNumLeafPartitionsThatWillBeSplit() {
         return partitions.stream()
                 .filter(PartitionStatus::isLeafPartition)
-                .filter(PartitionStatus::isNeedsSplitting)
+                .filter(PartitionStatus::willBeSplit)
                 .count();
     }
 

--- a/java/clients/src/test/java/sleeper/clients/admin/PartitionsStatusReportScreenTest.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/PartitionsStatusReportScreenTest.java
@@ -40,6 +40,7 @@ import static sleeper.clients.testutil.TestConsoleInput.CONFIRM_PROMPT;
 import static sleeper.clients.util.console.ConsoleOutput.CLEAR_CONSOLE;
 
 class PartitionsStatusReportScreenTest extends AdminClientMockStoreBase {
+
     @Test
     void shouldRunPartitionStatusReport() throws Exception {
         // Given
@@ -62,7 +63,7 @@ class PartitionsStatusReportScreenTest extends AdminClientMockStoreBase {
                 .endsWith(PROMPT_RETURN_TO_MAIN + CLEAR_CONSOLE + MAIN_SCREEN)
                 .contains("Partitions Status Report:")
                 .contains("There are 3 partitions (2 leaf partitions")
-                .contains("There are 0 leaf partitions that need splitting")
+                .contains("There are 0 leaf partitions that will be split")
                 .contains("Split threshold is 1000000000 records");
         confirmAndVerifyNoMoreInteractions();
     }

--- a/java/clients/src/test/java/sleeper/clients/status/report/partitions/PartitionsStatusTest.java
+++ b/java/clients/src/test/java/sleeper/clients/status/report/partitions/PartitionsStatusTest.java
@@ -82,7 +82,7 @@ class PartitionsStatusTest {
         PartitionsStatus status = PartitionsStatus.from(tableProperties, store);
 
         // Then
-        assertThat(status.getNumLeafPartitionsThatNeedSplitting()).isZero();
+        assertThat(status.getNumLeafPartitionsThatWillBeSplit()).isZero();
     }
 
     @Test
@@ -96,7 +96,7 @@ class PartitionsStatusTest {
         PartitionsStatus status = PartitionsStatus.from(tableProperties, store);
 
         // Then
-        assertThat(status.getNumLeafPartitionsThatNeedSplitting()).isEqualTo(2);
+        assertThat(status.getNumLeafPartitionsThatWillBeSplit()).isEqualTo(2);
     }
 
     @Test
@@ -113,7 +113,7 @@ class PartitionsStatusTest {
         PartitionsStatus status = PartitionsStatus.from(tableProperties, store);
 
         // Then
-        assertThat(status.getNumLeafPartitionsThatNeedSplitting()).isEqualTo(0);
+        assertThat(status.getNumLeafPartitionsThatWillBeSplit()).isEqualTo(0);
     }
 
     @Test

--- a/java/clients/src/test/resources/reports/partitions/noPartitions.txt
+++ b/java/clients/src/test/resources/reports/partitions/noPartitions.txt
@@ -2,8 +2,8 @@
 Partitions Status Report:
 --------------------------
 There are 0 partitions (0 leaf partitions)
-There are 0 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
----------------------------------------------------------------------------------------------------------------------------
-| ID | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
----------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------------------
+| ID | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+--------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/nonLeafPartitionRecordCountExceedsThreshold.txt
+++ b/java/clients/src/test/resources/reports/partitions/nonLeafPartitionRecordCountExceedsThreshold.txt
@@ -2,11 +2,11 @@
 Partitions Status Report:
 --------------------------
 There are 3 partitions (2 leaf partitions)
-There are 0 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
------------------------------------------------------------------------------------------------------------------------------
-| ID   | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
-| L    | root   | min         |     0 |              0 |             0 | yes  | no              |             |             |
-| R    | root   | max         |     0 |              0 |             0 | yes  | no              |             |             |
-| root |        |             |     1 |            100 |           100 | no   |                 | key         | abc         |
------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------
+| ID   | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+| L    | root   | min         |     0 |              0 |             0 | yes  | no            | yes                    |             |             |
+| R    | root   | max         |     0 |              0 |             0 | yes  | no            | yes                    |             |             |
+| root |        |             |     1 |            100 |           100 | no   |               |                        | key         | abc         |
+----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/rootWithNestedChildrenSplitOnDifferentFields.txt
+++ b/java/clients/src/test/resources/reports/partitions/rootWithNestedChildrenSplitOnDifferentFields.txt
@@ -2,13 +2,13 @@
 Partitions Status Report:
 --------------------------
 There are 5 partitions (3 leaf partitions)
-There are 0 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
--------------------------------------------------------------------------------------------------------------------------------
-| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
-| A      | parent | min         |     1 |              5 |             5 | yes  | no              |             |             |
-| C      | B      | min         |     1 |              5 |             5 | yes  | no              |             |             |
-| D      | B      | max         |     1 |              5 |             5 | yes  | no              |             |             |
-| B      | parent | max         |     0 |              0 |             0 | no   |                 | another-key | aaa         |
-| parent |        |             |     0 |              0 |             0 | no   |                 | first-key   | 123         |
--------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------------------------------------
+| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+| A      | parent | min         |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+| C      | B      | min         |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+| D      | B      | max         |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+| B      | parent | max         |     0 |              0 |             0 | no   |               |                        | another-key | aaa         |
+| parent |        |             |     0 |              0 |             0 | no   |               |                        | first-key   | 123         |
+------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/rootWithNoChildren.txt
+++ b/java/clients/src/test/resources/reports/partitions/rootWithNoChildren.txt
@@ -2,9 +2,9 @@
 Partitions Status Report:
 --------------------------
 There are 1 partitions (1 leaf partitions)
-There are 0 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
------------------------------------------------------------------------------------------------------------------------------
-| ID   | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
-| root |        |             |     1 |              5 |             5 | yes  | no              |             |             |
------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------
+| ID   | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+| root |        |             |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/rootWithTwoChildren.txt
+++ b/java/clients/src/test/resources/reports/partitions/rootWithTwoChildren.txt
@@ -2,11 +2,11 @@
 Partitions Status Report:
 --------------------------
 There are 3 partitions (2 leaf partitions)
-There are 0 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
--------------------------------------------------------------------------------------------------------------------------------
-| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
-| A      | parent | min         |     1 |              5 |             5 | yes  | no              |             |             |
-| B      | parent | max         |     1 |              5 |             5 | yes  | no              |             |             |
-| parent |        |             |     0 |              0 |             0 | no   |                 | key         | aaa         |
--------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------------------------------------
+| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+| A      | parent | min         |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+| B      | parent | max         |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+| parent |        |             |     0 |              0 |             0 | no   |               |                        | key         | aaa         |
+------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenBothNeedSplitting.txt
+++ b/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenBothNeedSplitting.txt
@@ -2,11 +2,11 @@
 Partitions Status Report:
 --------------------------
 There are 3 partitions (2 leaf partitions)
-There are 2 leaf partitions that need splitting
+There are 2 leaf partitions that will be split
 Split threshold is 10 records
--------------------------------------------------------------------------------------------------------------------------------
-| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
-| A      | parent | min         |     1 |            100 |           100 | yes  | yes             |             |             |
-| B      | parent | max         |     1 |            100 |           100 | yes  | yes             |             |             |
-| parent |        |             |     0 |              0 |             0 | no   |                 | key         | aaa         |
--------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------------------------------------
+| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+| A      | parent | min         |     1 |            100 |           100 | yes  | yes           |                        |             |             |
+| B      | parent | max         |     1 |            100 |           100 | yes  | yes           |                        |             |             |
+| parent |        |             |     0 |              0 |             0 | no   |               |                        | key         | aaa         |
+------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenSplitOnByteArray.txt
+++ b/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenSplitOnByteArray.txt
@@ -2,11 +2,11 @@
 Partitions Status Report:
 --------------------------
 There are 3 partitions (2 leaf partitions)
-There are 0 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
--------------------------------------------------------------------------------------------------------------------------------
-| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
-| A      | parent | min         |     1 |              5 |             5 | yes  | no              |             |             |
-| B      | parent | max         |     1 |              5 |             5 | yes  | no              |             |             |
-| parent |        |             |     0 |              0 |             0 | no   |                 | key         | [raw bytes] |
--------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------------------------------------
+| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+| A      | parent | min         |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+| B      | parent | max         |     1 |              5 |             5 | yes  | no            | no                     |             |             |
+| parent |        |             |     0 |              0 |             0 | no   |               |                        | key         | [raw bytes] |
+------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenSplitOnLongString.txt
+++ b/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenSplitOnLongString.txt
@@ -2,11 +2,11 @@
 Partitions Status Report:
 --------------------------
 There are 3 partitions (2 leaf partitions)
-There are 0 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
------------------------------------------------------------------------------------------------------------------------------------------------------
-| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE                       |
-| A      | parent | min         |     1 |              5 |             5 | yes  | no              |             |                                   |
-| B      | parent | max         |     1 |              5 |             5 | yes  | no              |             |                                   |
-| parent |        |             |     0 |              0 |             0 | no   |                 | key         | abcdefghijklmno...LMNOPQRSTUVWXYZ |
------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE                       |
+| A      | parent | min         |     1 |              5 |             5 | yes  | no            | no                     |             |                                   |
+| B      | parent | max         |     1 |              5 |             5 | yes  | no            | no                     |             |                                   |
+| parent |        |             |     0 |              0 |             0 | no   |               |                        | key         | abcdefghijklmno...LMNOPQRSTUVWXYZ |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenWithSplitFiles.txt
+++ b/java/clients/src/test/resources/reports/partitions/rootWithTwoChildrenWithSplitFiles.txt
@@ -2,11 +2,11 @@
 Partitions Status Report:
 --------------------------
 There are 3 partitions (2 leaf partitions)
-There are 2 leaf partitions that need splitting
+There are 0 leaf partitions that will be split
 Split threshold is 10 records
--------------------------------------------------------------------------------------------------------------------------------
-| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | NEEDS_SPLITTING | SPLIT_FIELD | SPLIT_VALUE |
-| A      | parent | min         |     2 |             10 |             5 | yes  | yes             |             |             |
-| B      | parent | max         |     2 |             10 |             5 | yes  | yes             |             |             |
-| parent |        |             |     0 |              0 |             0 | no   |                 | key         | aaa         |
--------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------------------------------------
+| ID     | PARENT | PARENT_SIDE | FILES | APPROX_RECORDS | KNOWN_RECORDS | LEAF | WILL_BE_SPLIT | MAY_SPLIT_IF_COMPACTED | SPLIT_FIELD | SPLIT_VALUE |
+| A      | parent | min         |     2 |             10 |             5 | yes  | no            | yes                    |             |             |
+| B      | parent | max         |     2 |             10 |             5 | yes  | no            | yes                    |             |             |
+| parent |        |             |     0 |              0 |             0 | no   |               |                        | key         | aaa         |
+------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/java/core/src/test/java/sleeper/core/partition/PartitionTreeTest.java
+++ b/java/core/src/test/java/sleeper/core/partition/PartitionTreeTest.java
@@ -216,10 +216,10 @@ public class PartitionTreeTest {
         List<String> ancestorsOfL2LOfL1LIds = partitionTree.getAllAncestorIds(L2_LEFT_OF_L1L);
 
         // Then
-        assertThat(ancestorsOfRoot).isEmpty();
         assertThat(ancestorsOfRootIds).isEmpty();
-        assertThat(ancestorsOfL2LOfL1L).containsExactly(l1Left, root);
+        assertThat(ancestorsOfRoot).isEmpty();
         assertThat(ancestorsOfL2LOfL1LIds).containsExactly(l1Left.getId(), root.getId());
+        assertThat(ancestorsOfL2LOfL1L).containsExactly(l1Left, root);
     }
 
     @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2369

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated partition reporting tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.