### PR TITLE
Issue 2400 - Disable transaction log state store snapshots by class name

### DIFF
--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -118,17 +118,16 @@ sleeper.table.compaction.strategy.sizeratio.max.concurrent.jobs.per.partition=21
 
 ## The following table properties relate to storing and retrieving metadata for tables.
 
-# The name of the class used for the metadata store. The default is S3StateStore. An alternative
-# option is the DynamoDBStateStore.
+# The name of the class used for the metadata store. The default is S3StateStore. Options are:
+# sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore
+# sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoSnapshots
+# sleeper.statestore.s3.S3StateStore
+# sleeper.statestore.dynamodb.DynamoDBStateStore
 sleeper.table.statestore.classname=sleeper.statestore.s3.S3StateStore
 
 # This specifies whether queries and scans against DynamoDB tables used in the state stores are
 # strongly consistent.
 sleeper.table.metadata.dynamo.consistent.reads=false
-
-# If set, the transaction log state store will load the latest snapshot from the snapshot store when
-# created.
-sleeper.table.metadata.transactionlog.load.latest.snapshots=true
 
 
 ## The following table properties relate to ingest.

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
@@ -55,7 +55,6 @@ import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_ROW_GROUP_SIZE;
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_S3A_READAHEAD_RANGE;
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_STATISTICS_TRUNCATE_LENGTH;
-import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_TRANSACTION_LOG_LOAD_LATEST_SNAPSHOTS;
 import static sleeper.configuration.properties.instance.GarbageCollectionProperty.DEFAULT_GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.configuration.properties.instance.NonPersistentEMRProperty.DEFAULT_BULK_IMPORT_EMR_EXECUTOR_ARM_INSTANCE_TYPES;
 import static sleeper.configuration.properties.instance.NonPersistentEMRProperty.DEFAULT_BULK_IMPORT_EMR_EXECUTOR_MARKET_TYPE;
@@ -232,19 +231,18 @@ public interface TableProperty extends SleeperProperty {
             .build();
     TableProperty STATESTORE_CLASSNAME = Index.propertyBuilder("sleeper.table.statestore.classname")
             .defaultValue("sleeper.statestore.s3.S3StateStore")
-            .description("The name of the class used for the metadata store. The default is S3StateStore. " +
-                    "An alternative option is the DynamoDBStateStore.")
+            .description("The name of the class used for the metadata store. " +
+                    "The default is S3StateStore. Options are:\n" +
+                    "sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore\n" +
+                    "sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoSnapshots\n" +
+                    "sleeper.statestore.s3.S3StateStore\n" +
+                    "sleeper.statestore.dynamodb.DynamoDBStateStore")
             .propertyGroup(TablePropertyGroup.METADATA)
             .editable(false).build();
     TableProperty DYNAMODB_STRONGLY_CONSISTENT_READS = Index.propertyBuilder("sleeper.table.metadata.dynamo.consistent.reads")
             .defaultProperty(DEFAULT_DYNAMO_STRONGLY_CONSISTENT_READS)
             .description("This specifies whether queries and scans against DynamoDB tables used in the state stores " +
                     "are strongly consistent.")
-            .propertyGroup(TablePropertyGroup.METADATA)
-            .build();
-    TableProperty TRANSACTION_LOG_LOAD_LATEST_SNAPSHOTS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.load.latest.snapshots")
-            .defaultProperty(DEFAULT_TRANSACTION_LOG_LOAD_LATEST_SNAPSHOTS)
-            .description("If set, the transaction log state store will load the latest snapshot from the snapshot store when created.")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
     TableProperty BULK_IMPORT_EMR_INSTANCE_ARCHITECTURE = Index.propertyBuilder("sleeper.table.bulk.import.emr.instance.architecture")

--- a/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
+++ b/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
@@ -25,6 +25,7 @@ import sleeper.core.statestore.StateStore;
 import sleeper.statestore.dynamodb.DynamoDBStateStore;
 import sleeper.statestore.s3.S3StateStore;
 import sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore;
+import sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoShapshots;
 
 import static sleeper.configuration.properties.table.TableProperty.STATESTORE_CLASSNAME;
 
@@ -50,7 +51,10 @@ public class StateStoreFactory {
             return new S3StateStore(instanceProperties, tableProperties, dynamoDB, configuration);
         }
         if (stateStoreClassName.equals(DynamoDBTransactionLogStateStore.class.getName())) {
-            return new DynamoDBTransactionLogStateStore(instanceProperties, tableProperties, dynamoDB, s3, configuration);
+            return DynamoDBTransactionLogStateStore.create(instanceProperties, tableProperties, dynamoDB, s3, configuration);
+        }
+        if (stateStoreClassName.equals(DynamoDBTransactionLogStateStoreNoShapshots.class.getName())) {
+            return DynamoDBTransactionLogStateStoreNoShapshots.create(instanceProperties, tableProperties, dynamoDB, s3);
         }
         throw new RuntimeException("Unknown StateStore class: " + stateStoreClassName);
     }

--- a/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
+++ b/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
@@ -25,7 +25,7 @@ import sleeper.core.statestore.StateStore;
 import sleeper.statestore.dynamodb.DynamoDBStateStore;
 import sleeper.statestore.s3.S3StateStore;
 import sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore;
-import sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoShapshots;
+import sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoSnapshots;
 
 import static sleeper.configuration.properties.table.TableProperty.STATESTORE_CLASSNAME;
 
@@ -53,8 +53,8 @@ public class StateStoreFactory {
         if (stateStoreClassName.equals(DynamoDBTransactionLogStateStore.class.getName())) {
             return DynamoDBTransactionLogStateStore.create(instanceProperties, tableProperties, dynamoDB, s3, configuration);
         }
-        if (stateStoreClassName.equals(DynamoDBTransactionLogStateStoreNoShapshots.class.getName())) {
-            return DynamoDBTransactionLogStateStoreNoShapshots.create(instanceProperties, tableProperties, dynamoDB, s3);
+        if (stateStoreClassName.equals(DynamoDBTransactionLogStateStoreNoSnapshots.class.getName())) {
+            return DynamoDBTransactionLogStateStoreNoSnapshots.create(instanceProperties, tableProperties, dynamoDB, s3);
         }
         throw new RuntimeException("Unknown StateStore class: " + stateStoreClassName);
     }

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
@@ -39,7 +39,7 @@ public class DynamoDBTransactionLogStateStore {
 
     public static TransactionLogStateStore.Builder builderFrom(
             InstanceProperties instanceProperties, TableProperties tableProperties, AmazonDynamoDB dynamoDB, AmazonS3 s3, Configuration configuration) {
-        TransactionLogStateStore.Builder builder = DynamoDBTransactionLogStateStoreNoShapshots.builderFrom(instanceProperties, tableProperties, dynamoDB, s3);
+        TransactionLogStateStore.Builder builder = DynamoDBTransactionLogStateStoreNoSnapshots.builderFrom(instanceProperties, tableProperties, dynamoDB, s3);
         loadLatestSnapshots(builder, instanceProperties, tableProperties, dynamoDB, configuration);
         return builder;
     }

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
@@ -25,8 +25,6 @@ import sleeper.core.statestore.transactionlog.TransactionLogStateStore;
 
 import java.io.IOException;
 
-import static sleeper.configuration.properties.table.TableProperty.TRANSACTION_LOG_LOAD_LATEST_SNAPSHOTS;
-
 public class DynamoDBTransactionLogStateStore {
     public static final String TABLE_ID = "TABLE_ID";
     public static final String TRANSACTION_NUMBER = "TRANSACTION_NUMBER";
@@ -42,9 +40,7 @@ public class DynamoDBTransactionLogStateStore {
     public static TransactionLogStateStore.Builder builderFrom(
             InstanceProperties instanceProperties, TableProperties tableProperties, AmazonDynamoDB dynamoDB, AmazonS3 s3, Configuration configuration) {
         TransactionLogStateStore.Builder builder = DynamoDBTransactionLogStateStoreNoShapshots.builderFrom(instanceProperties, tableProperties, dynamoDB, s3);
-        if (tableProperties.getBoolean(TRANSACTION_LOG_LOAD_LATEST_SNAPSHOTS)) {
-            loadLatestSnapshots(builder, instanceProperties, tableProperties, dynamoDB, configuration);
-        }
+        loadLatestSnapshots(builder, instanceProperties, tableProperties, dynamoDB, configuration);
         return builder;
     }
 

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
@@ -25,26 +25,23 @@ import sleeper.core.statestore.transactionlog.TransactionLogStateStore;
 
 import java.io.IOException;
 
-import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_FILES_TABLENAME;
-import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_PARTITIONS_TABLENAME;
 import static sleeper.configuration.properties.table.TableProperty.TRANSACTION_LOG_LOAD_LATEST_SNAPSHOTS;
 
-public class DynamoDBTransactionLogStateStore extends TransactionLogStateStore {
+public class DynamoDBTransactionLogStateStore {
     public static final String TABLE_ID = "TABLE_ID";
     public static final String TRANSACTION_NUMBER = "TRANSACTION_NUMBER";
 
-    public DynamoDBTransactionLogStateStore(
+    private DynamoDBTransactionLogStateStore() {
+    }
+
+    public static TransactionLogStateStore create(
             InstanceProperties instanceProperties, TableProperties tableProperties, AmazonDynamoDB dynamoDB, AmazonS3 s3, Configuration configuration) {
-        super(builderFrom(instanceProperties, tableProperties, dynamoDB, s3, configuration));
+        return builderFrom(instanceProperties, tableProperties, dynamoDB, s3, configuration).build();
     }
 
     public static TransactionLogStateStore.Builder builderFrom(
             InstanceProperties instanceProperties, TableProperties tableProperties, AmazonDynamoDB dynamoDB, AmazonS3 s3, Configuration configuration) {
-        Builder builder = builder()
-                .sleeperTable(tableProperties.getStatus())
-                .schema(tableProperties.getSchema())
-                .filesLogStore(new DynamoDBTransactionLogStore(instanceProperties.get(TRANSACTION_LOG_FILES_TABLENAME), instanceProperties, tableProperties, dynamoDB, s3))
-                .partitionsLogStore(new DynamoDBTransactionLogStore(instanceProperties.get(TRANSACTION_LOG_PARTITIONS_TABLENAME), instanceProperties, tableProperties, dynamoDB, s3));
+        TransactionLogStateStore.Builder builder = DynamoDBTransactionLogStateStoreNoShapshots.builderFrom(instanceProperties, tableProperties, dynamoDB, s3);
         if (tableProperties.getBoolean(TRANSACTION_LOG_LOAD_LATEST_SNAPSHOTS)) {
             loadLatestSnapshots(builder, instanceProperties, tableProperties, dynamoDB, configuration);
         }

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStoreNoShapshots.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStoreNoShapshots.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.statestore.transactionlog;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.s3.AmazonS3;
+
+import sleeper.configuration.properties.instance.InstanceProperties;
+import sleeper.configuration.properties.table.TableProperties;
+import sleeper.core.statestore.transactionlog.TransactionLogStateStore;
+
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_FILES_TABLENAME;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_PARTITIONS_TABLENAME;
+
+public class DynamoDBTransactionLogStateStoreNoShapshots {
+
+    private DynamoDBTransactionLogStateStoreNoShapshots() {
+    }
+
+    public static TransactionLogStateStore create(
+            InstanceProperties instanceProperties, TableProperties tableProperties,
+            AmazonDynamoDB dynamoDB, AmazonS3 s3) {
+        return builderFrom(instanceProperties, tableProperties, dynamoDB, s3).build();
+    }
+
+    public static TransactionLogStateStore.Builder builderFrom(
+            InstanceProperties instanceProperties, TableProperties tableProperties,
+            AmazonDynamoDB dynamoDB, AmazonS3 s3) {
+        return TransactionLogStateStore.builder()
+                .sleeperTable(tableProperties.getStatus())
+                .schema(tableProperties.getSchema())
+                .filesLogStore(new DynamoDBTransactionLogStore(instanceProperties.get(TRANSACTION_LOG_FILES_TABLENAME), instanceProperties, tableProperties, dynamoDB, s3))
+                .partitionsLogStore(new DynamoDBTransactionLogStore(instanceProperties.get(TRANSACTION_LOG_PARTITIONS_TABLENAME), instanceProperties, tableProperties, dynamoDB, s3));
+    }
+
+}

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStoreNoSnapshots.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStoreNoSnapshots.java
@@ -25,9 +25,9 @@ import sleeper.core.statestore.transactionlog.TransactionLogStateStore;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_FILES_TABLENAME;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_PARTITIONS_TABLENAME;
 
-public class DynamoDBTransactionLogStateStoreNoShapshots {
+public class DynamoDBTransactionLogStateStoreNoSnapshots {
 
-    private DynamoDBTransactionLogStateStoreNoShapshots() {
+    private DynamoDBTransactionLogStateStoreNoSnapshots() {
     }
 
     public static TransactionLogStateStore create(

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreDynamoDBSpecificIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreDynamoDBSpecificIT.java
@@ -139,7 +139,7 @@ public class TransactionLogStateStoreDynamoDBSpecificIT extends TransactionLogSt
         @Test
         void shouldNotLoadLatestSnapshotsByClassname() throws Exception {
             // Given
-            tableProperties.set(STATESTORE_CLASSNAME, DynamoDBTransactionLogStateStoreNoShapshots.class.getName());
+            tableProperties.set(STATESTORE_CLASSNAME, DynamoDBTransactionLogStateStoreNoSnapshots.class.getName());
             PartitionTree tree = new PartitionsBuilder(schema)
                     .rootFirst("root")
                     .splitToNewChildren("root", "L", "R", 123L)

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreTestBase.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreTestBase.java
@@ -64,6 +64,6 @@ public class TransactionLogStateStoreTestBase {
     }
 
     public StateStore createStateStore(TableProperties tableProperties) {
-        return new DynamoDBTransactionLogStateStore(instanceProperties, tableProperties, dynamoDBClient, s3Client, configuration);
+        return DynamoDBTransactionLogStateStore.create(instanceProperties, tableProperties, dynamoDBClient, s3Client, configuration);
     }
 }

--- a/scripts/templates/tableproperties.template
+++ b/scripts/templates/tableproperties.template
@@ -33,6 +33,9 @@ sleeper.table.gc.delay.minutes=15
 
 ## The following table properties relate to storing and retrieving metadata for tables.
 
-# The name of the class used for the metadata store. The default is S3StateStore. An alternative
-# option is the DynamoDBStateStore.
+# The name of the class used for the metadata store. The default is S3StateStore. Options are:
+# sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore
+# sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoSnapshots
+# sleeper.statestore.s3.S3StateStore
+# sleeper.statestore.dynamodb.DynamoDBStateStore
 sleeper.table.statestore.classname=sleeper.statestore.s3.S3StateStore


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2400

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated TransactionLogStateStoreDynamoDBSpecificIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.