### PR TITLE
Issue 2671 - Add missing java flags required by Arrow to read statestore files

### DIFF
--- a/scripts/deploy/deleteTable.sh
+++ b/scripts/deploy/deleteTable.sh
@@ -31,4 +31,6 @@ VERSION=$(cat "${TEMPLATE_DIR}/version.txt")
 echo "-------------------------------------------------------"
 echo "Deleting table"
 echo "-------------------------------------------------------"
-java -cp "${JAR_DIR}/clients-${VERSION}-utility.jar" sleeper.clients.status.update.DeleteTable "$@"
+java -cp "${JAR_DIR}/clients-${VERSION}-utility.jar" \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  sleeper.clients.status.update.DeleteTable "$@"

--- a/scripts/utility/adminClient.sh
+++ b/scripts/utility/adminClient.sh
@@ -24,4 +24,6 @@ fi
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd "../" && pwd)
 VERSION=$(cat "${SCRIPTS_DIR}/templates/version.txt")
 
-java -cp "${SCRIPTS_DIR}/jars/clients-${VERSION}-utility.jar" sleeper.clients.AdminClient "${SCRIPTS_DIR}" "$@"
+java -cp "${SCRIPTS_DIR}/jars/clients-${VERSION}-utility.jar" \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  sleeper.clients.AdminClient "${SCRIPTS_DIR}" "$@"

--- a/scripts/utility/filesStatusReport.sh
+++ b/scripts/utility/filesStatusReport.sh
@@ -17,4 +17,6 @@ set -e
 unset CDPATH
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd "../" && pwd)
-java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.report.FilesStatusReport "$@"
+java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  sleeper.clients.status.report.FilesStatusReport "$@"

--- a/scripts/utility/fullStatusReport.sh
+++ b/scripts/utility/fullStatusReport.sh
@@ -31,9 +31,13 @@ TABLE_NAME=$2
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd "../" && pwd)
 
 if [[ -z $3 ]]; then
-  java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.report.StatusReport "${INSTANCE_ID}" "${TABLE_NAME}"
+  java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar \
+    --add-opens java.base/java.nio=ALL-UNNAMED \
+    sleeper.clients.status.report.StatusReport "${INSTANCE_ID}" "${TABLE_NAME}"
 else
   VERBOSE=$3
   echo "Optional Parameter for <Verbose> recognised and set to" "${VERBOSE}"
-  java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.report.StatusReport "${INSTANCE_ID}" "${TABLE_NAME}" "${VERBOSE}"
+  java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar \
+    --add-opens java.base/java.nio=ALL-UNNAMED \
+    sleeper.clients.status.report.StatusReport "${INSTANCE_ID}" "${TABLE_NAME}" "${VERBOSE}"
 fi

--- a/scripts/utility/partitionsStatusReport.sh
+++ b/scripts/utility/partitionsStatusReport.sh
@@ -30,4 +30,6 @@ TABLE_NAME=$2
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd "../" && pwd)
 
-java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.report.PartitionsStatusReport "${INSTANCE_ID}" "${TABLE_NAME}"
+java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  sleeper.clients.status.report.PartitionsStatusReport "${INSTANCE_ID}" "${TABLE_NAME}"

--- a/scripts/utility/query.sh
+++ b/scripts/utility/query.sh
@@ -17,4 +17,6 @@ set -e
 unset CDPATH
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd "../" && pwd)
-java -cp ${SCRIPTS_DIR}/jars/clients-*-utility.jar sleeper.clients.QueryClient "$@"
+java -cp ${SCRIPTS_DIR}/jars/clients-*-utility.jar \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  sleeper.clients.QueryClient "$@"

--- a/scripts/utility/reinitialiseTable.sh
+++ b/scripts/utility/reinitialiseTable.sh
@@ -29,9 +29,10 @@ INSTANCE_ID=$1
 TABLE_NAME=$2
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd "../" && pwd)
+ARROW_FLAGS="--add-opens java.base/java.nio=ALL-UNNAMED"
 
 if [[ -z $3 ]]; then
-  java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.update.ReinitialiseTable "${INSTANCE_ID}" "${TABLE_NAME}"
+  java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar $ARROW_FLAGS sleeper.clients.status.update.ReinitialiseTable "${INSTANCE_ID}" "${TABLE_NAME}"
 else
   DELETE_PARTITIONS=$3
   echo "Optional parameter for <delete-partitions> recognised and set to" "${DELETE_PARTITIONS}"
@@ -41,11 +42,11 @@ else
     if [[ -n $5 ]]; then
       SPLIT_POINTS_FILE_ENCODED=$5
       echo "Optional parameter for <split-points-file-base64-encoded> recognised and set to" "${SPLIT_POINTS_FILE_ENCODED}"
-      java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.update.ReinitialiseTableFromSplitPoints "${INSTANCE_ID}" "${TABLE_NAME}" "${SPLIT_POINT_FILE_LOCATION}" "${SPLIT_POINTS_FILE_ENCODED}"
+      java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar $ARROW_FLAGS sleeper.clients.status.update.ReinitialiseTableFromSplitPoints "${INSTANCE_ID}" "${TABLE_NAME}" "${SPLIT_POINT_FILE_LOCATION}" "${SPLIT_POINTS_FILE_ENCODED}"
     else
-      java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.update.ReinitialiseTableFromSplitPoints "${INSTANCE_ID}" "${TABLE_NAME}" "${SPLIT_POINT_FILE_LOCATION}"
+      java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar $ARROW_FLAGS sleeper.clients.status.update.ReinitialiseTableFromSplitPoints "${INSTANCE_ID}" "${TABLE_NAME}" "${SPLIT_POINT_FILE_LOCATION}"
     fi
   else
-    java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.status.update.ReinitialiseTable "${INSTANCE_ID}" "${TABLE_NAME}" "${DELETE_PARTITIONS}"
+    java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar $ARROW_FLAGS sleeper.clients.status.update.ReinitialiseTable "${INSTANCE_ID}" "${TABLE_NAME}" "${DELETE_PARTITIONS}"
   fi
 fi


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2671

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Tested in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.