### PR TITLE
Issue 2524 - Remove setting transaction log state in builder

### DIFF
--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -202,11 +202,13 @@ class TransactionLogHead<T> {
         }
 
         public Builder<StateStoreFiles> forFiles() {
-            return transactionType(FileReferenceTransaction.class);
+            return transactionType(FileReferenceTransaction.class)
+                    .state(new StateStoreFiles());
         }
 
         public Builder<StateStorePartitions> forPartitions() {
-            return transactionType(PartitionTransaction.class);
+            return transactionType(PartitionTransaction.class)
+                    .state(new StateStorePartitions());
         }
 
         public TransactionLogHead<T> build() {

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
@@ -28,6 +28,14 @@ public class TransactionLogSnapshot {
         this((Object) state, transactionNumber);
     }
 
+    public static TransactionLogSnapshot filesInitialState() {
+        return new TransactionLogSnapshot(new StateStoreFiles(), 0);
+    }
+
+    public static TransactionLogSnapshot partitionsInitialState() {
+        return new TransactionLogSnapshot(new StateStorePartitions(), 0);
+    }
+
     TransactionLogSnapshot(Object state, long transactionNumber) {
         this.state = state;
         this.transactionNumber = transactionNumber;

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshot.java
@@ -21,11 +21,14 @@ public class TransactionLogSnapshot {
     private final long transactionNumber;
 
     public TransactionLogSnapshot(StateStoreFiles state, long transactionNumber) {
-        this.state = state;
-        this.transactionNumber = transactionNumber;
+        this((Object) state, transactionNumber);
     }
 
     public TransactionLogSnapshot(StateStorePartitions state, long transactionNumber) {
+        this((Object) state, transactionNumber);
+    }
+
+    TransactionLogSnapshot(Object state, long transactionNumber) {
         this.state = state;
         this.transactionNumber = transactionNumber;
     }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotCreator.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotCreator.java
@@ -48,7 +48,7 @@ public class TransactionLogSnapshotCreator {
         return Optional.of(newSnapshot);
     }
 
-    public static <T> TransactionLogSnapshot updateState(
+    private static <T> TransactionLogSnapshot updateState(
             TransactionLogSnapshot lastSnapshot,
             Class<? extends StateStoreTransaction<T>> transactionType, TransactionLogStore logStore,
             TableStatus table) throws StateStoreException {

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotCreator.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotCreator.java
@@ -18,8 +18,8 @@ package sleeper.core.statestore.transactionlog;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.core.table.TableStatus;
 
-public class TransactionLogSnapshotUtils {
-    private TransactionLogSnapshotUtils() {
+public class TransactionLogSnapshotCreator {
+    private TransactionLogSnapshotCreator() {
     }
 
     public static <T> TransactionLogSnapshot updateState(

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotUtils.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotUtils.java
@@ -22,6 +22,21 @@ public class TransactionLogSnapshotUtils {
     private TransactionLogSnapshotUtils() {
     }
 
+    public static <T> TransactionLogSnapshot updateState(
+            TableStatus table, TransactionLogSnapshot lastSnapshot, TransactionLogStore logStore,
+            Class<? extends StateStoreTransaction<T>> transactionType) throws StateStoreException {
+        T state = lastSnapshot.getState();
+        TransactionLogHead<T> head = TransactionLogHead.builder()
+                .transactionType(transactionType)
+                .logStore(logStore)
+                .lastTransactionNumber(lastSnapshot.getTransactionNumber())
+                .state(state)
+                .sleeperTable(table)
+                .build();
+        head.update();
+        return new TransactionLogSnapshot(state, head.lastTransactionNumber());
+    }
+
     public static long updateFilesState(
             TableStatus table, StateStoreFiles state, TransactionLogStore store, long lastTransactionNumber) throws StateStoreException {
         return updateState(TransactionLogHead.builder().forFiles()

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotUtils.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogSnapshotUtils.java
@@ -23,8 +23,9 @@ public class TransactionLogSnapshotUtils {
     }
 
     public static <T> TransactionLogSnapshot updateState(
-            TableStatus table, TransactionLogSnapshot lastSnapshot, TransactionLogStore logStore,
-            Class<? extends StateStoreTransaction<T>> transactionType) throws StateStoreException {
+            TransactionLogSnapshot lastSnapshot,
+            Class<? extends StateStoreTransaction<T>> transactionType, TransactionLogStore logStore,
+            TableStatus table) throws StateStoreException {
         T state = lastSnapshot.getState();
         TransactionLogHead<T> head = TransactionLogHead.builder()
                 .transactionType(transactionType)
@@ -35,30 +36,5 @@ public class TransactionLogSnapshotUtils {
                 .build();
         head.update();
         return new TransactionLogSnapshot(state, head.lastTransactionNumber());
-    }
-
-    public static long updateFilesState(
-            TableStatus table, StateStoreFiles state, TransactionLogStore store, long lastTransactionNumber) throws StateStoreException {
-        return updateState(TransactionLogHead.builder().forFiles()
-                .lastTransactionNumber(lastTransactionNumber)
-                .logStore(store)
-                .sleeperTable(table)
-                .state(state)
-                .build());
-    }
-
-    public static long updatePartitionsState(
-            TableStatus table, StateStorePartitions state, TransactionLogStore store, long lastTransactionNumber) throws StateStoreException {
-        return updateState(TransactionLogHead.builder().forPartitions()
-                .lastTransactionNumber(lastTransactionNumber)
-                .logStore(store)
-                .sleeperTable(table)
-                .state(state)
-                .build());
-    }
-
-    private static long updateState(TransactionLogHead<?> head) throws StateStoreException {
-        head.update();
-        return head.lastTransactionNumber();
     }
 }

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
@@ -37,15 +37,11 @@ public class TransactionLogStateStore extends DelegatingStateStore {
     private TransactionLogStateStore(Builder builder, TransactionLogHead.Builder<?> headBuilder) {
         this(builder.schema,
                 headBuilder.forFiles()
-                        .state(builder.filesState)
                         .logStore(builder.filesLogStore)
-                        .lastTransactionNumber(builder.filesTransactionNumber)
                         .snapshotLoader(builder.filesSnapshotLoader)
                         .build(),
                 headBuilder.forPartitions()
-                        .state(builder.partitionsState)
                         .logStore(builder.partitionsLogStore)
-                        .lastTransactionNumber(builder.partitionsTransactionNumber)
                         .snapshotLoader(builder.partitionsSnapshotLoader)
                         .build());
     }
@@ -64,10 +60,6 @@ public class TransactionLogStateStore extends DelegatingStateStore {
         private Schema schema;
         private TransactionLogStore filesLogStore;
         private TransactionLogStore partitionsLogStore;
-        private StateStoreFiles filesState = new StateStoreFiles();
-        private StateStorePartitions partitionsState = new StateStorePartitions();
-        private long partitionsTransactionNumber = 0;
-        private long filesTransactionNumber = 0;
         private long minTransactionsAheadToLoadSnapshot = 1;
         private int maxAddTransactionAttempts = MAX_ADD_TRANSACTION_ATTEMPTS;
         private ExponentialBackoffWithJitter retryBackoff = new ExponentialBackoffWithJitter(RETRY_WAIT_RANGE);
@@ -94,26 +86,6 @@ public class TransactionLogStateStore extends DelegatingStateStore {
 
         public Builder partitionsLogStore(TransactionLogStore partitionsLogStore) {
             this.partitionsLogStore = partitionsLogStore;
-            return this;
-        }
-
-        public Builder filesState(StateStoreFiles filesState) {
-            this.filesState = filesState;
-            return this;
-        }
-
-        public Builder partitionsState(StateStorePartitions partitionsState) {
-            this.partitionsState = partitionsState;
-            return this;
-        }
-
-        public Builder partitionsTransactionNumber(long partitionsTransactionNumber) {
-            this.partitionsTransactionNumber = partitionsTransactionNumber;
-            return this;
-        }
-
-        public Builder filesTransactionNumber(long filesTransactionNumber) {
-            this.filesTransactionNumber = filesTransactionNumber;
             return this;
         }
 

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -70,12 +70,12 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
         }
 
         public TransactionLogSnapshot createFilesSnapshot(long transactionNumber) throws StateStoreException {
-            return TransactionLogSnapshotUtils.updateState(
+            return TransactionLogSnapshotCreator.updateState(
                     TransactionLogSnapshot.filesInitialState(), FileReferenceTransaction.class, filesLog, sleeperTable);
         }
 
         public TransactionLogSnapshot createPartitionsSnapshot(long transactionNumber) throws StateStoreException {
-            return TransactionLogSnapshotUtils.updateState(
+            return TransactionLogSnapshotCreator.updateState(
                     TransactionLogSnapshot.partitionsInitialState(), PartitionTransaction.class, partitionsLog, sleeperTable);
         }
 

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -70,14 +70,18 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
         }
 
         public TransactionLogSnapshot createFilesSnapshot(long transactionNumber) throws StateStoreException {
-            TransactionLogSnapshot snapshot = TransactionLogSnapshotCreator.updateState(
-                    TransactionLogSnapshot.filesInitialState(), FileReferenceTransaction.class, filesLog, sleeperTable);
+            TransactionLogSnapshot snapshot = TransactionLogSnapshot.filesInitialState();
+            snapshot = TransactionLogSnapshotCreator.createSnapshotIfChanged(
+                    snapshot, filesLog, FileReferenceTransaction.class, sleeperTable)
+                    .orElse(snapshot);
             return new TransactionLogSnapshot((StateStoreFiles) snapshot.getState(), transactionNumber);
         }
 
         public TransactionLogSnapshot createPartitionsSnapshot(long transactionNumber) throws StateStoreException {
-            TransactionLogSnapshot snapshot = TransactionLogSnapshotCreator.updateState(
-                    TransactionLogSnapshot.partitionsInitialState(), PartitionTransaction.class, partitionsLog, sleeperTable);
+            TransactionLogSnapshot snapshot = TransactionLogSnapshot.partitionsInitialState();
+            snapshot = TransactionLogSnapshotCreator.createSnapshotIfChanged(
+                    snapshot, partitionsLog, PartitionTransaction.class, sleeperTable)
+                    .orElse(snapshot);
             return new TransactionLogSnapshot((StateStorePartitions) snapshot.getState(), transactionNumber);
         }
 

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -70,13 +70,15 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
         }
 
         public TransactionLogSnapshot createFilesSnapshot(long transactionNumber) throws StateStoreException {
-            return TransactionLogSnapshotCreator.updateState(
+            TransactionLogSnapshot snapshot = TransactionLogSnapshotCreator.updateState(
                     TransactionLogSnapshot.filesInitialState(), FileReferenceTransaction.class, filesLog, sleeperTable);
+            return new TransactionLogSnapshot((StateStoreFiles) snapshot.getState(), transactionNumber);
         }
 
         public TransactionLogSnapshot createPartitionsSnapshot(long transactionNumber) throws StateStoreException {
-            return TransactionLogSnapshotCreator.updateState(
+            TransactionLogSnapshot snapshot = TransactionLogSnapshotCreator.updateState(
                     TransactionLogSnapshot.partitionsInitialState(), PartitionTransaction.class, partitionsLog, sleeperTable);
+            return new TransactionLogSnapshot((StateStorePartitions) snapshot.getState(), transactionNumber);
         }
 
         public TransactionLogStore getFilesLog() {

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogSnapshots.java
@@ -44,18 +44,6 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
         return new SnapshotSetup(sleeperTable, fileTransactions, partitionTransactions);
     }
 
-    public static TransactionLogSnapshot createFilesSnapshot(TableStatus sleeperTable, TransactionLogStore log, long transactionNumber) throws StateStoreException {
-        StateStoreFiles state = new StateStoreFiles();
-        TransactionLogSnapshotUtils.updateFilesState(sleeperTable, state, log, 0);
-        return new TransactionLogSnapshot(state, transactionNumber);
-    }
-
-    public static TransactionLogSnapshot createPartitionsSnapshot(TableStatus sleeperTable, TransactionLogStore log, long transactionNumber) throws StateStoreException {
-        StateStorePartitions state = new StateStorePartitions();
-        TransactionLogSnapshotUtils.updatePartitionsState(sleeperTable, state, log, 0);
-        return new TransactionLogSnapshot(state, transactionNumber);
-    }
-
     public void setLatestSnapshot(TransactionLogSnapshot latestSnapshot) {
         this.latestSnapshot = latestSnapshot;
     }
@@ -82,15 +70,13 @@ public class InMemoryTransactionLogSnapshots implements TransactionLogSnapshotLo
         }
 
         public TransactionLogSnapshot createFilesSnapshot(long transactionNumber) throws StateStoreException {
-            StateStoreFiles state = new StateStoreFiles();
-            TransactionLogSnapshotUtils.updateFilesState(sleeperTable, state, filesLog, 0);
-            return new TransactionLogSnapshot(state, transactionNumber);
+            return TransactionLogSnapshotUtils.updateState(
+                    TransactionLogSnapshot.filesInitialState(), FileReferenceTransaction.class, filesLog, sleeperTable);
         }
 
         public TransactionLogSnapshot createPartitionsSnapshot(long transactionNumber) throws StateStoreException {
-            StateStorePartitions state = new StateStorePartitions();
-            TransactionLogSnapshotUtils.updatePartitionsState(sleeperTable, state, partitionsLog, 0);
-            return new TransactionLogSnapshot(state, transactionNumber);
+            return TransactionLogSnapshotUtils.updateState(
+                    TransactionLogSnapshot.partitionsInitialState(), PartitionTransaction.class, partitionsLog, sleeperTable);
         }
 
         public TransactionLogStore getFilesLog() {

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -18,7 +18,6 @@ package sleeper.core.statestore.transactionlog;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.partition.Partition;
-import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
 import sleeper.core.schema.Schema;
 import sleeper.core.schema.type.StringType;
@@ -68,64 +67,6 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
         // Then
         assertThat(stateStore().getAllPartitions())
                 .containsExactlyInAnyOrderElementsOf(partitions.buildList());
-    }
-
-    @Test
-    void shouldSetPartitionsStateWhenCreatingStateStore() throws Exception {
-        // Given
-        StateStorePartitions partitionsState = new StateStorePartitions();
-        PartitionTree splitTree = partitions.splitToNewChildren("root", "L", "R", "l").buildTree();
-
-        // When
-        StateStore stateStore = stateStore(builder -> builder.partitionsState(partitionsState));
-        stateStore.initialise(splitTree.getAllPartitions());
-
-        // Then
-        assertThat(partitionsState.all()).containsExactlyElementsOf(splitTree.getAllPartitions());
-    }
-
-    @Test
-    void shouldSetFilesStateWhenCreatingStateStore() throws Exception {
-        // Given
-        StateStoreFiles filesState = new StateStoreFiles();
-        FileReference file = fileFactory().rootFile(123);
-
-        // When
-        StateStore stateStore = stateStore(builder -> builder.filesState(filesState));
-        stateStore.addFile(file);
-
-        // Then
-        assertThat(filesState.references()).containsExactly(file);
-    }
-
-    @Test
-    void shouldNotLoadOldPartitionTransactionsWhenSettingTransactionNumber() throws Exception {
-        // Given
-        StateStore stateStore = stateStore();
-        PartitionTree splitTree = partitions.splitToNewChildren("root", "L", "R", "l").buildTree();
-        stateStore.initialise(splitTree.getAllPartitions());
-
-        // When
-        StateStore stateStoreSkippingTransaction = stateStore(builder -> builder
-                .partitionsTransactionNumber(partitionsLogStore.getLastTransactionNumber()));
-
-        // Then
-        assertThat(stateStoreSkippingTransaction.getAllPartitions()).isEmpty();
-    }
-
-    @Test
-    void shouldNotLoadOldFileTransactionsWhenSettingTransactionNumber() throws Exception {
-        // Given
-        StateStore stateStore = stateStore();
-        FileReference file = fileFactory().rootFile(123);
-        stateStore.addFile(file);
-
-        // When
-        StateStore stateStoreSkippingTransaction = stateStore(builder -> builder
-                .filesTransactionNumber(filesLogStore.getLastTransactionNumber()));
-
-        // Then
-        assertThat(stateStoreSkippingTransaction.getFileReferences()).isEmpty();
     }
 
     @Test

--- a/java/statestore-lambda/src/main/java/sleeper/statestore/TransactionLogSnapshotCreationLambda.java
+++ b/java/statestore-lambda/src/main/java/sleeper/statestore/TransactionLogSnapshotCreationLambda.java
@@ -32,7 +32,7 @@ import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TablePropertiesProvider;
 import sleeper.core.util.LoggedDuration;
 import sleeper.io.parquet.utils.HadoopConfigurationProvider;
-import sleeper.statestore.transactionlog.TransactionLogSnapshotCreator;
+import sleeper.statestore.transactionlog.DynamoDBTransactionLogSnapshotCreator;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -83,7 +83,7 @@ public class TransactionLogSnapshotCreationLambda implements RequestHandler<SQSE
         for (TableProperties table : tables) {
             LOGGER.info("Creating snapshot for table {}", table.getStatus());
             try {
-                TransactionLogSnapshotCreator.from(instanceProperties, table, s3Client, dynamoClient,
+                DynamoDBTransactionLogSnapshotCreator.from(instanceProperties, table, s3Client, dynamoClient,
                         HadoopConfigurationProvider.getConfigurationForLambdas(instanceProperties))
                         .createSnapshot();
             } catch (RuntimeException e) {

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogSnapshotStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogSnapshotStore.java
@@ -48,23 +48,21 @@ public class DynamoDBTransactionLogSnapshotStore {
     public DynamoDBTransactionLogSnapshotStore(
             InstanceProperties instanceProperties, TableProperties tableProperties, AmazonDynamoDB dynamo, Configuration configuration) {
         this(new DynamoDBTransactionLogSnapshotMetadataStore(instanceProperties, tableProperties, dynamo),
-                new TransactionLogSnapshotSerDe(tableProperties.getSchema(), configuration),
                 instanceProperties, tableProperties, configuration);
     }
 
     private DynamoDBTransactionLogSnapshotStore(
-            DynamoDBTransactionLogSnapshotMetadataStore metadataStore, TransactionLogSnapshotSerDe snapshotSerDe,
+            DynamoDBTransactionLogSnapshotMetadataStore metadataStore,
             InstanceProperties instanceProperties, TableProperties tableProperties, Configuration configuration) {
-        this(metadataStore::getLatestSnapshots, metadataStore::saveSnapshot, snapshotSerDe, instanceProperties, tableProperties, configuration);
+        this(metadataStore::getLatestSnapshots, metadataStore::saveSnapshot, instanceProperties, tableProperties, configuration);
     }
 
     DynamoDBTransactionLogSnapshotStore(
             LatestSnapshotsMetadataLoader latestMetadataLoader, SnapshotMetadataSaver metadataSaver,
-            TransactionLogSnapshotSerDe snapshotSerDe,
             InstanceProperties instanceProperties, TableProperties tableProperties, Configuration configuration) {
         this.latestMetadataLoader = latestMetadataLoader;
         this.metadataSaver = metadataSaver;
-        this.snapshotSerDe = snapshotSerDe;
+        this.snapshotSerDe = new TransactionLogSnapshotSerDe(tableProperties.getSchema(), configuration);
         this.instanceProperties = instanceProperties;
         this.tableProperties = tableProperties;
         this.configuration = configuration;

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogSnapshotStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogSnapshotStore.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 import sleeper.configuration.properties.instance.InstanceProperties;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.configuration.properties.table.TableProperty;
+import sleeper.core.statestore.transactionlog.StateStoreFiles;
+import sleeper.core.statestore.transactionlog.StateStorePartitions;
 import sleeper.core.statestore.transactionlog.TransactionLogSnapshot;
 import sleeper.statestore.transactionlog.DynamoDBTransactionLogSnapshotMetadataStore.LatestSnapshots;
 
@@ -80,6 +82,18 @@ public class DynamoDBTransactionLogSnapshotStore {
         return latestMetadataLoader.load().getPartitionsSnapshot()
                 .filter(metadata -> metadata.getTransactionNumber() >= transactionNumber)
                 .map(this::loadPartitionsSnapshot);
+    }
+
+    public TransactionLogSnapshot loadFilesSnapshot(LatestSnapshots snapshots) {
+        return snapshots.getFilesSnapshot()
+                .map(this::loadFilesSnapshot)
+                .orElseGet(() -> new TransactionLogSnapshot(new StateStoreFiles(), 0));
+    }
+
+    public TransactionLogSnapshot loadPartitionsSnapshot(LatestSnapshots snapshots) {
+        return snapshots.getPartitionsSnapshot()
+                .map(this::loadPartitionsSnapshot)
+                .orElseGet(() -> new TransactionLogSnapshot(new StateStorePartitions(), 0));
     }
 
     private TransactionLogSnapshot loadFilesSnapshot(TransactionLogSnapshotMetadata metadata) {

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreatorIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreatorIT.java
@@ -341,7 +341,7 @@ public class TransactionLogSnapshotCreatorIT extends TransactionLogStateStoreTes
 
     private void runSnapshotCreator(
             TableProperties table, LatestSnapshotsMetadataLoader latestSnapshotsLoader, SnapshotMetadataSaver snapshotSaver) {
-        new TransactionLogSnapshotCreator(
+        new DynamoDBTransactionLogSnapshotCreator(
                 instanceProperties, table,
                 fileTransactionStoreByTableId.get(table.get(TABLE_ID)),
                 partitionTransactionStoreByTableId.get(table.get(TABLE_ID)),

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreDynamoDBSpecificIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreDynamoDBSpecificIT.java
@@ -246,7 +246,7 @@ public class TransactionLogStateStoreDynamoDBSpecificIT extends TransactionLogSt
 
             DynamoDBTransactionLogSnapshotMetadataStore snapshotStore = new DynamoDBTransactionLogSnapshotMetadataStore(
                     instanceProperties, tableProperties, dynamoDBClient);
-            new TransactionLogSnapshotCreator(
+            new DynamoDBTransactionLogSnapshotCreator(
                     instanceProperties, tableProperties,
                     snapshotSetup.getFilesLog(), snapshotSetup.getPartitionsLog(),
                     configuration, snapshotStore::getLatestSnapshots, snapshotStore::saveSnapshot)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2524

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests, removed some in TransactionLogStateStoreSnapshotsTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.