### PR TITLE
Issue 2422 - Handle files in partitions that no longer exist in FilesStatusReport

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/status/report/filestatus/TableFilesStatistics.java
+++ b/java/clients/src/main/java/sleeper/clients/status/report/filestatus/TableFilesStatistics.java
@@ -39,9 +39,11 @@ public class TableFilesStatistics {
                 .flatMap(file -> file.getInternalReferences().stream())
                 .collect(Collectors.toUnmodifiableList());
         List<FileReference> fileReferencesInLeafPartitions = fileReferences.stream()
+                .filter(f -> partitionById.containsKey(f.getPartitionId()))
                 .filter(f -> partitionById.get(f.getPartitionId()).isLeafPartition())
                 .collect(Collectors.toList());
         List<FileReference> fileReferencesInNonLeafPartitions = fileReferences.stream()
+                .filter(f -> partitionById.containsKey(f.getPartitionId()))
                 .filter(f -> !partitionById.get(f.getPartitionId()).isLeafPartition())
                 .collect(Collectors.toList());
 

--- a/java/clients/src/test/resources/reports/filestatus/json/fileWithPartitionThatNoLongerExists.json
+++ b/java/clients/src/test/resources/reports/filestatus/json/fileWithPartitionThatNoLongerExists.json
@@ -1,0 +1,64 @@
+{
+    "moreThanMax": false,
+    "leafPartitionCount": 1,
+    "nonLeafPartitionCount": 0,
+    "statistics": {
+        "records": {
+            "allPartitions": {
+                "totalRecords": 3000,
+                "totalRecordsApprox": 0,
+                "totalRecordsKnown": 3000
+            },
+            "leafPartitions": {
+                "totalRecords": 0,
+                "totalRecordsApprox": 0,
+                "totalRecordsKnown": 0
+            },
+            "nonLeafPartitions": {
+                "totalRecords": 0,
+                "totalRecordsApprox": 0,
+                "totalRecordsKnown": 0
+            }
+        },
+        "fileReferences": {
+            "totalFiles": 2,
+            "totalReferences": 2,
+            "leafPartitions": {
+                "totalReferences": 0
+            },
+            "nonLeafPartitions": {
+                "totalReferences": 0
+            }
+        }
+    },
+    "files": [
+        {
+            "filename": "file1.parquet",
+            "lastUpdateTime": "2022-08-22T14:20:00.001Z",
+            "totalReferenceCount": 1,
+            "internalReferences": [
+                {
+                    "partitionId": "A",
+                    "numberOfRecords": 1000,
+                    "lastUpdateTime": "2022-08-22T14:20:00.001Z",
+                    "countApproximate": false,
+                    "onlyContainsDataForThisPartition": true
+                }
+            ]
+        },
+        {
+            "filename": "file2.parquet",
+            "lastUpdateTime": "2022-08-22T14:20:00.001Z",
+            "totalReferenceCount": 1,
+            "internalReferences": [
+                {
+                    "partitionId": "A",
+                    "numberOfRecords": 2000,
+                    "lastUpdateTime": "2022-08-22T14:20:00.001Z",
+                    "countApproximate": false,
+                    "onlyContainsDataForThisPartition": true
+                }
+            ]
+        }
+    ]
+}

--- a/java/clients/src/test/resources/reports/filestatus/standard/fileWithPartitionThatNoLongerExists.txt
+++ b/java/clients/src/test/resources/reports/filestatus/standard/fileWithPartitionThatNoLongerExists.txt
@@ -1,0 +1,22 @@
+
+Files Status Report:
+--------------------------
+There are 1 leaf partitions and 0 non-leaf partitions
+Number of files: 2
+Number of files with references: 2
+Number of files with no references, which will be garbage collected: 0
+Number of references to files: 2
+Number of file references in leaf partitions: 0
+Number of file references in non-leaf partitions: 0
+Number of records referenced in partitions: 3K (3,000)
+Number of records in non-leaf partitions: 0
+Number of records in leaf partitions: 0
+Percentage of records in leaf partitions: 0.0
+
+Files with no references: none
+
+Files with references:
+file1.parquet, 1 reference total, last updated at 2022-08-22T14:20:00.001Z
+	Reference in partition A, 1000 records, last updated at 2022-08-22T14:20:00.001Z
+file2.parquet, 1 reference total, last updated at 2022-08-22T14:20:00.001Z
+	Reference in partition A, 2000 records, last updated at 2022-08-22T14:20:00.001Z


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2422

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - FilesStatusReportTest.shouldReportFilesStatusWhenPartitionsNoLongerExist

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.