### PR TITLE
Issue 2820 - Avoid botocore version clash in Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -19,8 +19,6 @@ pkgs.mkShell {
       python-pkgs.pip
       python-pkgs.setuptools
       python-pkgs.pyarrow
-      python-pkgs.boto3
-      python-pkgs.s3fs
     ]))
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,10 @@ pkgs.mkShell {
       python-pkgs.wheel
       python-pkgs.pip
       python-pkgs.setuptools
+      # PyArrow requires native code that isn't accessible through Nix with pip install
       python-pkgs.pyarrow
+      # Note that including boto3 or botocore here may break the AWS CLI.
+      # Nix adds Python dependencies for all Python installs, including the one in the AWS CLI package.
     ]))
   ];
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2820

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Manually tested that both the AWS CLI and the Sleeper Python code work

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.