### PR TITLE
Issue 2822 - Test system test reporting, add exceptions when no instance/table chosen

### DIFF
--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperTablesForTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/DeployedSleeperTablesForTest.java
@@ -81,11 +81,11 @@ public final class DeployedSleeperTablesForTest {
     }
 
     public TableProperties getTableProperties() {
-        return currentTable;
+        return currentTable();
     }
 
     public Schema getSchema() {
-        return currentTable.getSchema();
+        return currentTable().getSchema();
     }
 
     public TablePropertiesProvider getTablePropertiesProvider() {
@@ -110,5 +110,9 @@ public final class DeployedSleeperTablesForTest {
 
     public void setCurrent(TableProperties tableProperties) {
         currentTable = tableProperties;
+    }
+
+    private TableProperties currentTable() {
+        return Optional.ofNullable(currentTable).orElseThrow(NoTableChosenException::new);
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/NoInstanceConnectedException.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/NoInstanceConnectedException.java
@@ -13,15 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package sleeper.systemtest.dsl.instance;
 
-package sleeper.systemtest.dsl.extension;
+public class NoInstanceConnectedException extends RuntimeException {
 
-import sleeper.systemtest.dsl.SystemTestContext;
-import sleeper.systemtest.dsl.reporting.SystemTestReports;
-
-public class AfterTestReports extends AfterTestReportsBase<SystemTestReports.SystemTestBuilder> {
-
-    public AfterTestReports(SystemTestContext context) {
-        super(() -> SystemTestReports.builder(context));
+    public NoInstanceConnectedException() {
+        super("Not connected to a Sleeper instance");
     }
+
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/NoTableChosenException.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/NoTableChosenException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.dsl.instance;
+
+public class NoTableChosenException extends RuntimeException {
+
+    public NoTableChosenException() {
+        super("No Sleeper table has been chosen to work with.");
+    }
+
+}

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceContext.java
@@ -72,7 +72,7 @@ public class SystemTestInstanceContext {
     }
 
     public SystemTestDrivers adminDrivers() {
-        return currentInstance.getInstanceAdminDrivers();
+        return currentInstance().getInstanceAdminDrivers();
     }
 
     private SleeperTablesDriver tablesDriver() {
@@ -80,7 +80,7 @@ public class SystemTestInstanceContext {
     }
 
     public void addDefaultTables() {
-        currentTables.addTablesAndSetCurrent(tablesDriver(), currentInstance.getDefaultTables().stream()
+        currentTables().addTablesAndSetCurrent(tablesDriver(), currentInstance().getDefaultTables().stream()
                 .map(deployProperties -> {
                     TableProperties properties = TableProperties.copyOf(deployProperties);
                     properties.unset(TABLE_ID);
@@ -91,7 +91,7 @@ public class SystemTestInstanceContext {
 
     public void createTables(int numberOfTables, Schema schema, Map<TableProperty, String> setProperties) {
         InstanceProperties instanceProperties = getInstanceProperties();
-        currentTables.addTablesAndSetCurrent(tablesDriver(), IntStream.range(0, numberOfTables)
+        currentTables().addTablesAndSetCurrent(tablesDriver(), IntStream.range(0, numberOfTables)
                 .mapToObj(i -> {
                     TableProperties tableProperties = parameters.createTableProperties(instanceProperties, schema);
                     setProperties.forEach(tableProperties::set);
@@ -103,26 +103,26 @@ public class SystemTestInstanceContext {
     public void createTable(String name, Schema schema) {
         TableProperties tableProperties = parameters.createTableProperties(getInstanceProperties(), schema);
         tableProperties.set(TABLE_NAME, name + "-" + UUID.randomUUID());
-        currentTables.addTables(tablesDriver(), List.of(tableProperties));
+        currentTables().addTables(tablesDriver(), List.of(tableProperties));
         tablesByTestName.put(name, tableProperties);
         testNameByTableId.put(tableProperties.get(TABLE_ID), name);
     }
 
     public void setCurrentTable(String name) {
         TableProperties tableProperties = Optional.ofNullable(tablesByTestName.get(name)).orElseThrow();
-        currentTables.setCurrent(tableProperties);
+        currentTables().setCurrent(tableProperties);
     }
 
     public void redeployCurrentInstance() {
-        currentInstance.redeploy(instanceDriver, parameters);
+        currentInstance().redeploy(instanceDriver, parameters);
     }
 
     public InstanceProperties getInstanceProperties() {
-        return currentInstance.getInstanceProperties();
+        return currentInstance().getInstanceProperties();
     }
 
     public TableProperties getTableProperties() {
-        return currentTables.getTableProperties();
+        return currentTables().getTableProperties();
     }
 
     /**
@@ -133,15 +133,15 @@ public class SystemTestInstanceContext {
      * @return           the table properties of the table
      */
     public Optional<TableProperties> getTablePropertiesByDeployedName(String tableName) {
-        return currentTables.getTablePropertiesByName(tableName);
+        return currentTables().getTablePropertiesByName(tableName);
     }
 
     public Optional<TableProperties> getTablePropertiesByDeployedId(String tableId) {
-        return currentTables.getTablePropertiesById(tableId);
+        return currentTables().getTablePropertiesById(tableId);
     }
 
     public TablePropertiesProvider getTablePropertiesProvider() {
-        return currentTables.getTablePropertiesProvider();
+        return currentTables().getTablePropertiesProvider();
     }
 
     public void updateTableProperties(Map<TableProperty, String> values) {
@@ -158,11 +158,11 @@ public class SystemTestInstanceContext {
     }
 
     public StateStoreProvider getStateStoreProvider() {
-        return currentTables.getStateStoreProvider();
+        return currentTables().getStateStoreProvider();
     }
 
     public Stream<Record> generateNumberedRecords(LongStream numbers) {
-        return generateNumberedRecords(currentTables.getSchema(), numbers);
+        return generateNumberedRecords(currentTables().getSchema(), numbers);
     }
 
     public Stream<Record> generateNumberedRecords(Schema schema, LongStream numbers) {
@@ -174,7 +174,7 @@ public class SystemTestInstanceContext {
     }
 
     public StateStore getStateStore(TableProperties tableProperties) {
-        return currentTables.getStateStore(tableProperties);
+        return currentTables().getStateStore(tableProperties);
     }
 
     public String getTableName() {
@@ -197,15 +197,15 @@ public class SystemTestInstanceContext {
     }
 
     public Stream<String> streamDeployedTableNames() {
-        return currentTables.streamTableNames();
+        return currentTables().streamTableNames();
     }
 
     public Stream<TableProperties> streamTableProperties() {
-        return currentTables.streamTableProperties();
+        return currentTables().streamTableProperties();
     }
 
     public void setCurrentTable(TableProperties tableProperties) {
-        currentTables.setCurrent(tableProperties);
+        currentTables().setCurrent(tableProperties);
     }
 
     public String getTestTableName(String tableName) {
@@ -215,5 +215,13 @@ public class SystemTestInstanceContext {
     public String getTestTableName(TableProperties tableProperties) {
         return Optional.ofNullable(testNameByTableId.get(tableProperties.get(TABLE_ID)))
                 .orElseGet(() -> tableProperties.get(TABLE_NAME));
+    }
+
+    private DeployedSleeperInstance currentInstance() {
+        return Optional.ofNullable(currentInstance).orElseThrow(NoInstanceConnectedException::new);
+    }
+
+    private DeployedSleeperTablesForTest currentTables() {
+        return Optional.ofNullable(currentTables).orElseThrow(NoInstanceConnectedException::new);
     }
 }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/SystemTestReporting.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/reporting/SystemTestReporting.java
@@ -24,26 +24,33 @@ import java.util.List;
 
 public class SystemTestReporting {
 
-    private final ReportingContext context;
-    private final IngestReportsDriver ingestDriver;
-    private final CompactionReportsDriver compactionDriver;
+    private final SystemTestContext context;
 
     public SystemTestReporting(SystemTestContext context) {
-        SystemTestDrivers drivers = context.instance().adminDrivers();
-        this.context = context.reporting();
-        this.ingestDriver = drivers.ingestReports(context);
-        this.compactionDriver = drivers.compactionReports(context);
+        this.context = context;
     }
 
     public SystemTestIngestJobsReport ingestJobs() {
-        return new SystemTestIngestJobsReport(ingestDriver.jobs(context));
+        return new SystemTestIngestJobsReport(ingestDriver().jobs(context.reporting()));
     }
 
     public SystemTestCompactionJobsReport compactionJobs() {
-        return new SystemTestCompactionJobsReport(compactionDriver.jobs(context));
+        return new SystemTestCompactionJobsReport(compactionDriver().jobs(context.reporting()));
     }
 
     public List<CompactionTaskStatus> finishedCompactionTasks() {
-        return compactionDriver.tasks(context);
+        return compactionDriver().tasks(context.reporting());
+    }
+
+    private IngestReportsDriver ingestDriver() {
+        return adminDrivers().ingestReports(context);
+    }
+
+    private CompactionReportsDriver compactionDriver() {
+        return adminDrivers().compactionReports(context);
+    }
+
+    private SystemTestDrivers adminDrivers() {
+        return context.instance().adminDrivers();
     }
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReportsBase.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/extension/AfterTestReportsBase.java
@@ -28,7 +28,7 @@ public class AfterTestReportsBase<B extends SystemTestReports.Builder> {
     private boolean reportIfPassed;
     private Consumer<B> config;
 
-    AfterTestReportsBase(Supplier<B> reportsFactory) {
+    public AfterTestReportsBase(Supplier<B> reportsFactory) {
         this.reportsFactory = reportsFactory;
     }
 
@@ -45,13 +45,13 @@ public class AfterTestReportsBase<B extends SystemTestReports.Builder> {
         this.config = config;
     }
 
-    void afterTestPassed(TestContext testContext) {
+    public void afterTestPassed(TestContext testContext) {
         if (reportIfPassed) {
             reports().print(testContext);
         }
     }
 
-    void afterTestFailed(TestContext testContext) {
+    public void afterTestFailed(TestContext testContext) {
         if (config != null) {
             reports().print(testContext);
         }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/SleeperInstanceTablesTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/SleeperInstanceTablesTest.java
@@ -225,4 +225,27 @@ public class SleeperInstanceTablesTest {
                     .isInstanceOf(SleeperPropertiesInvalidException.class);
         }
     }
+
+    @Nested
+    @DisplayName("Fail when no instance/table chosen")
+    class FailWithNoInstanceOrTable {
+
+        @Test
+        void shouldFailToIngestWhenNoInstanceConnected(SleeperSystemTest sleeper) {
+            // When / Then
+            assertThatThrownBy(() -> sleeper.ingest())
+                    .isInstanceOf(NoInstanceConnectedException.class);
+        }
+
+        @Test
+        void shouldFailToIngestWhenNoTableChosen(SleeperSystemTest sleeper) {
+            // Given
+            sleeper.connectToInstanceNoTables(withDefaultProperties("main"));
+            var ingest = sleeper.ingest().direct(null);
+
+            // When / Then
+            assertThatThrownBy(() -> ingest.numberedRecords(LongStream.of(1, 2, 3)))
+                    .isInstanceOf(NoTableChosenException.class);
+        }
+    }
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/reporting/SystemTestReportingTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/reporting/SystemTestReportingTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.dsl.reporting;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import sleeper.systemtest.dsl.SleeperSystemTest;
+import sleeper.systemtest.dsl.SystemTestContext;
+import sleeper.systemtest.dsl.extension.AfterTestReports;
+import sleeper.systemtest.dsl.extension.TestContextFactory;
+import sleeper.systemtest.dsl.instance.NoInstanceConnectedException;
+import sleeper.systemtest.dsl.testutil.InMemoryDslTest;
+import sleeper.systemtest.dsl.testutil.InMemorySystemTestDrivers;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.withDefaultProperties;
+
+@InMemoryDslTest
+public class SystemTestReportingTest {
+
+    private Path tempDir = null;
+
+    @Test
+    void shouldReportFinishedIngestJob(SleeperSystemTest sleeper) {
+        // Given
+        sleeper.connectToInstance(withDefaultProperties("main"));
+        sleeper.sourceFiles().createWithNumberedRecords("test.parquet", LongStream.of(1, 2, 3));
+        sleeper.ingest().byQueue().sendSourceFiles("test.parquet").invokeTask().waitForJobs();
+
+        // When / Then
+        assertThat(sleeper.reporting().ingestJobs().finishedStatistics())
+                .matches(stats -> stats.isAllFinishedOneRunEach(1),
+                        "has one finished job");
+    }
+
+    @Test
+    void shouldReportFinishedCompactionJob(SleeperSystemTest sleeper) {
+        // Given
+        sleeper.connectToInstance(withDefaultProperties("main"));
+        sleeper.ingest().direct(tempDir).numberedRecords(LongStream.of(1, 2, 3));
+        sleeper.compaction().forceCreateJobs(1).invokeTasks(1).waitForJobs();
+
+        // When / Then
+        assertThat(sleeper.reporting().compactionJobs().finishedStatistics())
+                .matches(stats -> stats.isAllFinishedOneRunEach(1),
+                        "has one finished job");
+    }
+
+    @Test
+    void shouldRunCompactionReportAfterTest(SleeperSystemTest sleeper, SystemTestContext context, InMemorySystemTestDrivers drivers, TestInfo info) {
+        // Given
+        List<String> fakeOutput = new ArrayList<>();
+        drivers.reports().setCompactionReport((out, time) -> fakeOutput.add("This is a test report"));
+        AfterTestReports afterTestReports = new AfterTestReports(context);
+        afterTestReports.reportAlways(builder -> builder.compactionTasksAndJobs());
+
+        // When
+        sleeper.connectToInstance(withDefaultProperties("main"));
+        afterTestReports.afterTestPassed(TestContextFactory.testContext(info));
+
+        // Then
+        assertThat(fakeOutput).containsExactly("This is a test report");
+    }
+
+    @Test
+    void shouldFailCompactionReportAfterTestNotConnectedToInstance(SystemTestContext context, InMemorySystemTestDrivers drivers, TestInfo info) {
+        // Given
+        List<String> fakeOutput = new ArrayList<>();
+        drivers.reports().setCompactionReport((out, time) -> fakeOutput.add("This is a test report"));
+        AfterTestReports afterTestReports = new AfterTestReports(context);
+        afterTestReports.reportAlways(builder -> builder.compactionTasksAndJobs());
+
+        // When / Then
+        assertThatThrownBy(() -> afterTestReports.afterTestPassed(TestContextFactory.testContext(info)))
+                .isInstanceOf(NoInstanceConnectedException.class);
+    }
+}

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -34,6 +34,9 @@ import sleeper.systemtest.dsl.instance.SystemTestParameters;
 import sleeper.systemtest.dsl.metrics.TableMetricsDriver;
 import sleeper.systemtest.dsl.partitioning.PartitionSplittingDriver;
 import sleeper.systemtest.dsl.query.QueryAllTablesDriver;
+import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
+import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
+import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
 import sleeper.systemtest.dsl.snapshot.SnapshotsDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
@@ -46,6 +49,7 @@ import sleeper.systemtest.dsl.testutil.drivers.InMemoryIngestBatcherDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryIngestByQueue;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryPartitionSplittingDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryQueryByQueueDriver;
+import sleeper.systemtest.dsl.testutil.drivers.InMemoryReports;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySketchesStore;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperInstanceDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemorySleeperTablesDriver;
@@ -69,6 +73,7 @@ public class InMemorySystemTestDrivers extends SystemTestDriversBase {
     private final InMemoryIngestByQueue ingestByQueue = new InMemoryIngestByQueue(sourceFiles, data, sketches);
     private final InMemoryCompaction compaction = new InMemoryCompaction(data, sketches);
     private final InMemoryTableMetrics metrics = new InMemoryTableMetrics();
+    private final InMemoryReports reports = new InMemoryReports(ingestByQueue, compaction);
     private long fileSizeBytesForBatcher = 1024;
 
     @Override
@@ -181,6 +186,25 @@ public class InMemorySystemTestDrivers extends SystemTestDriversBase {
         return metrics.driver(context);
     }
 
+    @Override
+    public CompactionReportsDriver compactionReports(SystemTestContext context) {
+        return reports.compaction(context.instance());
+    }
+
+    @Override
+    public IngestReportsDriver ingestReports(SystemTestContext context) {
+        return reports.ingest(context.instance());
+    }
+
+    @Override
+    public PartitionReportDriver partitionReports(SystemTestContext context) {
+        return reports.partitions(context.instance());
+    }
+
+    public InMemoryReports reports() {
+        return reports;
+    }
+
     public InMemoryDataStore data() {
         return data;
     }
@@ -189,4 +213,5 @@ public class InMemorySystemTestDrivers extends SystemTestDriversBase {
     public SnapshotsDriver snapshots() {
         return new InMemorySnapshotsDriver();
     }
+
 }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryCompaction.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryCompaction.java
@@ -93,6 +93,14 @@ public class InMemoryCompaction {
         }, properties -> taskStore);
     }
 
+    public CompactionJobStatusStore jobStore() {
+        return jobStore;
+    }
+
+    public CompactionTaskStatusStore taskStore() {
+        return taskStore;
+    }
+
     private class Driver implements CompactionDriver {
 
         private final SystemTestInstanceContext instance;

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryIngestByQueue.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryIngestByQueue.java
@@ -106,6 +106,14 @@ public class InMemoryIngestByQueue {
         });
     }
 
+    public IngestJobStatusStore jobStore() {
+        return jobStore;
+    }
+
+    public IngestTaskStatusStore taskStore() {
+        return taskStore;
+    }
+
     private void finishJobs(SystemTestContext context, String taskId) {
         for (IngestJob queuedJob : queuedJobs) {
             IngestJob job = addTableId(queuedJob, context);

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryReports.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryReports.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.dsl.testutil.drivers;
+
+import sleeper.compaction.job.status.CompactionJobStatus;
+import sleeper.compaction.task.CompactionTaskStatus;
+import sleeper.ingest.job.status.IngestJobStatus;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
+import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
+import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
+import sleeper.systemtest.dsl.reporting.ReportingContext;
+import sleeper.systemtest.dsl.reporting.SystemTestReport;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+public class InMemoryReports {
+
+    private final InMemoryIngestByQueue ingest;
+    private final InMemoryCompaction compaction;
+    private SystemTestReport compactionReport;
+    private SystemTestReport ingestTasksReport;
+    private SystemTestReport ingestJobsReport;
+    private SystemTestReport partitionsReport;
+
+    public InMemoryReports(InMemoryIngestByQueue ingest, InMemoryCompaction compaction) {
+        this.ingest = ingest;
+        this.compaction = compaction;
+    }
+
+    public IngestReportsDriver ingest(SystemTestInstanceContext instance) {
+        return new Ingest(instance);
+    }
+
+    public CompactionReportsDriver compaction(SystemTestInstanceContext instance) {
+        return new Compaction(instance);
+    }
+
+    public PartitionReportDriver partitions(SystemTestInstanceContext instance) {
+        return new Partitions(instance);
+    }
+
+    public void setIngestTasksReport(SystemTestReport ingestTasksReport) {
+        this.ingestTasksReport = ingestTasksReport;
+    }
+
+    public void setIngestJobsReport(SystemTestReport ingestJobsReport) {
+        this.ingestJobsReport = ingestJobsReport;
+    }
+
+    public void setCompactionReport(SystemTestReport compactionReport) {
+        this.compactionReport = compactionReport;
+    }
+
+    public void setPartitionsReport(SystemTestReport partitionsReport) {
+        this.partitionsReport = partitionsReport;
+    }
+
+    private class Ingest implements IngestReportsDriver {
+
+        private final SystemTestInstanceContext instance;
+
+        private Ingest(SystemTestInstanceContext instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public SystemTestReport tasksAndJobsReport() {
+            return SystemTestReport.join(tasksReport(), jobsReport());
+        }
+
+        @Override
+        public SystemTestReport tasksReport() {
+            return Objects.requireNonNull(ingestTasksReport, "Ingest tasks report is not set");
+        }
+
+        @Override
+        public SystemTestReport jobsReport() {
+            return Objects.requireNonNull(ingestJobsReport, "Ingest jobs report is not set");
+        }
+
+        @Override
+        public List<IngestJobStatus> jobs(ReportingContext reportingContext) {
+            return ingest.jobStore().getJobsInTimePeriod(
+                    instance.getTableStatus().getTableUniqueId(),
+                    reportingContext.getRecordingStartTime(), Instant.MAX);
+        }
+    }
+
+    private class Compaction implements CompactionReportsDriver {
+
+        private final SystemTestInstanceContext instance;
+
+        private Compaction(SystemTestInstanceContext instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public SystemTestReport tasksAndJobsReport() {
+            return Objects.requireNonNull(compactionReport, "Compaction report is not set");
+        }
+
+        @Override
+        public List<CompactionJobStatus> jobs(ReportingContext reportingContext) {
+            return compaction.jobStore().getJobsInTimePeriod(
+                    instance.getTableStatus().getTableUniqueId(),
+                    reportingContext.getRecordingStartTime(), Instant.MAX);
+        }
+
+        @Override
+        public List<CompactionTaskStatus> tasks(ReportingContext reportingContext) {
+            return compaction.taskStore().getTasksInTimePeriod(
+                    reportingContext.getRecordingStartTime(), Instant.MAX);
+        }
+    }
+
+    private class Partitions implements PartitionReportDriver {
+
+        private final SystemTestInstanceContext instance;
+
+        private Partitions(SystemTestInstanceContext instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public SystemTestReport statusReport() {
+            return Objects.requireNonNull(partitionsReport, "Partitions report is not set");
+        }
+    }
+
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2822

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Added SystemTestReportingTest
    - Updated SleeperInstanceTablesTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.