### PR TITLE
Issue 2519 - Logic to load snapshot on state store update

### DIFF
--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -24,6 +24,7 @@ import sleeper.core.util.ExponentialBackoffWithJitter;
 import sleeper.core.util.LoggedDuration;
 
 import java.time.Instant;
+import java.util.Optional;
 
 class TransactionLogHead<T> {
     public static final Logger LOGGER = LoggerFactory.getLogger(TransactionLogHead.class);
@@ -43,7 +44,7 @@ class TransactionLogHead<T> {
         this.maxAddTransactionAttempts = builder.maxAddTransactionAttempts;
         this.retryBackoff = builder.retryBackoff;
         this.transactionType = builder.transactionType;
-        this.snapshots = new TransactionLogSnapshotLoader();
+        this.snapshots = transactionNumber -> Optional.empty();
         this.state = builder.state;
         this.lastTransactionNumber = builder.lastTransactionNumber;
     }
@@ -94,7 +95,7 @@ class TransactionLogHead<T> {
         try {
             Instant startTime = Instant.now();
             long transactionNumberBefore = lastTransactionNumber;
-            snapshots.loadIfShouldUpdateFromTransaction(transactionNumberBefore).ifPresent(snapshot -> {
+            snapshots.loadLatestSnapshotIfLaterThan(transactionNumberBefore).ifPresent(snapshot -> {
                 state = snapshot.getState();
                 lastTransactionNumber = snapshot.getTransactionNumber();
             });

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -96,7 +96,7 @@ class TransactionLogHead<T> {
         try {
             Instant startTime = Instant.now();
             long transactionNumberBefore = lastTransactionNumber;
-            snapshotLoader.loadLatestSnapshotAtMinimumTransaction(
+            snapshotLoader.loadLatestSnapshotIfAtMinimumTransaction(
                     transactionNumberBefore + minTransactionsAheadToLoadSnapshot)
                     .ifPresent(snapshot -> {
                         state = snapshot.getState();

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -115,8 +115,9 @@ class TransactionLogHead<T> {
                     state.getClass().getSimpleName(),
                     LoggedDuration.withShortOutput(startTime, endTime),
                     LoggedDuration.withShortOutput(startTime, loadedSnapshotTime),
+                    lastTransactionNumber - transactionNumberBeforeLogLoad,
                     LoggedDuration.withShortOutput(loadedSnapshotTime, endTime),
-                    lastTransactionNumber - transactionNumberBeforeLogLoad, lastTransactionNumber);
+                    lastTransactionNumber);
         } catch (RuntimeException e) {
             throw new StateStoreException("Failed reading transactions", e);
         }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -92,6 +92,11 @@ class TransactionLogHead<T> {
         try {
             Instant startTime = Instant.now();
             long transactionNumberBefore = lastTransactionNumber;
+            // TODO replace state from snapshot if there's one worth loading
+            // snapshots.loadIfShouldUpdateFromTransaction(transactionNumberBefore).ifPresent(snapshot -> {
+            //     state = snapshot.getState();
+            //     lastTransactionNumber = snapshot.getTransactionNumber();
+            // });
             logStore.readTransactionsAfter(lastTransactionNumber)
                     .forEach(this::applyTransaction);
             LOGGER.info("Updated {}, read {} transactions, took {}, last transaction number is {}",

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
@@ -17,11 +17,24 @@ package sleeper.core.statestore.transactionlog;
 
 public class TransactionLogSnapshot {
 
+    private final Object state;
+    private final long transactionNumber;
+
+    public TransactionLogSnapshot(StateStoreFiles state, long transactionNumber) {
+        this.state = state;
+        this.transactionNumber = transactionNumber;
+    }
+
+    public TransactionLogSnapshot(StateStorePartitions state, long transactionNumber) {
+        this.state = state;
+        this.transactionNumber = transactionNumber;
+    }
+
     public <T> T getState() {
-        throw new UnsupportedOperationException("Unimplemented method 'getState'");
+        return (T) state;
     }
 
     public long getTransactionNumber() {
-        throw new UnsupportedOperationException("Unimplemented method 'getTransactionNumber'");
+        return transactionNumber;
     }
 }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.statestore.transactionlog;
+
+public class TransactionLogSnapshot {
+
+    public <T> T getState() {
+        throw new UnsupportedOperationException("Unimplemented method 'getState'");
+    }
+
+    public long getTransactionNumber() {
+        throw new UnsupportedOperationException("Unimplemented method 'getTransactionNumber'");
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
@@ -23,5 +23,5 @@ public interface TransactionLogSnapshotLoader {
         return transactionNumber -> Optional.empty();
     }
 
-    Optional<TransactionLogSnapshot> loadLatestSnapshotAtMinimumTransaction(long transactionNumber);
+    Optional<TransactionLogSnapshot> loadLatestSnapshotIfAtMinimumTransaction(long transactionNumber);
 }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.statestore.transactionlog;
+
+import java.util.Optional;
+
+public class TransactionLogSnapshotLoader {
+    public Optional<TransactionLogSnapshot> loadIfShouldUpdateFromTransaction(long transactionNumber) {
+        return Optional.empty();
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
@@ -17,8 +17,7 @@ package sleeper.core.statestore.transactionlog;
 
 import java.util.Optional;
 
-public class TransactionLogSnapshotLoader {
-    public Optional<TransactionLogSnapshot> loadIfShouldUpdateFromTransaction(long transactionNumber) {
-        return Optional.empty();
-    }
+@FunctionalInterface
+public interface TransactionLogSnapshotLoader {
+    Optional<TransactionLogSnapshot> loadLatestSnapshotIfLaterThan(long transactionNumber);
 }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
@@ -23,5 +23,5 @@ public interface TransactionLogSnapshotLoader {
         return transactionNumber -> Optional.empty();
     }
 
-    Optional<TransactionLogSnapshot> loadLatestSnapshotIfLaterThan(long transactionNumber);
+    Optional<TransactionLogSnapshot> loadLatestSnapshotAtMinimumTransaction(long transactionNumber);
 }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotLoader.java
@@ -19,5 +19,9 @@ import java.util.Optional;
 
 @FunctionalInterface
 public interface TransactionLogSnapshotLoader {
+    static TransactionLogSnapshotLoader neverLoad() {
+        return transactionNumber -> Optional.empty();
+    }
+
     Optional<TransactionLogSnapshot> loadLatestSnapshotIfLaterThan(long transactionNumber);
 }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
@@ -39,11 +39,13 @@ public class TransactionLogStateStore extends DelegatingStateStore {
                         .state(builder.filesState)
                         .logStore(builder.filesLogStore)
                         .lastTransactionNumber(builder.filesTransactionNumber)
+                        .snapshotLoader(builder.filesSnapshotLoader)
                         .build(),
                 headBuilder.forPartitions()
                         .state(builder.partitionsState)
                         .logStore(builder.partitionsLogStore)
                         .lastTransactionNumber(builder.partitionsTransactionNumber)
+                        .snapshotLoader(builder.partitionsSnapshotLoader)
                         .build());
     }
 
@@ -67,6 +69,8 @@ public class TransactionLogStateStore extends DelegatingStateStore {
         private long filesTransactionNumber = 0;
         private int maxAddTransactionAttempts = MAX_ADD_TRANSACTION_ATTEMPTS;
         private ExponentialBackoffWithJitter retryBackoff = new ExponentialBackoffWithJitter(RETRY_WAIT_RANGE);
+        private TransactionLogSnapshotLoader filesSnapshotLoader = TransactionLogSnapshotLoader.neverLoad();
+        private TransactionLogSnapshotLoader partitionsSnapshotLoader = TransactionLogSnapshotLoader.neverLoad();
 
         private Builder() {
         }
@@ -118,6 +122,16 @@ public class TransactionLogStateStore extends DelegatingStateStore {
 
         public Builder retryBackoff(ExponentialBackoffWithJitter retryBackoff) {
             this.retryBackoff = retryBackoff;
+            return this;
+        }
+
+        public Builder filesSnapshotLoader(TransactionLogSnapshotLoader filesSnapshotLoader) {
+            this.filesSnapshotLoader = filesSnapshotLoader;
+            return this;
+        }
+
+        public Builder partitionsSnapshotLoader(TransactionLogSnapshotLoader partitionsSnapshotLoader) {
+            this.partitionsSnapshotLoader = partitionsSnapshotLoader;
             return this;
         }
 

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
@@ -30,6 +30,7 @@ public class TransactionLogStateStore extends DelegatingStateStore {
         this(builder, TransactionLogHead.builder()
                 .sleeperTable(builder.sleeperTable)
                 .maxAddTransactionAttempts(builder.maxAddTransactionAttempts)
+                .minTransactionsAheadToLoadSnapshot(builder.minTransactionsAheadToLoadSnapshot)
                 .retryBackoff(builder.retryBackoff));
     }
 
@@ -67,6 +68,7 @@ public class TransactionLogStateStore extends DelegatingStateStore {
         private StateStorePartitions partitionsState = new StateStorePartitions();
         private long partitionsTransactionNumber = 0;
         private long filesTransactionNumber = 0;
+        private long minTransactionsAheadToLoadSnapshot = 1;
         private int maxAddTransactionAttempts = MAX_ADD_TRANSACTION_ATTEMPTS;
         private ExponentialBackoffWithJitter retryBackoff = new ExponentialBackoffWithJitter(RETRY_WAIT_RANGE);
         private TransactionLogSnapshotLoader filesSnapshotLoader = TransactionLogSnapshotLoader.neverLoad();
@@ -132,6 +134,11 @@ public class TransactionLogStateStore extends DelegatingStateStore {
 
         public Builder partitionsSnapshotLoader(TransactionLogSnapshotLoader partitionsSnapshotLoader) {
             this.partitionsSnapshotLoader = partitionsSnapshotLoader;
+            return this;
+        }
+
+        public Builder minTransactionsAheadToLoadSnapshot(long minTransactionsAheadToLoadSnapshot) {
+            this.minTransactionsAheadToLoadSnapshot = minTransactionsAheadToLoadSnapshot;
             return this;
         }
 

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -24,15 +24,15 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
 
     private TransactionLogSnapshot latestSnapshot;
 
-    public static TransactionLogSnapshot createFilesSnapshot(TableStatus sleeperTable, TransactionLogStore log) throws StateStoreException {
+    public static TransactionLogSnapshot createFilesSnapshot(TableStatus sleeperTable, TransactionLogStore log, long transactionNumber) throws StateStoreException {
         StateStoreFiles state = new StateStoreFiles();
-        long transactionNumber = TransactionLogSnapshotUtils.updateFilesState(sleeperTable, state, log, 0);
+        TransactionLogSnapshotUtils.updateFilesState(sleeperTable, state, log, 0);
         return new TransactionLogSnapshot(state, transactionNumber);
     }
 
-    public static TransactionLogSnapshot createPartitionsSnapshot(TableStatus sleeperTable, TransactionLogStore log) throws StateStoreException {
+    public static TransactionLogSnapshot createPartitionsSnapshot(TableStatus sleeperTable, TransactionLogStore log, long transactionNumber) throws StateStoreException {
         StateStorePartitions state = new StateStorePartitions();
-        long transactionNumber = TransactionLogSnapshotUtils.updatePartitionsState(sleeperTable, state, log, 0);
+        TransactionLogSnapshotUtils.updatePartitionsState(sleeperTable, state, log, 0);
         return new TransactionLogSnapshot(state, transactionNumber);
     }
 

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.statestore.transactionlog;
+
+import sleeper.core.statestore.StateStoreException;
+import sleeper.core.table.TableStatus;
+
+import java.util.Optional;
+
+public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLoader {
+
+    private TransactionLogSnapshot latestSnapshot;
+
+    public static TransactionLogSnapshot createFilesSnapshot(TableStatus sleeperTable, TransactionLogStore log) throws StateStoreException {
+        StateStoreFiles state = new StateStoreFiles();
+        long transactionNumber = TransactionLogSnapshotUtils.updateFilesState(sleeperTable, state, log, 0);
+        return new TransactionLogSnapshot(state, transactionNumber);
+    }
+
+    public static TransactionLogSnapshot createPartitionsSnapshot(TableStatus sleeperTable, TransactionLogStore log) throws StateStoreException {
+        StateStorePartitions state = new StateStorePartitions();
+        long transactionNumber = TransactionLogSnapshotUtils.updatePartitionsState(sleeperTable, state, log, 0);
+        return new TransactionLogSnapshot(state, transactionNumber);
+    }
+
+    public void setLatestSnapshot(TransactionLogSnapshot latestSnapshot) {
+        this.latestSnapshot = latestSnapshot;
+    }
+
+    @Override
+    public Optional<TransactionLogSnapshot> loadLatestSnapshotIfLaterThan(long transactionNumber) {
+        return Optional.ofNullable(latestSnapshot)
+                .filter(snapshot -> snapshot.getTransactionNumber() > transactionNumber);
+    }
+
+}

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -41,7 +41,7 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
     }
 
     @Override
-    public Optional<TransactionLogSnapshot> loadLatestSnapshotAtMinimumTransaction(long transactionNumber) {
+    public Optional<TransactionLogSnapshot> loadLatestSnapshotIfAtMinimumTransaction(long transactionNumber) {
         return Optional.ofNullable(latestSnapshot)
                 .filter(snapshot -> snapshot.getTransactionNumber() >= transactionNumber);
     }

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -41,9 +41,9 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
     }
 
     @Override
-    public Optional<TransactionLogSnapshot> loadLatestSnapshotIfLaterThan(long transactionNumber) {
+    public Optional<TransactionLogSnapshot> loadLatestSnapshotAtMinimumTransaction(long transactionNumber) {
         return Optional.ofNullable(latestSnapshot)
-                .filter(snapshot -> snapshot.getTransactionNumber() > transactionNumber);
+                .filter(snapshot -> snapshot.getTransactionNumber() >= transactionNumber);
     }
 
 }

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStateStoreTestBase.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStateStoreTestBase.java
@@ -22,16 +22,23 @@ import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.core.util.ExponentialBackoffWithJitter;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
 import static sleeper.core.statestore.FileReferenceTestData.DEFAULT_UPDATE_TIME;
 import static sleeper.core.table.TableStatusTestHelper.uniqueIdAndName;
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.fixJitterSeed;
-import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.noWaits;
+import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.recordWaits;
 
 public class InMemoryTransactionLogStateStoreTestBase {
 
     private PartitionsBuilder partitions;
     protected FileReferenceFactory factory;
+    protected InMemoryTransactionLogStore filesLogStore = new InMemoryTransactionLogStore();
+    protected InMemoryTransactionLogStore partitionsLogStore = new InMemoryTransactionLogStore();
     protected StateStore store;
+    protected final List<Duration> retryWaits = new ArrayList<>();
 
     protected void initialiseWithSchema(Schema schema) throws Exception {
         createStore(new PartitionsBuilder(schema).singlePartition("root"));
@@ -46,15 +53,25 @@ public class InMemoryTransactionLogStateStoreTestBase {
     private void createStore(PartitionsBuilder partitions) {
         this.partitions = partitions;
         factory = FileReferenceFactory.fromUpdatedAt(partitions.buildTree(), DEFAULT_UPDATE_TIME);
-        store = TransactionLogStateStore.builder()
+        store = stateStore(stateStoreBuilder(partitions.getSchema()));
+    }
+
+    protected StateStore stateStore(TransactionLogStateStore.Builder builder) {
+        StateStore stateStore = builder.build();
+        stateStore.fixFileUpdateTime(DEFAULT_UPDATE_TIME);
+        return stateStore;
+    }
+
+    protected TransactionLogStateStore.Builder stateStoreBuilder(Schema schema) {
+        return TransactionLogStateStore.builder()
                 .sleeperTable(uniqueIdAndName("test-table-id", "test-table"))
-                .schema(partitions.getSchema())
-                .filesLogStore(new InMemoryTransactionLogStore())
-                .partitionsLogStore(new InMemoryTransactionLogStore())
+                .schema(schema)
+                .filesLogStore(filesLogStore)
+                .partitionsLogStore(partitionsLogStore)
+                .maxAddTransactionAttempts(10)
                 .retryBackoff(new ExponentialBackoffWithJitter(
-                        TransactionLogStateStore.RETRY_WAIT_RANGE, fixJitterSeed(), noWaits()))
-                .build();
-        store.fixFileUpdateTime(DEFAULT_UPDATE_TIME);
+                        TransactionLogStateStore.RETRY_WAIT_RANGE,
+                        fixJitterSeed(), recordWaits(retryWaits)));
     }
 
     protected void splitPartition(String parentId, String leftId, String rightId, long splitPoint) throws StateStoreException {

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStateStoreTestBase.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStateStoreTestBase.java
@@ -20,6 +20,7 @@ import sleeper.core.schema.Schema;
 import sleeper.core.statestore.FileReferenceFactory;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
+import sleeper.core.table.TableStatus;
 import sleeper.core.util.ExponentialBackoffWithJitter;
 
 import java.time.Duration;
@@ -33,10 +34,13 @@ import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.recordWai
 
 public class InMemoryTransactionLogStateStoreTestBase {
 
+    protected final TableStatus sleeperTable = uniqueIdAndName("test-table-id", "test-table");
     private PartitionsBuilder partitions;
     protected FileReferenceFactory factory;
     protected InMemoryTransactionLogStore filesLogStore = new InMemoryTransactionLogStore();
     protected InMemoryTransactionLogStore partitionsLogStore = new InMemoryTransactionLogStore();
+    protected InMemoryTransactionLogSnapshots fileSnapshots = new InMemoryTransactionLogSnapshots();
+    protected InMemoryTransactionLogSnapshots partitionSnapshots = new InMemoryTransactionLogSnapshots();
     protected StateStore store;
     protected final List<Duration> retryWaits = new ArrayList<>();
 
@@ -64,7 +68,7 @@ public class InMemoryTransactionLogStateStoreTestBase {
 
     protected TransactionLogStateStore.Builder stateStoreBuilder(Schema schema) {
         return TransactionLogStateStore.builder()
-                .sleeperTable(uniqueIdAndName("test-table-id", "test-table"))
+                .sleeperTable(sleeperTable)
                 .schema(schema)
                 .filesLogStore(filesLogStore)
                 .partitionsLogStore(partitionsLogStore)

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStateStoreTestBase.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStateStoreTestBase.java
@@ -71,7 +71,9 @@ public class InMemoryTransactionLogStateStoreTestBase {
                 .sleeperTable(sleeperTable)
                 .schema(schema)
                 .filesLogStore(filesLogStore)
+                .filesSnapshotLoader(fileSnapshots)
                 .partitionsLogStore(partitionsLogStore)
+                .partitionsSnapshotLoader(partitionSnapshots)
                 .maxAddTransactionAttempts(10)
                 .retryBackoff(new ExponentialBackoffWithJitter(
                         TransactionLogStateStore.RETRY_WAIT_RANGE,

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
@@ -159,64 +159,6 @@ public class TransactionLogStateStoreLogSpecificTest extends InMemoryTransaction
     }
 
     @Test
-    void shouldSetPartitionsStateWhenCreatingStateStore() throws Exception {
-        // Given
-        StateStorePartitions partitionsState = new StateStorePartitions();
-        PartitionTree splitTree = partitions.splitToNewChildren("root", "L", "R", "l").buildTree();
-
-        // When
-        StateStore stateStore = stateStore(builder -> builder.partitionsState(partitionsState));
-        stateStore.initialise(splitTree.getAllPartitions());
-
-        // Then
-        assertThat(partitionsState.all()).containsExactlyElementsOf(splitTree.getAllPartitions());
-    }
-
-    @Test
-    void shouldSetFilesStateWhenCreatingStateStore() throws Exception {
-        // Given
-        StateStoreFiles filesState = new StateStoreFiles();
-        FileReference file = fileFactory().rootFile(123);
-
-        // When
-        StateStore stateStore = stateStore(builder -> builder.filesState(filesState));
-        stateStore.addFile(file);
-
-        // Then
-        assertThat(filesState.references()).containsExactly(file);
-    }
-
-    @Test
-    void shouldNotLoadOldPartitionTransactionsWhenSettingTransactionNumber() throws Exception {
-        // Given
-        StateStore stateStore = stateStore();
-        PartitionTree splitTree = partitions.splitToNewChildren("root", "L", "R", "l").buildTree();
-        stateStore.initialise(splitTree.getAllPartitions());
-
-        // When
-        StateStore stateStoreSkippingTransaction = stateStore(builder -> builder
-                .partitionsTransactionNumber(partitionsLogStore.getLastTransactionNumber()));
-
-        // Then
-        assertThat(stateStoreSkippingTransaction.getAllPartitions()).isEmpty();
-    }
-
-    @Test
-    void shouldNotLoadOldFileTransactionsWhenSettingTransactionNumber() throws Exception {
-        // Given
-        StateStore stateStore = stateStore();
-        FileReference file = fileFactory().rootFile(123);
-        stateStore.addFile(file);
-
-        // When
-        StateStore stateStoreSkippingTransaction = stateStore(builder -> builder
-                .filesTransactionNumber(filesLogStore.getLastTransactionNumber()));
-
-        // Then
-        assertThat(stateStoreSkippingTransaction.getFileReferences()).isEmpty();
-    }
-
-    @Test
     void shouldNotAddSplitFileTransactionWithNoRequests() throws Exception {
         // Given
         long transactionNumberBefore = filesLogStore.getLastTransactionNumber();

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -51,7 +51,7 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
         FileReference file = fileFactory().rootFile(123);
 
         // When
-        createSnapshotWithFreshState(stateStore -> {
+        createSnapshotWithFreshStateAtTransactionNumber(1, stateStore -> {
             stateStore.addFile(file);
         });
 
@@ -65,7 +65,7 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
         partitions.splitToNewChildren("root", "L", "R", "abc");
 
         // When
-        createSnapshotWithFreshState(stateStore -> {
+        createSnapshotWithFreshStateAtTransactionNumber(1, stateStore -> {
             stateStore.initialise(partitions.buildList());
         });
 
@@ -147,7 +147,8 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
         return FileReferenceFactory.fromUpdatedAt(partitions.buildTree(), DEFAULT_UPDATE_TIME);
     }
 
-    protected void createSnapshotWithFreshState(SetupStateStore setupState) throws Exception {
+    protected void createSnapshotWithFreshStateAtTransactionNumber(
+            long transactionNumber, SetupStateStore setupState) throws Exception {
         InMemoryTransactionLogStore fileTransactions = new InMemoryTransactionLogStore();
         InMemoryTransactionLogStore partitionTransactions = new InMemoryTransactionLogStore();
         StateStore stateStore = TransactionLogStateStore.builder()
@@ -159,8 +160,8 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
         stateStore.fixFileUpdateTime(DEFAULT_UPDATE_TIME);
         stateStore.fixPartitionUpdateTime(DEFAULT_UPDATE_TIME);
         setupState.run(stateStore);
-        fileSnapshots.setLatestSnapshot(createFilesSnapshot(sleeperTable, fileTransactions));
-        partitionSnapshots.setLatestSnapshot(createPartitionsSnapshot(sleeperTable, partitionTransactions));
+        fileSnapshots.setLatestSnapshot(createFilesSnapshot(sleeperTable, fileTransactions, transactionNumber));
+        partitionSnapshots.setLatestSnapshot(createPartitionsSnapshot(sleeperTable, partitionTransactions, transactionNumber));
     }
 
     public interface SetupStateStore {

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -93,6 +93,24 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
     }
 
     @Test
+    void shouldLoadSnapshotWhenMoreThanConfiguredTransactionsAheadAfterLoadingLog() throws Exception {
+        // Given
+        StateStore stateStore = stateStore(builder -> builder
+                .minTransactionsAheadToLoadSnapshot(2));
+        FileReference logFile = fileFactory().rootFile("log-file.parquet", 123);
+        FileReference snapshotFile = fileFactory().rootFile("snapshot-file.parquet", 123);
+        stateStore.addFile(logFile);
+
+        // When
+        createSnapshotWithFreshStateAtTransactionNumber(3, snapshotStateStore -> {
+            snapshotStateStore.addFile(snapshotFile);
+        });
+
+        // Then
+        assertThat(stateStore.getFileReferences()).containsExactly(snapshotFile);
+    }
+
+    @Test
     void shouldSetPartitionsStateWhenCreatingStateStore() throws Exception {
         // Given
         StateStorePartitions partitionsState = new StateStorePartitions();

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.statestore.transactionlog;
+
+public class TransactionLogStateStoreSnapshotsTest {
+
+}

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -15,7 +15,6 @@
  */
 package sleeper.core.statestore.transactionlog;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.partition.PartitionTree;
@@ -39,11 +38,6 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
 
     private final Schema schema = schemaWithKey("key", new StringType());
     private final PartitionsBuilder partitions = new PartitionsBuilder(schema).singlePartition("root");
-
-    @BeforeEach
-    void setUp() throws Exception {
-        initialiseWithPartitions(partitions);
-    }
 
     @Test
     void shouldLoadFilesFromSnapshotWhenNotInLogOnFirstLoad() throws Exception {

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -16,7 +16,6 @@
 package sleeper.core.statestore.transactionlog;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.partition.PartitionTree;
@@ -47,7 +46,6 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
     }
 
     @Test
-    @Disabled("TODO")
     void shouldLoadFilesFromSnapshotWhenNotInLog() throws Exception {
         // Given
         FileReference file = fileFactory().rootFile(123);

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -60,6 +60,21 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
     }
 
     @Test
+    void shouldLoadPartitionsFromSnapshotWhenNotInLog() throws Exception {
+        // Given
+        partitions.splitToNewChildren("root", "L", "R", "abc");
+
+        // When
+        createSnapshotWithFreshState(stateStore -> {
+            stateStore.initialise(partitions.buildList());
+        });
+
+        // Then
+        assertThat(stateStore().getAllPartitions())
+                .containsExactlyInAnyOrderElementsOf(partitions.buildList());
+    }
+
+    @Test
     void shouldSetPartitionsStateWhenCreatingStateStore() throws Exception {
         // Given
         StateStorePartitions partitionsState = new StateStorePartitions();

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
@@ -64,7 +64,7 @@ public class DynamoDBTransactionLogStateStore {
 
     private static void loadLatestFilesSnapshot(TransactionLogStateStore.Builder builder, TransactionLogSnapshotSerDe snapshotSerDe, LatestSnapshots latestSnapshots) {
         if (latestSnapshots.getFilesSnapshot().isPresent()) {
-            TransactionLogSnapshot filesSnapshot = latestSnapshots.getFilesSnapshot().get();
+            TransactionLogSnapshotMetadata filesSnapshot = latestSnapshots.getFilesSnapshot().get();
             LOGGER.info("Found latest files snapshot with last transaction number {}. Creating file reference store using this snapshot.",
                     filesSnapshot.getTransactionNumber());
             try {
@@ -84,7 +84,7 @@ public class DynamoDBTransactionLogStateStore {
 
     private static void loadLatestPartitionsSnapshot(TransactionLogStateStore.Builder builder, TransactionLogSnapshotSerDe snapshotSerDe, LatestSnapshots latestSnapshots) {
         if (latestSnapshots.getPartitionsSnapshot().isPresent()) {
-            TransactionLogSnapshot partitionsSnapshot = latestSnapshots.getPartitionsSnapshot().get();
+            TransactionLogSnapshotMetadata partitionsSnapshot = latestSnapshots.getPartitionsSnapshot().get();
             LOGGER.info("Found latest partitions snapshot with last transaction number {}. Creating partitions store using this snapshot.",
                     partitionsSnapshot.getTransactionNumber());
             try {

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreator.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreator.java
@@ -96,7 +96,7 @@ public class TransactionLogSnapshotCreator {
                 })
                 .orElseGet(StateStoreFiles::new);
         long filesTransactionNumberBefore = latestSnapshots.getFilesSnapshot()
-                .map(TransactionLogSnapshot::getTransactionNumber)
+                .map(TransactionLogSnapshotMetadata::getTransactionNumber)
                 .orElse(0L);
         StateStorePartitions partitionsState = latestSnapshots.getPartitionsSnapshot()
                 .map(snapshot -> {
@@ -108,7 +108,7 @@ public class TransactionLogSnapshotCreator {
                 })
                 .orElseGet(StateStorePartitions::new);
         long partitionsTransactionNumberBefore = latestSnapshots.getPartitionsSnapshot()
-                .map(TransactionLogSnapshot::getTransactionNumber)
+                .map(TransactionLogSnapshotMetadata::getTransactionNumber)
                 .orElse(0L);
         try {
             saveFilesSnapshot(filesState, filesTransactionNumberBefore);
@@ -130,7 +130,7 @@ public class TransactionLogSnapshotCreator {
         LOGGER.info("Transaction found with transaction number {} is newer than latest files snapshot transaction number {}.",
                 transactionNumberAfter, transactionNumberBefore);
         LOGGER.info("Creating a new files snapshot from latest transaction.");
-        TransactionLogSnapshot snapshot = TransactionLogSnapshot.forFiles(getBasePath(), transactionNumberAfter);
+        TransactionLogSnapshotMetadata snapshot = TransactionLogSnapshotMetadata.forFiles(getBasePath(), transactionNumberAfter);
         snapshotSerDe.saveFiles(snapshot, filesState);
         try {
             snapshotSaver.save(snapshot);
@@ -155,7 +155,7 @@ public class TransactionLogSnapshotCreator {
         LOGGER.info("Transaction found with transaction number {} is newer than latest partitions snapshot transaction number {}.",
                 transactionNumberAfter, transactionNumberBefore);
         LOGGER.info("Creating a new partitions snapshot from latest transaction.");
-        TransactionLogSnapshot snapshot = TransactionLogSnapshot.forPartitions(getBasePath(), transactionNumberAfter);
+        TransactionLogSnapshotMetadata snapshot = TransactionLogSnapshotMetadata.forPartitions(getBasePath(), transactionNumberAfter);
         snapshotSerDe.savePartitions(snapshot, partitionsState);
         try {
             snapshotSaver.save(snapshot);
@@ -179,6 +179,6 @@ public class TransactionLogSnapshotCreator {
     }
 
     public interface SnapshotSaver {
-        void save(TransactionLogSnapshot snapshot) throws DuplicateSnapshotException;
+        void save(TransactionLogSnapshotMetadata snapshot) throws DuplicateSnapshotException;
     }
 }

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/TransactionLogSnapshotMetadata.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/TransactionLogSnapshotMetadata.java
@@ -17,20 +17,20 @@ package sleeper.statestore.transactionlog;
 
 import java.util.Objects;
 
-public class TransactionLogSnapshot {
+public class TransactionLogSnapshotMetadata {
     private final String path;
     private final SnapshotType type;
     private final long transactionNumber;
 
-    public static TransactionLogSnapshot forFiles(String basePath, long transactionNumber) {
-        return new TransactionLogSnapshot(getFilesPath(basePath, transactionNumber), SnapshotType.FILES, transactionNumber);
+    public static TransactionLogSnapshotMetadata forFiles(String basePath, long transactionNumber) {
+        return new TransactionLogSnapshotMetadata(getFilesPath(basePath, transactionNumber), SnapshotType.FILES, transactionNumber);
     }
 
-    public static TransactionLogSnapshot forPartitions(String basePath, long transactionNumber) {
-        return new TransactionLogSnapshot(getPartitionsPath(basePath, transactionNumber), SnapshotType.PARTITIONS, transactionNumber);
+    public static TransactionLogSnapshotMetadata forPartitions(String basePath, long transactionNumber) {
+        return new TransactionLogSnapshotMetadata(getPartitionsPath(basePath, transactionNumber), SnapshotType.PARTITIONS, transactionNumber);
     }
 
-    public TransactionLogSnapshot(String path, SnapshotType type, long transactionNumber) {
+    public TransactionLogSnapshotMetadata(String path, SnapshotType type, long transactionNumber) {
         this.path = path;
         this.type = type;
         this.transactionNumber = transactionNumber;
@@ -66,10 +66,10 @@ public class TransactionLogSnapshot {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof TransactionLogSnapshot)) {
+        if (!(obj instanceof TransactionLogSnapshotMetadata)) {
             return false;
         }
-        TransactionLogSnapshot other = (TransactionLogSnapshot) obj;
+        TransactionLogSnapshotMetadata other = (TransactionLogSnapshotMetadata) obj;
         return Objects.equals(path, other.path) && type == other.type && transactionNumber == other.transactionNumber;
     }
 

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/TransactionLogSnapshotSerDe.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/TransactionLogSnapshotSerDe.java
@@ -33,21 +33,21 @@ public class TransactionLogSnapshotSerDe {
         this.stateStoreFileUtils = new StateStoreFileUtils(configuration);
     }
 
-    void savePartitions(TransactionLogSnapshot snapshot, StateStorePartitions state) throws IOException {
+    void savePartitions(TransactionLogSnapshotMetadata snapshot, StateStorePartitions state) throws IOException {
         stateStoreFileUtils.savePartitions(snapshot.getPath(), state, sleeperSchema);
     }
 
-    StateStorePartitions loadPartitions(TransactionLogSnapshot snapshot) throws IOException {
+    StateStorePartitions loadPartitions(TransactionLogSnapshotMetadata snapshot) throws IOException {
         StateStorePartitions partitions = new StateStorePartitions();
         stateStoreFileUtils.loadPartitions(snapshot.getPath(), sleeperSchema, partitions::put);
         return partitions;
     }
 
-    void saveFiles(TransactionLogSnapshot snapshot, StateStoreFiles state) throws IOException {
+    void saveFiles(TransactionLogSnapshotMetadata snapshot, StateStoreFiles state) throws IOException {
         stateStoreFileUtils.saveFiles(snapshot.getPath(), state);
     }
 
-    StateStoreFiles loadFiles(TransactionLogSnapshot snapshot) throws IOException {
+    StateStoreFiles loadFiles(TransactionLogSnapshotMetadata snapshot) throws IOException {
         StateStoreFiles files = new StateStoreFiles();
         stateStoreFileUtils.loadFiles(snapshot.getPath(), files::add);
         return files;

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogSnapshotStoreIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogSnapshotStoreIT.java
@@ -247,19 +247,19 @@ public class DynamoDBTransactionLogSnapshotStoreIT {
         return new DynamoDBTransactionLogSnapshotStore(instanceProperties, tableProperties, dynamoDBClient, Instant::now);
     }
 
-    private TransactionLogSnapshot filesSnapshot(long transactionNumber) {
+    private TransactionLogSnapshotMetadata filesSnapshot(long transactionNumber) {
         return filesSnapshot(tableProperties, transactionNumber);
     }
 
-    private TransactionLogSnapshot filesSnapshot(TableProperties tableProperties, long transactionNumber) {
-        return TransactionLogSnapshot.forFiles(tableProperties.get(TABLE_ID), transactionNumber);
+    private TransactionLogSnapshotMetadata filesSnapshot(TableProperties tableProperties, long transactionNumber) {
+        return TransactionLogSnapshotMetadata.forFiles(tableProperties.get(TABLE_ID), transactionNumber);
     }
 
-    private TransactionLogSnapshot partitionsSnapshot(long transactionNumber) {
+    private TransactionLogSnapshotMetadata partitionsSnapshot(long transactionNumber) {
         return partitionsSnapshot(tableProperties, transactionNumber);
     }
 
-    private TransactionLogSnapshot partitionsSnapshot(TableProperties tableProperties, long transactionNumber) {
-        return TransactionLogSnapshot.forPartitions(tableProperties.get(TABLE_ID), transactionNumber);
+    private TransactionLogSnapshotMetadata partitionsSnapshot(TableProperties tableProperties, long transactionNumber) {
+        return TransactionLogSnapshotMetadata.forPartitions(tableProperties.get(TABLE_ID), transactionNumber);
     }
 }

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreatorIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreatorIT.java
@@ -281,7 +281,7 @@ public class TransactionLogSnapshotCreatorIT extends TransactionLogStateStoreTes
         StateStore stateStore = createStateStoreWithInMemoryTransactionLog(table);
         stateStore.initialise(partitions.buildList());
         runSnapshotCreator(table);
-        TransactionLogSnapshot snapshot = getLatestPartitionsSnapshot(table);
+        TransactionLogSnapshotMetadata snapshot = getLatestPartitionsSnapshot(table);
         deleteSnapshotFile(snapshot);
         // And we add a transaction that would trigger a new snapshot
         partitions.splitToNewChildren("root", "L", "R", 123L)
@@ -302,7 +302,7 @@ public class TransactionLogSnapshotCreatorIT extends TransactionLogStateStoreTes
         stateStore.initialise();
         stateStore.addFile(FileReferenceFactory.from(stateStore).rootFile("file1.parquet", 123));
         runSnapshotCreator(table);
-        TransactionLogSnapshot snapshot = getLatestFilesSnapshot(table);
+        TransactionLogSnapshotMetadata snapshot = getLatestFilesSnapshot(table);
         deleteSnapshotFile(snapshot);
         // And we add a transaction that would trigger a new snapshot
         stateStore.addFile(FileReferenceFactory.from(stateStore).rootFile("file2.parquet", 456));
@@ -314,15 +314,15 @@ public class TransactionLogSnapshotCreatorIT extends TransactionLogStateStoreTes
         assertThat(snapshotStore(table).getFilesSnapshots()).containsExactly(snapshot);
     }
 
-    private TransactionLogSnapshot getLatestPartitionsSnapshot(TableProperties table) {
+    private TransactionLogSnapshotMetadata getLatestPartitionsSnapshot(TableProperties table) {
         return snapshotStore(table).getLatestSnapshots().getPartitionsSnapshot().orElseThrow();
     }
 
-    private TransactionLogSnapshot getLatestFilesSnapshot(TableProperties table) {
+    private TransactionLogSnapshotMetadata getLatestFilesSnapshot(TableProperties table) {
         return snapshotStore(table).getLatestSnapshots().getFilesSnapshot().orElseThrow();
     }
 
-    private void deleteSnapshotFile(TransactionLogSnapshot snapshot) throws Exception {
+    private void deleteSnapshotFile(TransactionLogSnapshotMetadata snapshot) throws Exception {
         org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(snapshot.getPath());
         FileSystem fs = path.getFileSystem(configuration);
         fs.delete(path, false);
@@ -375,20 +375,20 @@ public class TransactionLogSnapshotCreatorIT extends TransactionLogStateStoreTes
         return tableProperties;
     }
 
-    private TransactionLogSnapshot filesSnapshot(TableProperties table, long transactionNumber) {
-        return TransactionLogSnapshot.forFiles(getBasePath(instanceProperties, table), transactionNumber);
+    private TransactionLogSnapshotMetadata filesSnapshot(TableProperties table, long transactionNumber) {
+        return TransactionLogSnapshotMetadata.forFiles(getBasePath(instanceProperties, table), transactionNumber);
     }
 
-    private TransactionLogSnapshot partitionsSnapshot(TableProperties table, long transactionNumber) {
-        return TransactionLogSnapshot.forPartitions(getBasePath(instanceProperties, table), transactionNumber);
+    private TransactionLogSnapshotMetadata partitionsSnapshot(TableProperties table, long transactionNumber) {
+        return TransactionLogSnapshotMetadata.forPartitions(getBasePath(instanceProperties, table), transactionNumber);
     }
 
     private Path filesSnapshotPath(TableProperties table, long transactionNumber) {
-        return Path.of(TransactionLogSnapshot.forFiles(getBasePathNoFs(instanceProperties, table), 1).getPath());
+        return Path.of(TransactionLogSnapshotMetadata.forFiles(getBasePathNoFs(instanceProperties, table), 1).getPath());
     }
 
     private Path partitionsSnapshotPath(TableProperties table, long transactionNumber) {
-        return Path.of(TransactionLogSnapshot.forPartitions(getBasePathNoFs(instanceProperties, table), 1).getPath());
+        return Path.of(TransactionLogSnapshotMetadata.forPartitions(getBasePathNoFs(instanceProperties, table), 1).getPath());
     }
 
     private static String getBasePath(InstanceProperties instanceProperties, TableProperties tableProperties) {

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotSerDeIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotSerDeIT.java
@@ -75,11 +75,11 @@ public class TransactionLogSnapshotSerDeIT {
         return FileReferenceFactory.fromUpdatedAt(partitions.buildTree(), DEFAULT_UPDATE_TIME);
     }
 
-    private TransactionLogSnapshot filesSnapshot(long transactionNumber) {
-        return TransactionLogSnapshot.forFiles(tempDir.toString(), transactionNumber);
+    private TransactionLogSnapshotMetadata filesSnapshot(long transactionNumber) {
+        return TransactionLogSnapshotMetadata.forFiles(tempDir.toString(), transactionNumber);
     }
 
-    private TransactionLogSnapshot partitionsSnapshot(long transactionNumber) {
-        return TransactionLogSnapshot.forPartitions(tempDir.toString(), transactionNumber);
+    private TransactionLogSnapshotMetadata partitionsSnapshot(long transactionNumber) {
+        return TransactionLogSnapshotMetadata.forPartitions(tempDir.toString(), transactionNumber);
     }
 }


### PR DESCRIPTION
Tasks:
- [x] Specify logic for how many transactions need to have passed before we load a snapshot
- [x] Rename TransactionLogSnapshot in statestore module to distinguish metadata from snapshot
- [x] Add logging of snapshot update

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2519

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - TransactionLogStateStoreSnapshotsTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.