### PR TITLE
Issue 2529 - Use attempts count consistently with exponential backoff retries

### DIFF
--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionJobCommitter.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionJobCommitter.java
@@ -79,8 +79,8 @@ public class CompactionJobCommitter {
         // Sometimes the compaction can finish before the job assignment is finished. We wait for the job assignment
         // rather than immediately failing the job run.
         FileReferenceNotAssignedToJobException failure = null;
-        for (int attempts = 0; attempts < jobAssignmentWaitAttempts; attempts++) {
-            jobAssignmentWaitBackoff.waitBeforeAttempt(attempts);
+        for (int attempt = 1; attempt <= jobAssignmentWaitAttempts; attempt++) {
+            jobAssignmentWaitBackoff.waitBeforeAttempt(attempt);
             try {
                 stateStore.atomicallyReplaceFileReferencesWithNewOne(job.getId(), job.getPartitionId(), job.getInputFiles(), fileReference);
                 return;

--- a/java/core/src/main/java/sleeper/core/util/ExponentialBackoffWithJitter.java
+++ b/java/core/src/main/java/sleeper/core/util/ExponentialBackoffWithJitter.java
@@ -55,6 +55,8 @@ public class ExponentialBackoffWithJitter {
     public long waitBeforeAttempt(int attempt) throws InterruptedException {
         if (attempt == 1) { // No wait on first attempt
             return 0;
+        } else if (attempt < 1) {
+            throw new IllegalArgumentException("Attempt count must start at 1, found " + attempt);
         }
         long waitMillis = getWaitMillisBeforeAttempt(attempt);
         LOGGER.debug("Sleeping for {}", LoggedDuration.withFullOutput(Duration.ofMillis(waitMillis)));
@@ -65,7 +67,7 @@ public class ExponentialBackoffWithJitter {
     private long getWaitMillisBeforeAttempt(int attempt) {
         double waitCeilingInSeconds = Math.min(
                 waitRange.maxWaitCeilingSecs,
-                waitRange.firstWaitCeilingSecs * 0.5 * Math.pow(2.0, attempt - 1));
+                waitRange.firstWaitCeilingSecs * Math.pow(2.0, attempt - 2)); // First retry is attempt 2
         return (long) (randomJitterFraction.getAsDouble() * waitCeilingInSeconds * 1000L);
     }
 

--- a/java/core/src/main/java/sleeper/core/util/ExponentialBackoffWithJitter.java
+++ b/java/core/src/main/java/sleeper/core/util/ExponentialBackoffWithJitter.java
@@ -46,24 +46,13 @@ public class ExponentialBackoffWithJitter {
     }
 
     /**
-     * Waits for a time calculated from the number of attempts that have been made so far.
-     *
-     * @param  attempt              the number of attempts so far
-     * @return                      the number of milliseconds waited for
-     * @throws InterruptedException if the current thread was interrupted
-     */
-    public long waitBeforeAttempt(int attempt) throws InterruptedException {
-        return waitBeforeAttemptNew(attempt + 1);
-    }
-
-    /**
      * Waits for a time calculated from the number of attempts.
      *
      * @param  attempt              the number of the attempt that is about to be made, starting at 1
      * @return                      the number of milliseconds waited for
      * @throws InterruptedException if the current thread was interrupted
      */
-    public long waitBeforeAttemptNew(int attempt) throws InterruptedException {
+    public long waitBeforeAttempt(int attempt) throws InterruptedException {
         if (attempt == 1) { // No wait on first attempt
             return 0;
         }

--- a/java/core/src/main/java/sleeper/core/util/ExponentialBackoffWithJitter.java
+++ b/java/core/src/main/java/sleeper/core/util/ExponentialBackoffWithJitter.java
@@ -53,7 +53,18 @@ public class ExponentialBackoffWithJitter {
      * @throws InterruptedException if the current thread was interrupted
      */
     public long waitBeforeAttempt(int attempt) throws InterruptedException {
-        if (attempt == 0) { // No wait on first attempt
+        return waitBeforeAttemptNew(attempt + 1);
+    }
+
+    /**
+     * Waits for a time calculated from the number of attempts.
+     *
+     * @param  attempt              the number of the attempt that is about to be made, starting at 1
+     * @return                      the number of milliseconds waited for
+     * @throws InterruptedException if the current thread was interrupted
+     */
+    public long waitBeforeAttemptNew(int attempt) throws InterruptedException {
+        if (attempt == 1) { // No wait on first attempt
             return 0;
         }
         long waitMillis = getWaitMillisBeforeAttempt(attempt);
@@ -65,7 +76,7 @@ public class ExponentialBackoffWithJitter {
     private long getWaitMillisBeforeAttempt(int attempt) {
         double waitCeilingInSeconds = Math.min(
                 waitRange.maxWaitCeilingSecs,
-                waitRange.firstWaitCeilingSecs * 0.5 * Math.pow(2.0, attempt));
+                waitRange.firstWaitCeilingSecs * 0.5 * Math.pow(2.0, attempt - 1));
         return (long) (randomJitterFraction.getAsDouble() * waitCeilingInSeconds * 1000L);
     }
 

--- a/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTest.java
+++ b/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTest.java
@@ -151,7 +151,7 @@ public class ExponentialBackoffWithJitterTest {
         ExponentialBackoffWithJitter backoff = new ExponentialBackoffWithJitter(
                 waitRange, randomJitterFraction, recordWaits(foundWaits));
         for (int i = 1; i <= attempts; i++) {
-            backoff.waitBeforeAttemptNew(i);
+            backoff.waitBeforeAttempt(i);
         }
     }
 }

--- a/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTest.java
+++ b/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.function.DoubleSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.constantJitterFraction;
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.fixJitterSeed;
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.noJitter;
@@ -138,6 +139,20 @@ public class ExponentialBackoffWithJitterTest {
                 Duration.parse("PT26.375S"));
     }
 
+    @Test
+    void shouldRefuseAttemptZero() {
+        ExponentialBackoffWithJitter backoff = backoff();
+        assertThatThrownBy(() -> backoff.waitBeforeAttempt(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRefuseNegativeAttempt() {
+        ExponentialBackoffWithJitter backoff = backoff();
+        assertThatThrownBy(() -> backoff.waitBeforeAttempt(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
     private void makeAttempts(int attempts) throws Exception {
         makeAttempts(attempts, fixJitterSeed());
     }
@@ -153,5 +168,9 @@ public class ExponentialBackoffWithJitterTest {
         for (int i = 1; i <= attempts; i++) {
             backoff.waitBeforeAttempt(i);
         }
+    }
+
+    private ExponentialBackoffWithJitter backoff() {
+        return new ExponentialBackoffWithJitter(WAIT_RANGE, fixJitterSeed(), recordWaits(foundWaits));
     }
 }

--- a/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTest.java
+++ b/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTest.java
@@ -150,8 +150,8 @@ public class ExponentialBackoffWithJitterTest {
             int attempts, WaitRange waitRange, DoubleSupplier randomJitterFraction) throws Exception {
         ExponentialBackoffWithJitter backoff = new ExponentialBackoffWithJitter(
                 waitRange, randomJitterFraction, recordWaits(foundWaits));
-        for (int i = 0; i < attempts; i++) {
-            backoff.waitBeforeAttempt(i);
+        for (int i = 1; i <= attempts; i++) {
+            backoff.waitBeforeAttemptNew(i);
         }
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2529

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated ExponentialBackoffWithJitterTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.