### PR TITLE
Issue 2615 - Don't purge deleted bulk import job queue in system test

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrPersistentBulkImportIT.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrPersistentBulkImportIT.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import sleeper.cdk.stack.bulkimport.PersistentEmrBulkImportStack;
 import sleeper.systemtest.dsl.SleeperSystemTest;
-import sleeper.systemtest.dsl.extension.AfterTestPurgeQueues;
 import sleeper.systemtest.dsl.extension.AfterTestReports;
 import sleeper.systemtest.dsl.reporting.SystemTestReports;
 import sleeper.systemtest.suite.fixtures.SystemTestSchema;
@@ -50,11 +49,12 @@ import static sleeper.systemtest.suite.testutil.PartitionsTestHelper.partitionsB
 public class EmrPersistentBulkImportIT {
 
     @BeforeEach
-    void setUp(SleeperSystemTest sleeper, AfterTestReports reporting, AfterTestPurgeQueues purgeQueues) {
+    void setUp(SleeperSystemTest sleeper, AfterTestReports reporting) {
         sleeper.connectToInstance(MAIN);
         sleeper.enableOptionalStack(PersistentEmrBulkImportStack.class);
         reporting.reportAlways(SystemTestReports.SystemTestBuilder::ingestJobs);
-        purgeQueues.purgeIfTestFailed(BULK_IMPORT_PERSISTENT_EMR_JOB_QUEUE_URL);
+        // Note that we don't purge the bulk import job queue when the test fails,
+        // because it is deleted when the optional stack is disabled.
     }
 
     @AfterEach


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2615

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by system test

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.