### PR TITLE
Issue 2467 - Assume ingest roles in system test cluster

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/util/AssumeSleeperRole.java
+++ b/java/clients/src/main/java/sleeper/clients/util/AssumeSleeperRole.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.instance.InstanceProperty;
@@ -79,6 +80,15 @@ public class AssumeSleeperRole {
             AWSSecurityTokenService sts, InstanceProperties instanceProperties, InstanceProperty roleArnProperty) {
         String region = instanceProperties.get(REGION);
         String roleArn = instanceProperties.get(roleArnProperty);
+        return fromRegionAndArn(sts, region, roleArn);
+    }
+
+    public static AssumeSleeperRole fromArn(AWSSecurityTokenService sts, String roleArn) {
+        String region = new DefaultAwsRegionProviderChain().getRegion().id();
+        return fromRegionAndArn(sts, region, roleArn);
+    }
+
+    public static AssumeSleeperRole fromRegionAndArn(AWSSecurityTokenService sts, String region, String roleArn) {
         LOGGER.info("Assuming instance role: {}", roleArn);
         AssumeRoleResult result = sts.assumeRole(new AssumeRoleRequest()
                 .withRoleArn(roleArn)

--- a/java/clients/src/main/java/sleeper/clients/util/AssumeSleeperRole.java
+++ b/java/clients/src/main/java/sleeper/clients/util/AssumeSleeperRole.java
@@ -100,7 +100,7 @@ public class AssumeSleeperRole {
         return builder.credentialsProvider(credentialsV2).region(Region.of(region)).build();
     }
 
-    public Configuration setInHadoopForS3A(Configuration configuration) {
+    public Configuration setS3ACredentials(Configuration configuration) {
         configuration.set("fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider");
         configuration.set("fs.s3a.access.key", credentials.getAccessKeyId());
         configuration.set("fs.s3a.secret.key", credentials.getSecretAccessKey());

--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
@@ -63,7 +63,6 @@ import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_RE
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_TASK_CPU;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_TASK_MEMORY;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_VPC_ID;
-import static sleeper.systemtest.configuration.SystemTestProperty.WRITE_DATA_ROLE_NAME;
 import static sleeper.systemtest.configuration.SystemTestProperty.WRITE_DATA_TASK_DEFINITION_FAMILY;
 
 public class SystemTestClusterStack extends NestedStack {
@@ -119,7 +118,6 @@ public class SystemTestClusterStack extends NestedStack {
                 .build();
         IRole taskRole = taskDefinition.getTaskRole();
         propertySetter.set(WRITE_DATA_TASK_DEFINITION_FAMILY, taskDefinition.getFamily());
-        propertySetter.set(WRITE_DATA_ROLE_NAME, taskRole.getRoleName());
         CfnOutputProps taskDefinitionFamilyOutputProps = new CfnOutputProps.Builder()
                 .value(taskDefinition.getFamily())
                 .build();

--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
@@ -68,8 +68,6 @@ import static sleeper.systemtest.configuration.SystemTestProperty.WRITE_DATA_TAS
 
 public class SystemTestClusterStack extends NestedStack {
 
-    private IRole taskRole;
-
     public SystemTestClusterStack(
             Construct scope, String id, SystemTestStandaloneProperties properties, SystemTestBucketStack bucketStack) {
         super(scope, id);
@@ -88,12 +86,6 @@ public class SystemTestClusterStack extends NestedStack {
             CoreStacks coreStacks, IngestStacks ingestStacks, IngestBatcherStack ingestBatcherStack) {
         super(scope, id);
         createSystemTestCluster(properties.testPropertiesOnly(), properties::set, properties, bucketStack);
-
-        coreStacks.grantIngest(taskRole);
-        ingestStacks.ingestQueues().forEach(queue -> queue.grantSendMessages(taskRole));
-        if (null != ingestBatcherStack) {
-            ingestBatcherStack.getSubmitQueue().grantSendMessages(taskRole);
-        }
         Utils.addStackTagIfSet(this, properties);
     }
 
@@ -125,7 +117,7 @@ public class SystemTestClusterStack extends NestedStack {
                 .cpu(properties.getInt(SYSTEM_TEST_TASK_CPU))
                 .memoryLimitMiB(properties.getInt(SYSTEM_TEST_TASK_MEMORY))
                 .build();
-        taskRole = taskDefinition.getTaskRole();
+        IRole taskRole = taskDefinition.getTaskRole();
         propertySetter.set(WRITE_DATA_TASK_DEFINITION_FAMILY, taskDefinition.getFamily());
         propertySetter.set(WRITE_DATA_ROLE_NAME, taskRole.getRoleName());
         CfnOutputProps taskDefinitionFamilyOutputProps = new CfnOutputProps.Builder()

--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
@@ -29,7 +29,9 @@ import software.amazon.awscdk.services.ecs.Cluster;
 import software.amazon.awscdk.services.ecs.ContainerDefinitionOptions;
 import software.amazon.awscdk.services.ecs.ContainerImage;
 import software.amazon.awscdk.services.ecs.FargateTaskDefinition;
+import software.amazon.awscdk.services.iam.Effect;
 import software.amazon.awscdk.services.iam.IRole;
+import software.amazon.awscdk.services.iam.PolicyStatement;
 import software.amazon.awscdk.services.s3.Bucket;
 import software.constructs.Construct;
 
@@ -45,6 +47,7 @@ import sleeper.systemtest.configuration.SystemTestPropertySetter;
 import sleeper.systemtest.configuration.SystemTestPropertyValues;
 import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
 
+import java.util.List;
 import java.util.Locale;
 
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
@@ -142,6 +145,11 @@ public class SystemTestClusterStack extends NestedStack {
 
         Bucket.fromBucketName(this, "JarsBucket", instanceProperties.get(JARS_BUCKET)).grantRead(taskRole);
         bucketStack.getBucket().grantReadWrite(taskRole);
+        taskRole.addToPrincipalPolicy(PolicyStatement.Builder.create()
+                .effect(Effect.ALLOW)
+                .actions(List.of("sts:AssumeRole"))
+                .resources(List.of("arn:aws:iam::*:role/sleeper-ingest-*"))
+                .build());
     }
 
     public static String generateSystemTestClusterName(String instanceId) {

--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
@@ -63,9 +63,6 @@ public interface SystemTestProperty extends InstanceProperty {
     SystemTestProperty WRITE_DATA_TASK_DEFINITION_FAMILY = Index.propertyBuilder("sleeper.systemtest.task.definition")
             .description("The name of the family of task definitions used for writing data")
             .setByCdk(true).build();
-    SystemTestProperty WRITE_DATA_ROLE_NAME = Index.propertyBuilder("sleeper.systemtest.writer.role")
-            .description("The name of the role used when writing data for an instance in an ECS cluster")
-            .setByCdk(true).build();
     SystemTestProperty SYSTEM_TEST_TASK_CPU = Index.propertyBuilder("sleeper.systemtest.task.cpu")
             .description("The number of CPU units for the containers that write random data, where 1024 is 1 vCPU.\n" +
                     "For valid values, see: " +

--- a/java/system-test/system-test-data-generation/pom.xml
+++ b/java/system-test/system-test-data-generation/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>ingest-batcher-submitter</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>sleeper</groupId>
+            <artifactId>clients</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/AssumedRoleClients.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/AssumedRoleClients.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.datageneration;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import org.apache.hadoop.conf.Configuration;
+
+import sleeper.clients.util.AssumeSleeperRole;
+import sleeper.configuration.properties.instance.InstanceProperties;
+import sleeper.configuration.properties.table.TableProperties;
+import sleeper.configuration.properties.table.TablePropertiesProvider;
+import sleeper.io.parquet.utils.HadoopConfigurationProvider;
+import sleeper.statestore.StateStoreProvider;
+
+public class AssumedRoleClients implements AutoCloseable {
+    private final AmazonS3 s3;
+    private final AmazonDynamoDB dynamo;
+    private final AmazonSQS sqs;
+    private final Configuration hadoopConfiguration;
+    private final InstanceProperties instanceProperties;
+    private final TableProperties tableProperties;
+
+    public AssumedRoleClients(AssumeSleeperRole role, InstanceProperties instanceProperties, String tableName) {
+        this.s3 = role.v1Client(AmazonS3ClientBuilder.standard());
+        this.dynamo = role.v1Client(AmazonDynamoDBClientBuilder.standard());
+        this.sqs = role.v1Client(AmazonSQSClientBuilder.standard());
+        this.hadoopConfiguration = role.setInHadoopForS3A(HadoopConfigurationProvider.getConfigurationForECS(instanceProperties));
+        this.instanceProperties = instanceProperties;
+        this.tableProperties = new TablePropertiesProvider(instanceProperties, s3, dynamo)
+                .getByName(tableName);
+    }
+
+    public AmazonS3 s3() {
+        return s3;
+    }
+
+    public AmazonDynamoDB dynamo() {
+        return dynamo;
+    }
+
+    public AmazonSQS sqs() {
+        return sqs;
+    }
+
+    public Configuration hadoopConfiguration() {
+        return hadoopConfiguration;
+    }
+
+    public InstanceProperties instanceProperties() {
+        return instanceProperties;
+    }
+
+    public TableProperties tableProperties() {
+        return tableProperties;
+    }
+
+    public StateStoreProvider createStateStoreProvider() {
+        return new StateStoreProvider(instanceProperties, s3, dynamo, hadoopConfiguration);
+    }
+
+    @Override
+    public void close() {
+        s3.shutdown();
+        dynamo.shutdown();
+        sqs.shutdown();
+    }
+}

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomData.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomData.java
@@ -19,9 +19,13 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import sleeper.clients.util.AssumeSleeperRole;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
@@ -51,19 +55,17 @@ public class IngestRandomData {
     private static final Logger LOGGER = LoggerFactory.getLogger(IngestRandomData.class);
 
     private final InstanceProperties instanceProperties;
-    private final TableProperties tableProperties;
     private final SystemTestPropertyValues systemTestProperties;
-    private final AmazonS3 s3Client;
-    private final AmazonDynamoDB dynamoClient;
+    private final String tableName;
+    private final AWSSecurityTokenService stsClient;
 
     private IngestRandomData(
-            InstanceProperties instanceProperties, TableProperties tableProperties,
-            SystemTestPropertyValues systemTestProperties, AmazonS3 s3Client, AmazonDynamoDB dynamoClient) {
+            InstanceProperties instanceProperties, SystemTestPropertyValues systemTestProperties, String tableName,
+            AWSSecurityTokenService stsClient) {
         this.instanceProperties = instanceProperties;
-        this.tableProperties = tableProperties;
         this.systemTestProperties = systemTestProperties;
-        this.s3Client = s3Client;
-        this.dynamoClient = dynamoClient;
+        this.tableName = tableName;
+        this.stsClient = stsClient;
     }
 
     public void run() throws IOException {
@@ -82,6 +84,7 @@ public class IngestRandomData {
         SystemTestPropertyValues systemTestProperties;
         AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
         AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.defaultClient();
+        AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.defaultClient();
         try {
             if (args.length == 2) {
                 SystemTestProperties properties = new SystemTestProperties();
@@ -95,45 +98,69 @@ public class IngestRandomData {
             } else {
                 throw new RuntimeException("Wrong number of arguments detected. Usage: IngestRandomData <S3 bucket> <Table name> <optional system test bucket>");
             }
-            TableProperties tableProperties = new TablePropertiesProvider(instanceProperties, s3Client, dynamoClient)
-                    .getByName(args[1]);
 
-            new IngestRandomData(instanceProperties, tableProperties, systemTestProperties, s3Client, dynamoClient)
+            new IngestRandomData(instanceProperties, systemTestProperties, args[1], stsClient)
                     .run();
         } finally {
             s3Client.shutdown();
             dynamoClient.shutdown();
+            stsClient.shutdown();
         }
     }
 
     private Ingester ingester() {
         SystemTestIngestMode ingestMode = systemTestProperties.getEnumValue(INGEST_MODE, SystemTestIngestMode.class);
         if (ingestMode == DIRECT) {
-            StateStoreProvider stateStoreProvider = new StateStoreProvider(instanceProperties, s3Client,
-                    dynamoClient, HadoopConfigurationProvider.getConfigurationForECS(instanceProperties));
-            return () -> WriteRandomDataDirect.writeWithIngestFactory(instanceProperties, tableProperties, systemTestProperties, stateStoreProvider);
+            return () -> {
+                AssumeSleeperRole assumeRole = AssumeSleeperRole.directIngest(stsClient, instanceProperties);
+                AmazonS3 s3Client = assumeRole.v1Client(AmazonS3ClientBuilder.standard());
+                AmazonDynamoDB dynamoClient = assumeRole.v1Client(AmazonDynamoDBClientBuilder.standard());
+                Configuration conf = assumeRole.setInHadoopForS3A(HadoopConfigurationProvider.getConfigurationForECS(instanceProperties));
+                try {
+                    TableProperties tableProperties = tableProperties(s3Client, dynamoClient);
+                    StateStoreProvider stateStoreProvider = new StateStoreProvider(instanceProperties, s3Client, dynamoClient, conf);
+                    WriteRandomDataDirect.writeWithIngestFactory(instanceProperties, tableProperties, systemTestProperties, stateStoreProvider);
+                } finally {
+                    s3Client.shutdown();
+                    dynamoClient.shutdown();
+                }
+            };
         }
-        FileIngester ingestFromFile;
-        if (ingestMode == QUEUE) {
-            ingestFromFile = (jobId, dir) -> IngestRandomDataViaQueue.sendJob(
-                    jobId, dir, instanceProperties, tableProperties, systemTestProperties);
-        } else if (ingestMode == BATCHER) {
-            ingestFromFile = (jobId, dir) -> IngestRandomDataViaBatcher.sendRequest(dir, instanceProperties, tableProperties);
-        } else if (ingestMode == GENERATE_ONLY) {
-            ingestFromFile = (jobId, dir) -> LOGGER.debug("Generate data only, no message was sent");
-        } else {
-            throw new IllegalArgumentException("Unrecognised ingest mode: " + ingestMode);
+        AssumeSleeperRole assumeRole = AssumeSleeperRole.ingestByQueue(stsClient, instanceProperties);
+        AmazonS3 s3Client = assumeRole.v1Client(AmazonS3ClientBuilder.standard());
+        AmazonDynamoDB dynamoClient = assumeRole.v1Client(AmazonDynamoDBClientBuilder.standard());
+        try {
+            TableProperties tableProperties = tableProperties(s3Client, dynamoClient);
+            FileIngester ingestFromFile;
+            if (ingestMode == QUEUE) {
+                ingestFromFile = (jobId, dir) -> IngestRandomDataViaQueue.sendJob(
+                        jobId, dir, instanceProperties, tableProperties, systemTestProperties);
+            } else if (ingestMode == BATCHER) {
+                ingestFromFile = (jobId, dir) -> IngestRandomDataViaBatcher.sendRequest(dir, instanceProperties, tableProperties);
+            } else if (ingestMode == GENERATE_ONLY) {
+                ingestFromFile = (jobId, dir) -> LOGGER.debug("Generate data only, no message was sent");
+            } else {
+                throw new IllegalArgumentException("Unrecognised ingest mode: " + ingestMode);
+            }
+            return writeRandomFileAnd(tableProperties, ingestFromFile);
+        } finally {
+            s3Client.shutdown();
+            dynamoClient.shutdown();
         }
-        return writeRandomFileAnd(ingestFromFile);
     }
 
-    private Ingester writeRandomFileAnd(FileIngester ingester) {
+    private Ingester writeRandomFileAnd(TableProperties tableProperties, FileIngester ingester) {
         return () -> {
             String jobId = UUID.randomUUID().toString();
             String dir = WriteRandomDataFiles.writeToS3GetDirectory(
                     instanceProperties, tableProperties, systemTestProperties, jobId);
             ingester.ingest(jobId, dir);
         };
+    }
+
+    private TableProperties tableProperties(AmazonS3 s3Client, AmazonDynamoDB dynamoClient) {
+        return new TablePropertiesProvider(instanceProperties, s3Client, dynamoClient)
+                .getByName(tableName);
     }
 
     interface Ingester {

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataViaBatcher.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataViaBatcher.java
@@ -33,10 +33,10 @@ public class IngestRandomDataViaBatcher {
     private IngestRandomDataViaBatcher() {
     }
 
-    public static void sendRequest(String dir, AssumedRoleClients clients) {
-        String queueUrl = clients.instanceProperties().get(INGEST_BATCHER_SUBMIT_QUEUE_URL);
-        String jsonRequest = FileIngestRequestSerDe.toJson(List.of(dir), clients.tableProperties().get(TABLE_NAME));
+    public static void sendRequest(String dir, InstanceIngestSession session) {
+        String queueUrl = session.instanceProperties().get(INGEST_BATCHER_SUBMIT_QUEUE_URL);
+        String jsonRequest = FileIngestRequestSerDe.toJson(List.of(dir), session.tableProperties().get(TABLE_NAME));
         LOGGER.debug("Sending message to ingest batcher queue {}: {}", queueUrl, jsonRequest);
-        clients.sqs().sendMessage(queueUrl, jsonRequest);
+        session.sqs().sendMessage(queueUrl, jsonRequest);
     }
 }

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataViaBatcher.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataViaBatcher.java
@@ -16,13 +16,9 @@
 
 package sleeper.systemtest.datageneration;
 
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sleeper.configuration.properties.instance.InstanceProperties;
-import sleeper.configuration.properties.table.TableProperties;
 import sleeper.ingest.batcher.submitter.FileIngestRequestSerDe;
 
 import java.util.List;
@@ -37,12 +33,10 @@ public class IngestRandomDataViaBatcher {
     private IngestRandomDataViaBatcher() {
     }
 
-    public static void sendRequest(String dir, InstanceProperties instanceProperties, TableProperties tableProperties) {
-        AmazonSQS sqsClient = AmazonSQSClientBuilder.defaultClient();
-        String queueUrl = instanceProperties.get(INGEST_BATCHER_SUBMIT_QUEUE_URL);
-        String jsonRequest = FileIngestRequestSerDe.toJson(List.of(dir), tableProperties.get(TABLE_NAME));
+    public static void sendRequest(String dir, AssumedRoleClients clients) {
+        String queueUrl = clients.instanceProperties().get(INGEST_BATCHER_SUBMIT_QUEUE_URL);
+        String jsonRequest = FileIngestRequestSerDe.toJson(List.of(dir), clients.tableProperties().get(TABLE_NAME));
         LOGGER.debug("Sending message to ingest batcher queue {}: {}", queueUrl, jsonRequest);
-        sqsClient.sendMessage(queueUrl, jsonRequest);
-        sqsClient.shutdown();
+        clients.sqs().sendMessage(queueUrl, jsonRequest);
     }
 }

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataViaQueue.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/IngestRandomDataViaQueue.java
@@ -35,17 +35,17 @@ public class IngestRandomDataViaQueue {
     }
 
     public static void sendJob(
-            String jobId, String dir, SystemTestPropertyValues systemTestProperties, AssumedRoleClients clients) {
+            String jobId, String dir, SystemTestPropertyValues systemTestProperties, InstanceIngestSession session) {
 
         IngestJob ingestJob = IngestJob.builder()
-                .tableName(clients.tableProperties().get(TABLE_NAME))
+                .tableName(session.tableProperties().get(TABLE_NAME))
                 .id(jobId)
                 .files(Collections.singletonList(dir))
                 .build();
         String jsonJob = new IngestJobSerDe().toJson(ingestJob);
         IngestQueue ingestQueue = systemTestProperties.getEnumValue(INGEST_QUEUE, IngestQueue.class);
-        String queueUrl = ingestQueue.getJobQueueUrl(clients.instanceProperties());
+        String queueUrl = ingestQueue.getJobQueueUrl(session.instanceProperties());
         LOGGER.debug("Sending message to ingest queue {}: {}", queueUrl, jsonJob);
-        clients.sqs().sendMessage(queueUrl, jsonJob);
+        session.sqs().sendMessage(queueUrl, jsonJob);
     }
 }

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/InstanceIngestSession.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/InstanceIngestSession.java
@@ -30,7 +30,7 @@ import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.io.parquet.utils.HadoopConfigurationProvider;
 import sleeper.statestore.StateStoreProvider;
 
-public class AssumedRoleClients implements AutoCloseable {
+public class InstanceIngestSession implements AutoCloseable {
     private final AmazonS3 s3;
     private final AmazonDynamoDB dynamo;
     private final AmazonSQS sqs;
@@ -38,11 +38,11 @@ public class AssumedRoleClients implements AutoCloseable {
     private final InstanceProperties instanceProperties;
     private final TableProperties tableProperties;
 
-    public AssumedRoleClients(AssumeSleeperRole role, InstanceProperties instanceProperties, String tableName) {
+    public InstanceIngestSession(AssumeSleeperRole role, InstanceProperties instanceProperties, String tableName) {
         this.s3 = role.v1Client(AmazonS3ClientBuilder.standard());
         this.dynamo = role.v1Client(AmazonDynamoDBClientBuilder.standard());
         this.sqs = role.v1Client(AmazonSQSClientBuilder.standard());
-        this.hadoopConfiguration = role.setInHadoopForS3A(HadoopConfigurationProvider.getConfigurationForECS(instanceProperties));
+        this.hadoopConfiguration = role.setS3ACredentials(HadoopConfigurationProvider.getConfigurationForECS(instanceProperties));
         this.instanceProperties = instanceProperties;
         this.tableProperties = new TablePropertiesProvider(instanceProperties, s3, dynamo)
                 .getByName(tableName);

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
@@ -15,11 +15,7 @@
  */
 package sleeper.systemtest.datageneration;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
-
 import sleeper.configuration.jars.ObjectFactory;
-import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.iterator.CloseableIterator;
 import sleeper.core.iterator.IteratorException;
@@ -27,7 +23,6 @@ import sleeper.core.iterator.WrappedIterator;
 import sleeper.core.record.Record;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.ingest.IngestFactory;
-import sleeper.statestore.StateStoreProvider;
 import sleeper.systemtest.configuration.SystemTestPropertyValues;
 
 import java.io.IOException;
@@ -41,22 +36,20 @@ public class WriteRandomDataDirect {
     }
 
     public static void writeWithIngestFactory(
-            InstanceProperties instanceProperties, TableProperties tableProperties,
-            SystemTestPropertyValues systemTestProperties, StateStoreProvider stateStoreProvider) throws IOException {
+            SystemTestPropertyValues systemTestProperties, AssumedRoleClients clients) throws IOException {
         writeWithIngestFactory(
                 IngestFactory.builder()
                         .objectFactory(ObjectFactory.noUserJars())
                         .localDir("/mnt/scratch")
-                        .stateStoreProvider(stateStoreProvider)
-                        .instanceProperties(instanceProperties)
+                        .stateStoreProvider(clients.createStateStoreProvider())
+                        .instanceProperties(clients.instanceProperties())
+                        .hadoopConfiguration(clients.hadoopConfiguration())
                         .build(),
-                systemTestProperties, tableProperties);
+                systemTestProperties, clients.tableProperties());
     }
 
     public static void writeWithIngestFactory(
             IngestFactory ingestFactory, SystemTestPropertyValues properties, TableProperties tableProperties) throws IOException {
-        AmazonDynamoDB dynamoDBClient = AmazonDynamoDBClientBuilder.defaultClient();
-
         CloseableIterator<Record> recordIterator = new WrappedIterator<>(
                 WriteRandomData.createRecordIterator(properties, tableProperties));
 
@@ -65,7 +58,5 @@ public class WriteRandomDataDirect {
         } catch (StateStoreException | IteratorException e) {
             throw new IOException("Failed to write records using iterator", e);
         }
-
-        dynamoDBClient.shutdown();
     }
 }

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
@@ -44,6 +44,7 @@ public class WriteRandomDataDirect {
                         .stateStoreProvider(session.createStateStoreProvider())
                         .instanceProperties(session.instanceProperties())
                         .hadoopConfiguration(session.hadoopConfiguration())
+                        .s3AsyncClient(session.s3Async())
                         .build(),
                 systemTestProperties, session.tableProperties());
     }

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
@@ -36,16 +36,16 @@ public class WriteRandomDataDirect {
     }
 
     public static void writeWithIngestFactory(
-            SystemTestPropertyValues systemTestProperties, AssumedRoleClients clients) throws IOException {
+            SystemTestPropertyValues systemTestProperties, InstanceIngestSession session) throws IOException {
         writeWithIngestFactory(
                 IngestFactory.builder()
                         .objectFactory(ObjectFactory.noUserJars())
                         .localDir("/mnt/scratch")
-                        .stateStoreProvider(clients.createStateStoreProvider())
-                        .instanceProperties(clients.instanceProperties())
-                        .hadoopConfiguration(clients.hadoopConfiguration())
+                        .stateStoreProvider(session.createStateStoreProvider())
+                        .instanceProperties(session.instanceProperties())
+                        .hadoopConfiguration(session.hadoopConfiguration())
                         .build(),
-                systemTestProperties, clients.tableProperties());
+                systemTestProperties, session.tableProperties());
     }
 
     public static void writeWithIngestFactory(

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
@@ -40,13 +40,13 @@ public class WriteRandomDataFiles {
     }
 
     public static String writeToS3GetDirectory(
-            SystemTestPropertyValues systemTestProperties, AssumedRoleClients clients, String jobId) throws IOException {
+            SystemTestPropertyValues systemTestProperties, InstanceIngestSession session, String jobId) throws IOException {
 
         String dir = systemTestProperties.get(SYSTEM_TEST_BUCKET_NAME) + "/ingest/" + jobId;
 
-        writeToPath(dir, "s3a://", clients.tableProperties(),
-                WriteRandomData.createRecordIterator(systemTestProperties, clients.tableProperties()),
-                clients.hadoopConfiguration());
+        writeToPath(dir, "s3a://", session.tableProperties(),
+                WriteRandomData.createRecordIterator(systemTestProperties, session.tableProperties()),
+                session.hadoopConfiguration());
         return dir;
     }
 

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
@@ -40,15 +40,13 @@ public class WriteRandomDataFiles {
     }
 
     public static String writeToS3GetDirectory(
-            InstanceProperties instanceProperties, TableProperties tableProperties,
-            SystemTestPropertyValues systemTestProperties, String jobId) throws IOException {
+            SystemTestPropertyValues systemTestProperties, AssumedRoleClients clients, String jobId) throws IOException {
 
         String dir = systemTestProperties.get(SYSTEM_TEST_BUCKET_NAME) + "/ingest/" + jobId;
 
-        Configuration conf = HadoopConfigurationProvider.getConfigurationForECS(instanceProperties);
-
-        writeToPath(dir, "s3a://", tableProperties,
-                WriteRandomData.createRecordIterator(systemTestProperties, tableProperties), conf);
+        writeToPath(dir, "s3a://", clients.tableProperties(),
+                WriteRandomData.createRecordIterator(systemTestProperties, clients.tableProperties()),
+                clients.hadoopConfiguration());
         return dir;
     }
 

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataFiles.java
@@ -40,13 +40,13 @@ public class WriteRandomDataFiles {
     }
 
     public static String writeToS3GetDirectory(
-            SystemTestPropertyValues systemTestProperties, InstanceIngestSession session, String jobId) throws IOException {
+            SystemTestPropertyValues systemTestProperties, TableProperties tableProperties, Configuration hadoopConf, String jobId) throws IOException {
 
         String dir = systemTestProperties.get(SYSTEM_TEST_BUCKET_NAME) + "/ingest/" + jobId;
 
-        writeToPath(dir, "s3a://", session.tableProperties(),
-                WriteRandomData.createRecordIterator(systemTestProperties, session.tableProperties()),
-                session.hadoopConfiguration());
+        writeToPath(dir, "s3a://", tableProperties,
+                WriteRandomData.createRecordIterator(systemTestProperties, tableProperties),
+                hadoopConf);
         return dir;
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/RunWriteRandomDataTaskOnECS.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/RunWriteRandomDataTaskOnECS.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.INGEST_BY_QUEUE_ROLE_ARN;
 import static sleeper.configuration.properties.instance.CommonProperty.FARGATE_VERSION;
 import static sleeper.configuration.properties.instance.CommonProperty.SUBNETS;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
@@ -73,10 +74,12 @@ public class RunWriteRandomDataTaskOnECS {
         this.ecsClient = ecsClient;
         this.args = List.of(
                 instanceProperties.get(CONFIG_BUCKET),
-                tableProperties.get(TABLE_NAME));
+                tableProperties.get(TABLE_NAME),
+                instanceProperties.get(INGEST_BY_QUEUE_ROLE_ARN));
     }
 
-    public RunWriteRandomDataTaskOnECS(InstanceProperties instanceProperties, TableProperties tableProperties,
+    public RunWriteRandomDataTaskOnECS(
+            InstanceProperties instanceProperties, TableProperties tableProperties,
             SystemTestStandaloneProperties systemTestProperties, AmazonECS ecsClient) {
         this.instanceProperties = instanceProperties;
         this.systemTestProperties = systemTestProperties;
@@ -84,6 +87,7 @@ public class RunWriteRandomDataTaskOnECS {
         this.args = List.of(
                 instanceProperties.get(CONFIG_BUCKET),
                 tableProperties.get(TABLE_NAME),
+                instanceProperties.get(INGEST_BY_QUEUE_ROLE_ARN),
                 systemTestProperties.get(SYSTEM_TEST_BUCKET_NAME));
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperInstance.java
@@ -28,15 +28,12 @@ import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.SleeperVersion;
 import sleeper.systemtest.dsl.SystemTestDrivers;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.VERSION;
 import static sleeper.configuration.properties.instance.CommonProperty.TAGS;
-import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_ROLE;
 
 public final class DeployedSleeperInstance {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeployedSleeperInstance.class);
@@ -97,15 +94,6 @@ public final class DeployedSleeperInstance {
 
     private boolean isRedeployNeeded(SystemTestParameters parameters, DeployedSystemTestResources systemTest) {
         boolean redeployNeeded = false;
-
-        Set<String> ingestRoles = new LinkedHashSet<>(instanceProperties.getList(INGEST_SOURCE_ROLE));
-        if (systemTest.isSystemTestClusterEnabled() &&
-                !ingestRoles.contains(systemTest.getSystemTestWriterRoleName())) {
-            ingestRoles.add(systemTest.getSystemTestWriterRoleName());
-            instanceProperties.set(INGEST_SOURCE_ROLE, String.join(",", ingestRoles));
-            redeployNeeded = true;
-            LOGGER.info("Redeploy required to give system test cluster access to the instance");
-        }
 
         if (!SleeperVersion.getVersion().equals(instanceProperties.get(VERSION))) {
             redeployNeeded = true;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSystemTestResources.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSystemTestResources.java
@@ -39,7 +39,6 @@ import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_JA
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_REGION;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_REPO;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_VPC_ID;
-import static sleeper.systemtest.configuration.SystemTestProperty.WRITE_DATA_ROLE_NAME;
 
 public class DeployedSystemTestResources {
     private static final Logger LOGGER = LoggerFactory.getLogger(DeployedSystemTestResources.class);
@@ -133,9 +132,5 @@ public class DeployedSystemTestResources {
 
     public String getSystemTestBucketName() {
         return properties.get(SYSTEM_TEST_BUCKET_NAME);
-    }
-
-    public String getSystemTestWriterRoleName() {
-        return properties.get(WRITE_DATA_ROLE_NAME);
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
@@ -19,11 +19,9 @@ package sleeper.systemtest.dsl.instance;
 import sleeper.configuration.deploy.DeployInstanceConfiguration;
 import sleeper.configuration.properties.instance.InstanceProperties;
 
-import java.util.List;
 import java.util.function.Supplier;
 
 import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_BUCKET;
-import static sleeper.configuration.properties.instance.IngestProperty.INGEST_SOURCE_ROLE;
 
 public class SystemTestInstanceConfiguration {
     private final String shortName;
@@ -57,11 +55,6 @@ public class SystemTestInstanceConfiguration {
         InstanceProperties properties = configuration.getInstanceProperties();
         if (shouldUseSystemTestIngestSourceBucket()) {
             properties.set(INGEST_SOURCE_BUCKET, systemTest.getSystemTestBucketName());
-        }
-
-        String systemTestClusterRole = systemTest.getSystemTestWriterRoleName();
-        if (systemTestClusterRole != null) {
-            properties.addToList(INGEST_SOURCE_ROLE, List.of(systemTestClusterRole));
         }
         return configuration;
     }


### PR DESCRIPTION
This is in draft because it currently fails to load the instance properties in the system test writer task. It doesn't have permissions for that. We can either add permissions to load the instance properties for any instance, or assume the correct role when loading instance properties.

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2467

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Ran SetupInstanceIT in AWS on top of stack with system test cluster enabled
    - Ran deployAll system test in AWS on top of stack
    - Ran quick system test suite without system test cluster enabled

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.