### PR TITLE
Issue 2761 - Keep statestore property prefixes consistent

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -104,29 +104,29 @@ sleeper.properties.force.reload=false
 
 # The maximum size of state store providers. If a state store is needed and the cache is full, the
 # oldest state store in the cache will be removed to make space.
-sleeper.metadata.statestore.provider.cache.size=10
+sleeper.statestore.statestore.provider.cache.size=10
 
 # This specifies whether point in time recovery is enabled for the DynamoDB state store. This is set
 # on the DynamoDB tables.
-sleeper.metadata.dynamo.pointintimerecovery=false
+sleeper.statestore.dynamo.pointintimerecovery=false
 
 # This specifies whether point in time recovery is enabled for the S3 state store. This is set on the
 # revision DynamoDB table.
-sleeper.metadata.s3.dynamo.pointintimerecovery=false
+sleeper.statestore.s3.dynamo.pointintimerecovery=false
 
 # The number of tables to create transaction log snapshots for in a single invocation. This will be
 # the batch size for a lambda as an SQS FIFO event source. This can be a maximum of 10.
-sleeper.metadata.transactionlog.snapshot.creation.batch.size=1
+sleeper.statestore.transactionlog.snapshot.creation.batch.size=1
 
 # The frequency in minutes with which the transaction log snapshot creation lambda is run.
-sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes=5
+sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes=5
 
 # The number of tables to delete old transaction log snapshots for in a single invocation. This will
 # be the batch size for a lambda as an SQS FIFO event source. This can be a maximum of 10.
-sleeper.metadata.transactionlog.snapshot.deletion.batch.size=1
+sleeper.statestore.transactionlog.snapshot.deletion.batch.size=1
 
 # The frequency in minutes with which the transaction log snapshot deletion lambda is run.
-sleeper.metadata.transactionlog.snapshot.deletion.lambda.period.minutes=60
+sleeper.statestore.transactionlog.snapshot.deletion.lambda.period.minutes=60
 
 # This specifies whether point in time recovery is enabled for the Sleeper table index. This is set on
 # the DynamoDB tables.
@@ -1062,14 +1062,14 @@ sleeper.default.parquet.writer.version=v2
 
 # The number of attempts to make when applying a transaction to the state store. This default can be
 # overridden by a table property.
-sleeper.default.metadata.transactionlog.add.transaction.max.attempts=10
+sleeper.default.statestore.transactionlog.add.transaction.max.attempts=10
 
 # The maximum amount of time to wait before the first retry when applying a transaction to the state
 # store. Full jitter will be applied so that the actual wait time will be a random period between 0
 # and this value. This ceiling will increase exponentially on further retries. See the below article.
 # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 # This default can be overridden by a table property.
-sleeper.default.transactionlog.metadata.add.transaction.first.retry.wait.ceiling.ms=200
+sleeper.default.statestore.transactionlog.add.transaction.first.retry.wait.ceiling.ms=200
 
 # The maximum amount of time to wait before any retry when applying a transaction to the state store.
 # Full jitter will be applied so that the actual wait time will be a random period between 0 and this
@@ -1077,13 +1077,13 @@ sleeper.default.transactionlog.metadata.add.transaction.first.retry.wait.ceiling
 # See the below article.
 # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 # This default can be overridden by a table property.
-sleeper.default.transactionlog.metadata.add.transaction.max.retry.wait.ceiling.ms=30000
+sleeper.default.statestore.transactionlog.add.transaction.max.retry.wait.ceiling.ms=30000
 
 # The number of seconds to wait after we've loaded a snapshot before looking for a new snapshot. This
 # should relate to the rate at which new snapshots are created, configured in the instance property
-# `sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes`. This default can be
+# `sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes`. This default can be
 # overridden by a table property.
-sleeper.default.metadata.transactionlog.time.between.snapshot.checks.secs=60
+sleeper.default.statestore.transactionlog.time.between.snapshot.checks.secs=60
 
 # The number of milliseconds to wait after we've updated from the transaction log before checking for
 # new transactions. The state visible to an instance of the state store can be out of date by this
@@ -1091,20 +1091,20 @@ sleeper.default.metadata.transactionlog.time.between.snapshot.checks.secs=60
 # when using multiple state store objects. When adding a new transaction to update the state, this
 # will be ignored and the state will be brought completely up to date. This default can be overridden
 # by a table property.
-sleeper.default.metadata.transactionlog.time.between.transaction.checks.ms=0
+sleeper.default.statestore.transactionlog.time.between.transaction.checks.ms=0
 
 # The minimum number of transactions that a snapshot must be ahead of the local state, before we load
 # the snapshot instead of updating from the transaction log.
-sleeper.default.metadata.transactionlog.snapshot.load.min.transactions.ahead=10
+sleeper.default.statestore.transactionlog.snapshot.load.min.transactions.ahead=10
 
 # The number of days that transaction log snapshots remain in the snapshot store before being deleted.
-sleeper.default.metadata.transactionlog.snapshot.expiry.days=2
+sleeper.default.statestore.transactionlog.snapshot.expiry.days=2
 
 # The minimum age in minutes of a snapshot in order to allow deletion of transactions leading up to
 # it. When deleting old transactions, there's a chance that processes may still read transactions
 # starting from an older snapshot. We need to avoid deletion of any transactions associated with a
 # snapshot that may still be used as the starting point for reading the log.
-sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age.minutes=2
+sleeper.default.statestore.transactionlog.delete.behind.snapshot.min.age.minutes=2
 
 # The minimum number of transactions that a transaction must be behind the latest snapshot before
 # being deleted. This is the number of transactions that will be kept and protected from deletion,
@@ -1114,11 +1114,11 @@ sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age.minutes=2
 # This should be configured in relation to the property which determines whether a process will load
 # the latest snapshot or instead seek through the transaction log, since we need to preserve
 # transactions that may still be read:
-# sleeper.default.metadata.snapshot.load.min.transactions.ahead
+# sleeper.default.statestore.snapshot.load.min.transactions.ahead
 # The snapshot that will be considered the latest snapshot is configured by a property to set the
 # minimum age for it to count for this:
-# sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age
-sleeper.default.metadata.transactionlog.delete.number.behind.latest.snapshot=200
+# sleeper.default.statestore.transactionlog.delete.behind.snapshot.min.age
+sleeper.default.statestore.transactionlog.delete.number.behind.latest.snapshot=200
 
 # This specifies whether queries and scans against DynamoDB tables used in the state stores are
 # strongly consistent. This default can be overridden by a table property.

--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -132,45 +132,45 @@ sleeper.table.compaction.strategy.sizeratio.max.concurrent.jobs.per.partition=21
 sleeper.table.statestore.classname=sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore
 
 # The number of attempts to make when applying a transaction to the state store.
-sleeper.table.metadata.transactionlog.add.transaction.max.attempts=10
+sleeper.table.statestore.transactionlog.add.transaction.max.attempts=10
 
 # The maximum amount of time to wait before the first retry when applying a transaction to the state
 # store. Full jitter will be applied so that the actual wait time will be a random period between 0
 # and this value. This ceiling will increase exponentially on further retries. See the below article.
 # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-sleeper.table.metadata.transactionlog.add.transaction.first.retry.wait.ceiling.ms=200
+sleeper.table.statestore.transactionlog.add.transaction.first.retry.wait.ceiling.ms=200
 
 # The maximum amount of time to wait before any retry when applying a transaction to the state store.
 # Full jitter will be applied so that the actual wait time will be a random period between 0 and this
 # value. This restricts the exponential increase of the wait ceiling while retrying the transaction.
 # See the below article.
 # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-sleeper.table.metadata.transactionlog.add.transaction.max.retry.wait.ceiling.ms=30000
+sleeper.table.statestore.transactionlog.add.transaction.max.retry.wait.ceiling.ms=30000
 
 # The number of seconds to wait after we've loaded a snapshot before looking for a new snapshot. This
 # should relate to the rate at which new snapshots are created, configured in the instance property
-# `sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes`.
-sleeper.table.metadata.transactionlog.time.between.snapshot.checks.secs=60
+# `sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes`.
+sleeper.table.statestore.transactionlog.time.between.snapshot.checks.secs=60
 
 # The number of milliseconds to wait after we've updated from the transaction log before checking for
 # new transactions. The state visible to an instance of the state store can be out of date by this
 # amount. This can avoid excessive queries by the same process, but can result in unwanted behaviour
 # when using multiple state store objects. When adding a new transaction to update the state, this
 # will be ignored and the state will be brought completely up to date.
-sleeper.table.metadata.transactionlog.time.between.transaction.checks.ms=0
+sleeper.table.statestore.transactionlog.time.between.transaction.checks.ms=0
 
 # The minimum number of transactions that a snapshot must be ahead of the local state, before we load
 # the snapshot instead of updating from the transaction log.
-sleeper.table.metadata.transactionlog.snapshot.load.min.transactions.ahead=10
+sleeper.table.statestore.transactionlog.snapshot.load.min.transactions.ahead=10
 
 # The number of days that transaction log snapshots remain in the snapshot store before being deleted.
-sleeper.table.metadata.transactionlog.snapshot.expiry.days=2
+sleeper.table.statestore.transactionlog.snapshot.expiry.days=2
 
 # The minimum age in minutes of a snapshot in order to allow deletion of transactions leading up to
 # it. When deleting old transactions, there's a chance that processes may still read transactions
 # starting from an older snapshot. We need to avoid deletion of any transactions associated with a
 # snapshot that may still be used as the starting point for reading the log.
-sleeper.table.metadata.transactionlog.delete.behind.snapshot.min.age.minutes=2
+sleeper.table.statestore.transactionlog.delete.behind.snapshot.min.age.minutes=2
 
 # The minimum number of transactions that a transaction must be behind the latest snapshot before
 # being deleted. This is the number of transactions that will be kept and protected from deletion,
@@ -180,15 +180,15 @@ sleeper.table.metadata.transactionlog.delete.behind.snapshot.min.age.minutes=2
 # This should be configured in relation to the property which determines whether a process will load
 # the latest snapshot or instead seek through the transaction log, since we need to preserve
 # transactions that may still be read:
-# sleeper.table.metadata.snapshot.load.min.transactions.ahead
+# sleeper.table.statestore.snapshot.load.min.transactions.ahead
 # The snapshot that will be considered the latest snapshot is configured by a property to set the
 # minimum age for it to count for this:
-# sleeper.table.metadata.transactionlog.delete.behind.snapshot.min.age
-sleeper.table.metadata.transactionlog.delete.number.behind.latest.snapshot=200
+# sleeper.table.statestore.transactionlog.delete.behind.snapshot.min.age
+sleeper.table.statestore.transactionlog.delete.number.behind.latest.snapshot=200
 
 # This specifies whether queries and scans against DynamoDB tables used in the state stores are
 # strongly consistent.
-sleeper.table.metadata.dynamo.consistent.reads=false
+sleeper.table.statestore.dynamo.consistent.reads=false
 
 
 ## The following table properties relate to ingest.

--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -123,7 +123,7 @@ sleeper.table.compaction.strategy.sizeratio.max.concurrent.jobs.per.partition=21
 
 ## The following table properties relate to storing and retrieving metadata for tables.
 
-# The name of the class used for the metadata store. The default is DynamoDBTransactionLogStateStore.
+# The name of the class used for the state store. The default is DynamoDBTransactionLogStateStore.
 # Options are:
 # sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore
 # sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoSnapshots

--- a/java/clients/src/test/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditorIT.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditorIT.java
@@ -219,7 +219,7 @@ class UpdatePropertiesWithTextEditorIT {
 
             // When
             UpdatePropertiesRequest<TableProperties> updatePropertiesRequest = helper.updatePropertiesWithGroup(
-                    before, "sleeper.table.metadata.dynamo.consistent.reads=true", TablePropertyGroup.METADATA);
+                    before, "sleeper.table.statestore.dynamo.consistent.reads=true", TablePropertyGroup.METADATA);
 
             // Then
             assertThat(updatePropertiesRequest.getUpdatedProperties())

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CdkDefinedInstanceProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CdkDefinedInstanceProperty.java
@@ -65,80 +65,80 @@ public interface CdkDefinedInstanceProperty extends InstanceProperty {
             .build();
 
     // DynamoDBStateStore
-    CdkDefinedInstanceProperty ACTIVE_FILES_TABLELENAME = Index.propertyBuilder("sleeper.metadata.dynamo.active.table")
+    CdkDefinedInstanceProperty ACTIVE_FILES_TABLELENAME = Index.propertyBuilder("sleeper.statestore.dynamo.active.table")
             .description("The name of the DynamoDB table holding metadata of active files in Sleeper tables.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty FILE_REFERENCE_COUNT_TABLENAME = Index.propertyBuilder("sleeper.metadata.dynamo.file.reference.count.table")
+    CdkDefinedInstanceProperty FILE_REFERENCE_COUNT_TABLENAME = Index.propertyBuilder("sleeper.statestore.dynamo.file.reference.count.table")
             .description("The name of the DynamoDB table holding metadata of the number of references to files " +
                     "in Sleeper tables.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty PARTITION_TABLENAME = Index.propertyBuilder("sleeper.metadata.dynamo.partition.table")
+    CdkDefinedInstanceProperty PARTITION_TABLENAME = Index.propertyBuilder("sleeper.statestore.dynamo.partition.table")
             .description("The name of the DynamoDB table holding metadata of partitions in Sleeper tables.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
 
     // S3StateStore
-    CdkDefinedInstanceProperty REVISION_TABLENAME = Index.propertyBuilder("sleeper.metadata.s3.dynamo.revision.table")
+    CdkDefinedInstanceProperty REVISION_TABLENAME = Index.propertyBuilder("sleeper.statestore.s3.dynamo.revision.table")
             .description("The name of the DynamoDB table used for atomically updating the S3StateStore.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
 
     // TransactionLogStateStore
-    CdkDefinedInstanceProperty TRANSACTION_LOG_FILES_TABLENAME = Index.propertyBuilder("sleeper.metadata.transactionlog.dynamo.file.log.table")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_FILES_TABLENAME = Index.propertyBuilder("sleeper.statestore.transactionlog.dynamo.file.log.table")
             .description("The name of the DynamoDB table holding the state store file transaction log.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_PARTITIONS_TABLENAME = Index.propertyBuilder("sleeper.metadata.transactionlog.dynamo.partition.log.table")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_PARTITIONS_TABLENAME = Index.propertyBuilder("sleeper.statestore.transactionlog.dynamo.partition.log.table")
             .description("The name of the DynamoDB table holding the state store partition transaction log.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_ALL_SNAPSHOTS_TABLENAME = Index.propertyBuilder("sleeper.metadata.transactionlog.dynamo.all.snapshots.table")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_ALL_SNAPSHOTS_TABLENAME = Index.propertyBuilder("sleeper.statestore.transactionlog.dynamo.all.snapshots.table")
             .description("The name of the DynamoDB table holding information about all transaction log snapshots.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_LATEST_SNAPSHOTS_TABLENAME = Index.propertyBuilder("sleeper.metadata.transactionlog.dynamo.latest.snapshots.table")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_LATEST_SNAPSHOTS_TABLENAME = Index.propertyBuilder("sleeper.statestore.transactionlog.dynamo.latest.snapshots.table")
             .description("The name of the DynamoDB table holding information about latest transaction log snapshots.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_QUEUE_URL = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.creation.queue.url")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_QUEUE_URL = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.creation.queue.url")
             .description("URL of the queue for transaction log snapshot creation requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_QUEUE_ARN = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.creation.queue.arn")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_QUEUE_ARN = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.creation.queue.arn")
             .description("The ARN of the queue for transaction log snapshot creation requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_DLQ_URL = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.creation.dlq.url")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_DLQ_URL = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.creation.dlq.url")
             .description("The URL of the dead letter queue for transaction log snapshot creation requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_DLQ_ARN = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.creation.dlq.arn")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_DLQ_ARN = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.creation.dlq.arn")
             .description("The ARN of the dead letter queue for transaction log snapshot creation requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_RULE = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.creation.rule")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_RULE = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.creation.rule")
             .description("The name of the CloudWatch rule that triggers creation of transaction log snapshots.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_QUEUE_URL = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.deletion.queue.url")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_QUEUE_URL = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.deletion.queue.url")
             .description("URL of the queue for transaction log snapshot deletion requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_QUEUE_ARN = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.deletion.queue.arn")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_QUEUE_ARN = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.deletion.queue.arn")
             .description("The ARN of the queue for transaction log snapshot deletion requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_DLQ_URL = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.deletion.dlq.url")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_DLQ_URL = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.deletion.dlq.url")
             .description("The URL of the dead letter queue for transaction log snapshot deletion requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_DLQ_ARN = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.deletion.dlq.arn")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_DLQ_ARN = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.deletion.dlq.arn")
             .description("The ARN of the dead letter queue for transaction log snapshot deletion requests.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_RULE = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshots.deletion.rule")
+    CdkDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_RULE = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshots.deletion.rule")
             .description("The name of the CloudWatch rule that triggers deletion of transaction log snapshots.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
@@ -180,47 +180,47 @@ public interface CommonProperty {
                     "We may add the ability to use this in the CDK in the future.")
             .propertyGroup(InstancePropertyGroup.COMMON)
             .editable(false).build();
-    UserDefinedInstanceProperty STATESTORE_PROVIDER_CACHE_SIZE = Index.propertyBuilder("sleeper.metadata.statestore.provider.cache.size")
+    UserDefinedInstanceProperty STATESTORE_PROVIDER_CACHE_SIZE = Index.propertyBuilder("sleeper.statestore.statestore.provider.cache.size")
             .description("The maximum size of state store providers. If a state store is needed and the cache is full, the oldest state store in the cache will be removed to make space.")
             .defaultValue("10")
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    UserDefinedInstanceProperty DYNAMO_STATE_STORE_POINT_IN_TIME_RECOVERY = Index.propertyBuilder("sleeper.metadata.dynamo.pointintimerecovery")
+    UserDefinedInstanceProperty DYNAMO_STATE_STORE_POINT_IN_TIME_RECOVERY = Index.propertyBuilder("sleeper.statestore.dynamo.pointintimerecovery")
             .description("This specifies whether point in time recovery is enabled for the DynamoDB state store. " +
                     "This is set on the DynamoDB tables.")
             .defaultValue("false")
             .validationPredicate(Utils::isTrueOrFalse)
             .propertyGroup(InstancePropertyGroup.COMMON)
             .runCdkDeployWhenChanged(true).build();
-    UserDefinedInstanceProperty S3_STATE_STORE_DYNAMO_POINT_IN_TIME_RECOVERY = Index.propertyBuilder("sleeper.metadata.s3.dynamo.pointintimerecovery")
+    UserDefinedInstanceProperty S3_STATE_STORE_DYNAMO_POINT_IN_TIME_RECOVERY = Index.propertyBuilder("sleeper.statestore.s3.dynamo.pointintimerecovery")
             .description("This specifies whether point in time recovery is enabled for the S3 state store. " +
                     "This is set on the revision DynamoDB table.")
             .defaultValue("false")
             .validationPredicate(Utils::isTrueOrFalse)
             .propertyGroup(InstancePropertyGroup.COMMON)
             .runCdkDeployWhenChanged(true).build();
-    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_BATCH_SIZE = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshot.creation.batch.size")
+    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_BATCH_SIZE = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.creation.batch.size")
             .description("The number of tables to create transaction log snapshots for in a single invocation. This will be the batch size" +
                     " for a lambda as an SQS FIFO event source. This can be a maximum of 10.")
             .defaultValue("1")
             .validationPredicate(Utils::isPositiveIntegerLtEq10)
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_LAMBDA_PERIOD_IN_MINUTES = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes")
+    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_LAMBDA_PERIOD_IN_MINUTES = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes")
             .description("The frequency in minutes with which the transaction log snapshot creation lambda is run.")
             .defaultValue("5")
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_BATCH_SIZE = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshot.deletion.batch.size")
+    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_BATCH_SIZE = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.deletion.batch.size")
             .description("The number of tables to delete old transaction log snapshots for in a single invocation. This will be the batch size" +
                     " for a lambda as an SQS FIFO event source. This can be a maximum of 10.")
             .defaultValue("1")
             .validationPredicate(Utils::isPositiveIntegerLtEq10)
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
-    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_LAMBDA_PERIOD_IN_MINUTES = Index.propertyBuilder("sleeper.metadata.transactionlog.snapshot.deletion.lambda.period.minutes")
+    UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_LAMBDA_PERIOD_IN_MINUTES = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.deletion.lambda.period.minutes")
             .description("The frequency in minutes with which the transaction log snapshot deletion lambda is run.")
             .defaultValue("60")
             .validationPredicate(Utils::isPositiveInteger)

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/DefaultProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/DefaultProperty.java
@@ -85,13 +85,13 @@ public interface DefaultProperty {
             .defaultValue("v2")
             .validationPredicate(List.of("v1", "v2")::contains)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
-    UserDefinedInstanceProperty DEFAULT_ADD_TRANSACTION_MAX_ATTEMPTS = Index.propertyBuilder("sleeper.default.metadata.transactionlog.add.transaction.max.attempts")
+    UserDefinedInstanceProperty DEFAULT_ADD_TRANSACTION_MAX_ATTEMPTS = Index.propertyBuilder("sleeper.default.statestore.transactionlog.add.transaction.max.attempts")
             .description("The number of attempts to make when applying a transaction to the state store. " +
                     "This default can be overridden by a table property.")
             .defaultValue("" + TransactionLogStateStore.DEFAULT_MAX_ADD_TRANSACTION_ATTEMPTS)
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
-    UserDefinedInstanceProperty DEFAULT_ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.default.transactionlog.metadata.add.transaction.first.retry.wait.ceiling.ms")
+    UserDefinedInstanceProperty DEFAULT_ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.default.statestore.transactionlog.add.transaction.first.retry.wait.ceiling.ms")
             .description("The maximum amount of time to wait before the first retry when applying a transaction to " +
                     "the state store. Full jitter will be applied so that the actual wait time will be a random " +
                     "period between 0 and this value. This ceiling will increase exponentially on further retries. " +
@@ -101,7 +101,7 @@ public interface DefaultProperty {
             .defaultValue("" + TransactionLogStateStore.DEFAULT_RETRY_WAIT_RANGE.getFirstWaitCeiling().toMillis())
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
-    UserDefinedInstanceProperty DEFAULT_ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.default.transactionlog.metadata.add.transaction.max.retry.wait.ceiling.ms")
+    UserDefinedInstanceProperty DEFAULT_ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.default.statestore.transactionlog.add.transaction.max.retry.wait.ceiling.ms")
             .description("The maximum amount of time to wait before any retry when applying a transaction to " +
                     "the state store. Full jitter will be applied so that the actual wait time will be a random " +
                     "period between 0 and this value. This restricts the exponential increase of the wait ceiling " +
@@ -111,15 +111,15 @@ public interface DefaultProperty {
             .defaultValue("" + TransactionLogStateStore.DEFAULT_RETRY_WAIT_RANGE.getMaxWaitCeiling().toMillis())
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
-    UserDefinedInstanceProperty DEFAULT_TIME_BETWEEN_SNAPSHOT_CHECKS_SECS = Index.propertyBuilder("sleeper.default.metadata.transactionlog.time.between.snapshot.checks.secs")
+    UserDefinedInstanceProperty DEFAULT_TIME_BETWEEN_SNAPSHOT_CHECKS_SECS = Index.propertyBuilder("sleeper.default.statestore.transactionlog.time.between.snapshot.checks.secs")
             .description("The number of seconds to wait after we've loaded a snapshot before looking for a new " +
                     "snapshot. This should relate to the rate at which new snapshots are created, configured in the " +
-                    "instance property `sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes`. " +
+                    "instance property `sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes`. " +
                     "This default can be overridden by a table property.")
             .defaultValue("" + TransactionLogStateStore.DEFAULT_TIME_BETWEEN_SNAPSHOT_CHECKS.toSeconds())
             .validationPredicate(Utils::isNonNegativeInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
-    UserDefinedInstanceProperty DEFAULT_TIME_BETWEEN_TRANSACTION_CHECKS_MS = Index.propertyBuilder("sleeper.default.metadata.transactionlog.time.between.transaction.checks.ms")
+    UserDefinedInstanceProperty DEFAULT_TIME_BETWEEN_TRANSACTION_CHECKS_MS = Index.propertyBuilder("sleeper.default.statestore.transactionlog.time.between.transaction.checks.ms")
             .description("The number of milliseconds to wait after we've updated from the transaction log before " +
                     "checking for new transactions. The state visible to an instance of the state store can be out " +
                     "of date by this amount. This can avoid excessive queries by the same process, but can result in " +
@@ -129,20 +129,20 @@ public interface DefaultProperty {
             .defaultValue("" + TransactionLogStateStore.DEFAULT_TIME_BETWEEN_TRANSACTION_CHECKS.toMillis())
             .validationPredicate(Utils::isNonNegativeInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
-    UserDefinedInstanceProperty DEFAULT_MIN_TRANSACTIONS_AHEAD_TO_LOAD_SNAPSHOT = Index.propertyBuilder("sleeper.default.metadata.transactionlog.snapshot.load.min.transactions.ahead")
+    UserDefinedInstanceProperty DEFAULT_MIN_TRANSACTIONS_AHEAD_TO_LOAD_SNAPSHOT = Index.propertyBuilder("sleeper.default.statestore.transactionlog.snapshot.load.min.transactions.ahead")
             .description("The minimum number of transactions that a snapshot must be ahead of the local " +
                     "state, before we load the snapshot instead of updating from the transaction log.")
             .defaultValue("" + TransactionLogStateStore.DEFAULT_MIN_TRANSACTIONS_AHEAD_TO_LOAD_SNAPSHOT)
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
-    UserDefinedInstanceProperty DEFAULT_TRANSACTION_LOG_SNAPSHOT_EXPIRY_IN_DAYS = Index.propertyBuilder("sleeper.default.metadata.transactionlog.snapshot.expiry.days")
+    UserDefinedInstanceProperty DEFAULT_TRANSACTION_LOG_SNAPSHOT_EXPIRY_IN_DAYS = Index.propertyBuilder("sleeper.default.statestore.transactionlog.snapshot.expiry.days")
             .description("The number of days that transaction log snapshots remain in the snapshot store before being deleted.")
             .defaultValue("2")
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT)
             .build();
     UserDefinedInstanceProperty DEFAULT_TRANSACTION_LOG_SNAPSHOT_MIN_AGE_MINUTES_TO_DELETE_TRANSACTIONS = Index
-            .propertyBuilder("sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age.minutes")
+            .propertyBuilder("sleeper.default.statestore.transactionlog.delete.behind.snapshot.min.age.minutes")
             .description("The minimum age in minutes of a snapshot in order to allow deletion of transactions " +
                     "leading up to it. When deleting old transactions, there's a chance that processes may still " +
                     "read transactions starting from an older snapshot. We need to avoid deletion of any " +
@@ -152,7 +152,7 @@ public interface DefaultProperty {
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT)
             .build();
-    UserDefinedInstanceProperty DEFAULT_TRANSACTION_LOG_NUMBER_BEHIND_TO_DELETE = Index.propertyBuilder("sleeper.default.metadata.transactionlog.delete.number.behind.latest.snapshot")
+    UserDefinedInstanceProperty DEFAULT_TRANSACTION_LOG_NUMBER_BEHIND_TO_DELETE = Index.propertyBuilder("sleeper.default.statestore.transactionlog.delete.number.behind.latest.snapshot")
             .description("The minimum number of transactions that a transaction must be behind the latest snapshot " +
                     "before being deleted. This is the number of transactions that will be kept and protected from " +
                     "deletion, whenever old transactions are deleted. This includes the transaction that the latest " +
@@ -161,10 +161,10 @@ public interface DefaultProperty {
                     "This should be configured in relation to the property which determines whether a process will " +
                     "load the latest snapshot or instead seek through the transaction log, since we need to preserve " +
                     "transactions that may still be read:\n" +
-                    "sleeper.default.metadata.snapshot.load.min.transactions.ahead\n" +
+                    "sleeper.default.statestore.snapshot.load.min.transactions.ahead\n" +
                     "The snapshot that will be considered the latest snapshot is configured by a property to set the " +
                     "minimum age for it to count for this:\n" +
-                    "sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age\n")
+                    "sleeper.default.statestore.transactionlog.delete.behind.snapshot.min.age\n")
             .defaultValue("200")
             .validationPredicate(Utils::isPositiveInteger)
             .propertyGroup(InstancePropertyGroup.DEFAULT)

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
@@ -257,12 +257,12 @@ public interface TableProperty extends SleeperProperty {
                     "sleeper.statestore.dynamodb.DynamoDBStateStore")
             .propertyGroup(TablePropertyGroup.METADATA)
             .editable(false).build();
-    TableProperty ADD_TRANSACTION_MAX_ATTEMPTS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.add.transaction.max.attempts")
+    TableProperty ADD_TRANSACTION_MAX_ATTEMPTS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.add.transaction.max.attempts")
             .defaultProperty(DEFAULT_ADD_TRANSACTION_MAX_ATTEMPTS)
             .description("The number of attempts to make when applying a transaction to the state store.")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.add.transaction.first.retry.wait.ceiling.ms")
+    TableProperty ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.add.transaction.first.retry.wait.ceiling.ms")
             .defaultProperty(DEFAULT_ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS)
             .description("The maximum amount of time to wait before the first retry when applying a transaction to " +
                     "the state store. Full jitter will be applied so that the actual wait time will be a random " +
@@ -271,7 +271,7 @@ public interface TableProperty extends SleeperProperty {
                     "https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.add.transaction.max.retry.wait.ceiling.ms")
+    TableProperty ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.add.transaction.max.retry.wait.ceiling.ms")
             .defaultProperty(DEFAULT_ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS)
             .description("The maximum amount of time to wait before any retry when applying a transaction to " +
                     "the state store. Full jitter will be applied so that the actual wait time will be a random " +
@@ -280,14 +280,14 @@ public interface TableProperty extends SleeperProperty {
                     "https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty TIME_BETWEEN_SNAPSHOT_CHECKS_SECS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.time.between.snapshot.checks.secs")
+    TableProperty TIME_BETWEEN_SNAPSHOT_CHECKS_SECS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.time.between.snapshot.checks.secs")
             .defaultProperty(DEFAULT_TIME_BETWEEN_SNAPSHOT_CHECKS_SECS)
             .description("The number of seconds to wait after we've loaded a snapshot before looking for a new " +
                     "snapshot. This should relate to the rate at which new snapshots are created, configured in the " +
-                    "instance property `sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes`.")
+                    "instance property `sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes`.")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty TIME_BETWEEN_TRANSACTION_CHECKS_MS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.time.between.transaction.checks.ms")
+    TableProperty TIME_BETWEEN_TRANSACTION_CHECKS_MS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.time.between.transaction.checks.ms")
             .defaultProperty(DEFAULT_TIME_BETWEEN_TRANSACTION_CHECKS_MS)
             .description("The number of milliseconds to wait after we've updated from the transaction log before " +
                     "checking for new transactions. The state visible to an instance of the state store can be out " +
@@ -296,18 +296,18 @@ public interface TableProperty extends SleeperProperty {
                     "update the state, this will be ignored and the state will be brought completely up to date.")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty MIN_TRANSACTIONS_AHEAD_TO_LOAD_SNAPSHOT = Index.propertyBuilder("sleeper.table.metadata.transactionlog.snapshot.load.min.transactions.ahead")
+    TableProperty MIN_TRANSACTIONS_AHEAD_TO_LOAD_SNAPSHOT = Index.propertyBuilder("sleeper.table.statestore.transactionlog.snapshot.load.min.transactions.ahead")
             .defaultProperty(DEFAULT_MIN_TRANSACTIONS_AHEAD_TO_LOAD_SNAPSHOT)
             .description("The minimum number of transactions that a snapshot must be ahead of the local " +
                     "state, before we load the snapshot instead of updating from the transaction log.")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty TRANSACTION_LOG_SNAPSHOT_EXPIRY_IN_DAYS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.snapshot.expiry.days")
+    TableProperty TRANSACTION_LOG_SNAPSHOT_EXPIRY_IN_DAYS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.snapshot.expiry.days")
             .defaultProperty(DEFAULT_TRANSACTION_LOG_SNAPSHOT_EXPIRY_IN_DAYS)
             .description("The number of days that transaction log snapshots remain in the snapshot store before being deleted.")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty TRANSACTION_LOG_SNAPSHOT_MIN_AGE_MINUTES_TO_DELETE_TRANSACTIONS = Index.propertyBuilder("sleeper.table.metadata.transactionlog.delete.behind.snapshot.min.age.minutes")
+    TableProperty TRANSACTION_LOG_SNAPSHOT_MIN_AGE_MINUTES_TO_DELETE_TRANSACTIONS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.delete.behind.snapshot.min.age.minutes")
             .description("The minimum age in minutes of a snapshot in order to allow deletion of transactions " +
                     "leading up to it. When deleting old transactions, there's a chance that processes may still " +
                     "read transactions starting from an older snapshot. We need to avoid deletion of any " +
@@ -316,7 +316,7 @@ public interface TableProperty extends SleeperProperty {
             .defaultProperty(DEFAULT_TRANSACTION_LOG_SNAPSHOT_MIN_AGE_MINUTES_TO_DELETE_TRANSACTIONS)
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty TRANSACTION_LOG_NUMBER_BEHIND_TO_DELETE = Index.propertyBuilder("sleeper.table.metadata.transactionlog.delete.number.behind.latest.snapshot")
+    TableProperty TRANSACTION_LOG_NUMBER_BEHIND_TO_DELETE = Index.propertyBuilder("sleeper.table.statestore.transactionlog.delete.number.behind.latest.snapshot")
             .defaultProperty(DEFAULT_TRANSACTION_LOG_NUMBER_BEHIND_TO_DELETE)
             .description("The minimum number of transactions that a transaction must be behind the latest snapshot " +
                     "before being deleted. This is the number of transactions that will be kept and protected from " +
@@ -326,13 +326,13 @@ public interface TableProperty extends SleeperProperty {
                     "This should be configured in relation to the property which determines whether a process will " +
                     "load the latest snapshot or instead seek through the transaction log, since we need to preserve " +
                     "transactions that may still be read:\n" +
-                    "sleeper.table.metadata.snapshot.load.min.transactions.ahead\n" +
+                    "sleeper.table.statestore.snapshot.load.min.transactions.ahead\n" +
                     "The snapshot that will be considered the latest snapshot is configured by a property to set the " +
                     "minimum age for it to count for this:\n" +
-                    "sleeper.table.metadata.transactionlog.delete.behind.snapshot.min.age\n")
+                    "sleeper.table.statestore.transactionlog.delete.behind.snapshot.min.age\n")
             .propertyGroup(TablePropertyGroup.METADATA)
             .build();
-    TableProperty DYNAMODB_STRONGLY_CONSISTENT_READS = Index.propertyBuilder("sleeper.table.metadata.dynamo.consistent.reads")
+    TableProperty DYNAMODB_STRONGLY_CONSISTENT_READS = Index.propertyBuilder("sleeper.table.statestore.dynamo.consistent.reads")
             .defaultProperty(DEFAULT_DYNAMO_STRONGLY_CONSISTENT_READS)
             .description("This specifies whether queries and scans against DynamoDB tables used in the state stores " +
                     "are strongly consistent.")

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
@@ -249,7 +249,7 @@ public interface TableProperty extends SleeperProperty {
             .build();
     TableProperty STATESTORE_CLASSNAME = Index.propertyBuilder("sleeper.table.statestore.classname")
             .defaultValue("sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore")
-            .description("The name of the class used for the metadata store. " +
+            .description("The name of the class used for the state store. " +
                     "The default is DynamoDBTransactionLogStateStore. Options are:\n" +
                     "sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore\n" +
                     "sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoSnapshots\n" +

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -145,29 +145,29 @@ sleeper.properties.force.reload=false
 
 # The maximum size of state store providers. If a state store is needed and the cache is full, the
 # oldest state store in the cache will be removed to make space.
-sleeper.metadata.statestore.provider.cache.size=10
+sleeper.statestore.statestore.provider.cache.size=10
 
 # This specifies whether point in time recovery is enabled for the DynamoDB state store. This is set
 # on the DynamoDB tables.
-sleeper.metadata.dynamo.pointintimerecovery=false
+sleeper.statestore.dynamo.pointintimerecovery=false
 
 # This specifies whether point in time recovery is enabled for the S3 state store. This is set on the
 # revision DynamoDB table.
-sleeper.metadata.s3.dynamo.pointintimerecovery=false
+sleeper.statestore.s3.dynamo.pointintimerecovery=false
 
 # The number of tables to create transaction log snapshots for in a single invocation. This will be
 # the batch size for a lambda as an SQS FIFO event source. This can be a maximum of 10.
-sleeper.metadata.transactionlog.snapshot.creation.batch.size=1
+sleeper.statestore.transactionlog.snapshot.creation.batch.size=1
 
 # The frequency in minutes with which the transaction log snapshot creation lambda is run.
-sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes=5
+sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes=5
 
 # The number of tables to delete old transaction log snapshots for in a single invocation. This will
 # be the batch size for a lambda as an SQS FIFO event source. This can be a maximum of 10.
-sleeper.metadata.transactionlog.snapshot.deletion.batch.size=1
+sleeper.statestore.transactionlog.snapshot.deletion.batch.size=1
 
 # The frequency in minutes with which the transaction log snapshot deletion lambda is run.
-sleeper.metadata.transactionlog.snapshot.deletion.lambda.period.minutes=60
+sleeper.statestore.transactionlog.snapshot.deletion.lambda.period.minutes=60
 
 # This specifies whether point in time recovery is enabled for the Sleeper table index. This is set on
 # the DynamoDB tables.
@@ -1086,14 +1086,14 @@ sleeper.default.parquet.writer.version=v2
 
 # The number of attempts to make when applying a transaction to the state store. This default can be
 # overridden by a table property.
-sleeper.default.metadata.transactionlog.add.transaction.max.attempts=10
+sleeper.default.statestore.transactionlog.add.transaction.max.attempts=10
 
 # The maximum amount of time to wait before the first retry when applying a transaction to the state
 # store. Full jitter will be applied so that the actual wait time will be a random period between 0
 # and this value. This ceiling will increase exponentially on further retries. See the below article.
 # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 # This default can be overridden by a table property.
-sleeper.default.transactionlog.metadata.add.transaction.first.retry.wait.ceiling.ms=200
+sleeper.default.statestore.transactionlog.add.transaction.first.retry.wait.ceiling.ms=200
 
 # The maximum amount of time to wait before any retry when applying a transaction to the state store.
 # Full jitter will be applied so that the actual wait time will be a random period between 0 and this
@@ -1101,13 +1101,13 @@ sleeper.default.transactionlog.metadata.add.transaction.first.retry.wait.ceiling
 # See the below article.
 # https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 # This default can be overridden by a table property.
-sleeper.default.transactionlog.metadata.add.transaction.max.retry.wait.ceiling.ms=30000
+sleeper.default.statestore.transactionlog.add.transaction.max.retry.wait.ceiling.ms=30000
 
 # The number of seconds to wait after we've loaded a snapshot before looking for a new snapshot. This
 # should relate to the rate at which new snapshots are created, configured in the instance property
-# `sleeper.metadata.transactionlog.snapshot.creation.lambda.period.minutes`. This default can be
+# `sleeper.statestore.transactionlog.snapshot.creation.lambda.period.minutes`. This default can be
 # overridden by a table property.
-sleeper.default.metadata.transactionlog.time.between.snapshot.checks.secs=60
+sleeper.default.statestore.transactionlog.time.between.snapshot.checks.secs=60
 
 # The number of milliseconds to wait after we've updated from the transaction log before checking for
 # new transactions. The state visible to an instance of the state store can be out of date by this
@@ -1115,20 +1115,20 @@ sleeper.default.metadata.transactionlog.time.between.snapshot.checks.secs=60
 # when using multiple state store objects. When adding a new transaction to update the state, this
 # will be ignored and the state will be brought completely up to date. This default can be overridden
 # by a table property.
-sleeper.default.metadata.transactionlog.time.between.transaction.checks.ms=0
+sleeper.default.statestore.transactionlog.time.between.transaction.checks.ms=0
 
 # The minimum number of transactions that a snapshot must be ahead of the local state, before we load
 # the snapshot instead of updating from the transaction log.
-sleeper.default.metadata.transactionlog.snapshot.load.min.transactions.ahead=10
+sleeper.default.statestore.transactionlog.snapshot.load.min.transactions.ahead=10
 
 # The number of days that transaction log snapshots remain in the snapshot store before being deleted.
-sleeper.default.metadata.transactionlog.snapshot.expiry.days=2
+sleeper.default.statestore.transactionlog.snapshot.expiry.days=2
 
 # The minimum age in minutes of a snapshot in order to allow deletion of transactions leading up to
 # it. When deleting old transactions, there's a chance that processes may still read transactions
 # starting from an older snapshot. We need to avoid deletion of any transactions associated with a
 # snapshot that may still be used as the starting point for reading the log.
-sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age.minutes=2
+sleeper.default.statestore.transactionlog.delete.behind.snapshot.min.age.minutes=2
 
 # The minimum number of transactions that a transaction must be behind the latest snapshot before
 # being deleted. This is the number of transactions that will be kept and protected from deletion,
@@ -1138,11 +1138,11 @@ sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age.minutes=2
 # This should be configured in relation to the property which determines whether a process will load
 # the latest snapshot or instead seek through the transaction log, since we need to preserve
 # transactions that may still be read:
-# sleeper.default.metadata.snapshot.load.min.transactions.ahead
+# sleeper.default.statestore.snapshot.load.min.transactions.ahead
 # The snapshot that will be considered the latest snapshot is configured by a property to set the
 # minimum age for it to count for this:
-# sleeper.default.metadata.transactionlog.delete.behind.snapshot.min.age
-sleeper.default.metadata.transactionlog.delete.number.behind.latest.snapshot=200
+# sleeper.default.statestore.transactionlog.delete.behind.snapshot.min.age
+sleeper.default.statestore.transactionlog.delete.number.behind.latest.snapshot=200
 
 # This specifies whether queries and scans against DynamoDB tables used in the state stores are
 # strongly consistent. This default can be overridden by a table property.

--- a/scripts/templates/tableproperties.template
+++ b/scripts/templates/tableproperties.template
@@ -33,7 +33,7 @@ sleeper.table.gc.delay.minutes=15
 
 ## The following table properties relate to storing and retrieving metadata for tables.
 
-# The name of the class used for the metadata store. The default is DynamoDBTransactionLogStateStore.
+# The name of the class used for the state store. The default is DynamoDBTransactionLogStateStore.
 # Options are:
 # sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore
 # sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStoreNoSnapshots


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2761

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Renaming properties

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.