### PR TITLE
Issue 2550 - Handle deleting tables with snapshots

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
@@ -60,8 +60,8 @@ public class DeleteTable {
     public void delete(String tableName) throws StateStoreException {
         TableProperties tableProperties = tablePropertiesStore.loadByName(tableName);
         stateStoreProvider.getStateStore(tableProperties).clearSleeperTable();
-        tablePropertiesStore.deleteByName(tableName);
         deleteAllObjectsInBucketWithPrefix(s3Client, instanceProperties.get(DATA_BUCKET), tableProperties.get(TABLE_ID));
+        tablePropertiesStore.deleteByName(tableName);
         LOGGER.info("Successfully deleted table {}", tableProperties.getStatus());
     }
 

--- a/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
@@ -57,21 +57,16 @@ public class DeleteTable {
         this.stateStoreProvider = stateStoreProvider;
     }
 
-    /**
-     * Deletes a table from the Sleeper instance.
-     *
-     * First we clear the state store for the table. This needs to happen first so that if a transaction log
-     * snapshot exists, it can be loaded when the transaction log state store updates.
-     * We then delete all files in the data bucket for the table.
-     * Finally, the table is removed from the table index, and the table properties file is removed. This happens
-     * last to handle the case where the deletion of files in the data bucket fails, so you can still see that a
-     * table existed.
-     *
-     * @param  tableName           the name of the table to delete
-     * @throws StateStoreException -
-     */
     public void delete(String tableName) throws StateStoreException {
         TableProperties tableProperties = tablePropertiesStore.loadByName(tableName);
+        /*
+         * - First we clear the state store for the table. This needs to happen first so that if a transaction log
+         * snapshot exists, it can be loaded when the transaction log state store updates.
+         * - We then delete all files in the data bucket for the table.
+         * - Finally, the table is removed from the table index, and the table properties file is removed. This happens
+         * last to handle the case where the deletion of files in the data bucket fails, so you can still see that a
+         * table existed.
+         */
         stateStoreProvider.getStateStore(tableProperties).clearSleeperTable();
         deleteAllObjectsInBucketWithPrefix(s3Client, instanceProperties.get(DATA_BUCKET), tableProperties.get(TABLE_ID));
         tablePropertiesStore.deleteByName(tableName);

--- a/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
@@ -59,9 +59,9 @@ public class DeleteTable {
 
     public void delete(String tableName) throws StateStoreException {
         TableProperties tableProperties = tablePropertiesStore.loadByName(tableName);
-        deleteAllObjectsInBucketWithPrefix(s3Client, instanceProperties.get(DATA_BUCKET), tableProperties.get(TABLE_ID));
         stateStoreProvider.getStateStore(tableProperties).clearSleeperTable();
         tablePropertiesStore.deleteByName(tableName);
+        deleteAllObjectsInBucketWithPrefix(s3Client, instanceProperties.get(DATA_BUCKET), tableProperties.get(TABLE_ID));
         LOGGER.info("Successfully deleted table {}", tableProperties.getStatus());
     }
 

--- a/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
+++ b/java/clients/src/main/java/sleeper/clients/status/update/DeleteTable.java
@@ -57,6 +57,19 @@ public class DeleteTable {
         this.stateStoreProvider = stateStoreProvider;
     }
 
+    /**
+     * Deletes a table from the Sleeper instance.
+     *
+     * First we clear the state store for the table. This needs to happen first so that if a transaction log
+     * snapshot exists, it can be loaded when the transaction log state store updates.
+     * We then delete all files in the data bucket for the table.
+     * Finally, the table is removed from the table index, and the table properties file is removed. This happens
+     * last to handle the case where the deletion of files in the data bucket fails, so you can still see that a
+     * table existed.
+     *
+     * @param  tableName           the name of the table to delete
+     * @throws StateStoreException -
+     */
     public void delete(String tableName) throws StateStoreException {
         TableProperties tableProperties = tablePropertiesStore.loadByName(tableName);
         stateStoreProvider.getStateStore(tableProperties).clearSleeperTable();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2550

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - `DeleteTableIT.shouldDeleteTableWhenSnapshotIsPresent`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.