### PR TITLE
Issue 2827 - Remove Sleeper CLI from environment EC2

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -5,51 +5,8 @@ There are 2 ways of deploying Sleeper and interacting with an instance. You can 
 local machine. The Docker version has limited functionality and will only work with small volumes of data, but will
 allow you to deploy an instance, ingest some files, and run reports and scripts against the instance.
 
-To get started we'll use the Sleeper CLI, which runs in Docker on your local machine.
-
-### Dependencies
-
-The Sleeper CLI has the following dependencies:
-
-* [Bash](https://www.gnu.org/software/bash/): Tested with v3.2 to v5.2. Use `bash --version`.
-* [Docker](https://docs.docker.com/get-docker/): Tested with v24.0.2
-
-### Installation
-
-The Sleeper CLI contains Docker images with the necessary dependencies and scripts to work with Sleeper. Run the
-following commands to install the latest development version of the CLI.
-
-```bash
-curl "https://raw.githubusercontent.com/gchq/sleeper/develop/scripts/cli/install.sh" -o ./sleeper-install.sh
-chmod +x ./sleeper-install.sh
-./sleeper-install.sh develop
-```
-
-This will install the latest development version. This will not have been as fully tested as released versions and may
-not work as expected. Most users should use the latest released version. You can find a list
-of released versions [here](https://github.com/gchq/sleeper/tags), and the change log [here](../CHANGELOG.md).
-
-**Due to a bug in GitHub, it is not currently possible to install released versions this way.** See the following
-issue: https://github.com/gchq/sleeper/issues/2494
-
-To use a released version, please follow the [developer guide](11-dev-guide.md) to build the CLI from source.
-
-If the bug is fixed, you can replace `develop` with `main` for the latest release, or a release in the format `v0.20.0`.
-These correspond to a branch or tag in the GitHub repository. If you do not specify a version on the command line, it
-will default to the latest release.
-
-```bash
-curl "https://raw.githubusercontent.com/gchq/sleeper/[version]/scripts/cli/install.sh" -o ./sleeper-install.sh
-chmod +x ./sleeper-install.sh
-./sleeper-install.sh [version]
-```
-
-This installs a `sleeper` command to run other commands inside a Docker container. You can use `sleeper aws` or
-`sleeper cdk` to run `aws` or `cdk` commands without needing to install the AWS or CDK CLI on your machine. If you set
-AWS environment variables or configuration on the host machine, that will be propagated to the Docker container when
-you use `sleeper`.
-
-You can also upgrade the CLI to a different version with `sleeper cli upgrade`.
+Currently in order to work with Sleeper you must build from source. Please follow the [developer guide](11-dev-guide.md)
+to build the system and get to the point where the scripts will work.
 
 ## Deploy to Docker
 
@@ -65,10 +22,46 @@ then use the status scripts to see how much data is in the system, run some exam
 understand what the system is doing. It is best to do this from an EC2 instance as a significant amount of code needs to
 be uploaded to AWS.
 
+We'll use the Sleeper CLI to deploy an EC2 instance in an environment suitable for working with Sleeper.
+
+### Dependencies
+
+The Sleeper CLI has the following dependencies:
+
+* [Bash](https://www.gnu.org/software/bash/): Tested with v3.2 to v5.2. Use `bash --version`.
+* [Docker](https://docs.docker.com/get-docker/): Tested with v24.0.2
+
+### Install Sleeper CLI
+
+**Due to a bug in GitHub, released versions must be built from source.** See the following
+issue: https://github.com/gchq/sleeper/issues/2494
+
+You can follow the [developer guide](11-dev-guide.md) to build and install the CLI from source. Most users should use
+the latest released version. You can find a list of released versions [here](https://github.com/gchq/sleeper/tags), and
+the change log [here](../CHANGELOG.md).
+
+For the latest development version, you can run the following commands to install the CLI from GitHub:
+
+```bash
+curl "https://raw.githubusercontent.com/gchq/sleeper/develop/scripts/cli/install.sh" -o ./sleeper-install.sh
+chmod +x ./sleeper-install.sh
+./sleeper-install.sh develop
+```
+
+This will not have been as fully tested as released versions and may not work as expected. If you build a specific
+release version after installing the development version, the version you build will replace the version you installed.
+
+The CLI consists of a `sleeper` command to run other commands inside a Docker container. You can use `sleeper aws` or
+`sleeper cdk` to run `aws` or `cdk` commands without needing to install the AWS or CDK CLI on your machine. If you set
+AWS environment variables or configuration on the host machine, that will be propagated to the Docker container when
+you use `sleeper`.
+
+If you installed the development version, you can upgrade to the latest version with `sleeper cli upgrade`.
+
 ### Authentication
 
 To use the Sleeper CLI against AWS, you need to authenticate against your AWS account. You can do this by running
-`sleeper aws configure`, or other `sleeper aws` commands according to your AWS setup. AWS Environment variables
+`sleeper aws configure`, or other `sleeper aws` commands according to your AWS setup. AWS environment variables
 will also be propagated to the Sleeper CLI.
 
 Most Sleeper clients also require you to set the default region.
@@ -82,13 +75,13 @@ once in a given AWS account.
 sleeper cdk bootstrap
 ```
 
-Next, you'll need a VPC that is suitable for deploying Sleeper. You'll also want an EC2 instance to deploy from, to
-avoid lengthy uploads of large jar files and Docker images. You can use the Sleeper CLI to create both of these.
+Next, you'll need a VPC that is suitable for deploying Sleeper, and an EC2 instance to deploy from. This lets you avoid
+lengthy uploads of large jar files and Docker images. You can use the Sleeper CLI to create both of these.
 
-If you'd prefer to use your own, you'll need to install the Sleeper CLI on your EC2, which should run on an x86_64
-architecture. You'll need to authenticate with AWS as described above. You'll need to ensure your VPC meets Sleeper's
-requirements, but you can also deploy a fresh VPC with the CLI. This is documented in
-the [deployment guide](02-deployment-guide.md#deployment-environment).
+If you prefer to use your own EC2, you'll need to build Sleeper there as described in
+the [developer guide](11-dev-guide.md). The EC2 should run on an x86_64 architecture. If you prefer to use your own VPC,
+you'll need to ensure it meets Sleeper's requirements. Deployment of an EC2 to an existing VPC is documented in
+the [deployment guide](02-deployment-guide.md#managing-environments).
 
 #### Sleeper CLI environment
 
@@ -122,12 +115,12 @@ tail /var/log/cloud-init-output.log
 Once it has finished the EC2 will restart. Once it's restarted you can use the Sleeper CLI. Reconnect to the EC2
 with `sleeper environment connect`.
 
-During the `cloud-init` step, the Sleeper Git repository will be cloned, and you can access it by running
-`sleeper builder` in the EC2. This will get you a shell inside a Docker container inside the EC2, with the dependencies
-for building Sleeper. You can run all the deployment scripts there as explained below. If you run it outside of the
-EC2, you'll get the same thing but in your local Docker host. Use the one in the EC2 to avoid the deployment being
-slow uploading jars and Docker images. Additionally, the whole working directory will be persisted between executions
-of `sleeper builder`.
+During the `cloud-init` step, the Sleeper Git repository will be cloned to the directory `~/sleeper` in the EC2. You can
+run `nix-shell` in that directory to get a shell with the dependencies for building Sleeper. You can run all the
+deployment scripts in that shell as explained below.
+
+Please ensure you run the scripts in the EC2 via `sleeper environment connect`, to avoid the deployment being slow
+uploading jars and Docker images. Note that the `sleeper` command will not be available in the EC2.
 
 If you want someone else to be able to access the same environment EC2, they can run `sleeper environment add <id>`
 with the same environment ID. To begin with you'll both log on as the same user and share a single `screen` session. You
@@ -154,16 +147,22 @@ zones). Multiple subnet ids can be specified with commas in between, e.g. `subne
 
 The VPC _must_ have an S3 Gateway endpoint associated with it otherwise the `cdk deploy` step will fail.
 
-Before you can run any scripts, you need to build the project. You can do this by running the following script:
+Before you can run any scripts, you need to build the project. From your local machine, run the following commands:
 
 ```bash
-sleeper builder sleeper/scripts/build/buildForTest.sh
+sleeper environment connect   # Get a shell in the EC2 you deployed
+cd sleeper                    # Change directory to the root of the Git repository
+nix-shell                     # Get a Nix shell with Sleeper's dependencies pre-installed
+scripts/build/buildForTest.sh
 ```
 
-Then you can deploy the system test instance by running the following command:
+The remaining instructions will assume that you start in a Nix shell at the root of the Sleeper Git repository, as shown
+in those commands.
+
+You can deploy the system test instance by running the following command:
 
 ```bash
-sleeper builder sleeper/scripts/test/deployAll/deployTest.sh ${ID} ${VPC} ${SUBNETS}
+scripts/test/deployAll/deployTest.sh ${ID} ${VPC} ${SUBNETS}
 ```
 
 An S3 bucket will be created for the jars, and ECR repos will be created and Docker images pushed to them.
@@ -179,7 +178,7 @@ sleeper-${ID}-system-test-cluster, finding a task and viewing the logs.
 Run the following command to see how many records are currently in the system:
 
 ```bash
-sleeper builder sleeper/scripts/utility/filesStatusReport.sh ${ID} system-test
+scripts/utility/filesStatusReport.sh ${ID} system-test
 ```
 
 The randomly generated data in the table conforms to the schema given in the file `scripts/templates/schema.template`.
@@ -187,7 +186,7 @@ This has a key field called `key` which is of type string. The code that randoml
 which are random strings of length 10. To run a query, use:
 
 ```bash
-sleeper builder sleeper/scripts/utility/query.sh ${ID}
+scripts/utility/query.sh ${ID}
 ```
 
 As the data that went into the table is randomly generated, you will need to query for a range of keys, rather than a
@@ -213,22 +212,21 @@ You will also see the number of leaf partitions increase. This functionality is 
 To ingest more random data, run:
 
 ```bash
-sleeper builder java -cp jars/system-test-*-utility.jar  sleeper.systemtest.drivers.ingest.RunWriteRandomDataTaskOnECS ${ID} system-test
+java -cp scripts/jars/system-test-*-utility.jar  sleeper.systemtest.drivers.ingest.RunWriteRandomDataTaskOnECS ${ID} system-test
 ```
 
 To tear all the infrastructure down, run
 
 ```bash
-sleeper builder sleeper/scripts/test/tearDown.sh
+scripts/test/tearDown.sh
 ```
 
 It is possible to run variations on this system-test by editing the system test properties, like this:
 
 ```bash
-sleeper builder
-cd sleeper/scripts/test/deployAll
+cd scripts/test/deployAll
 editor system-test-instance.properties
 ./buildDeployTest.sh  ${ID} ${VPC} ${SUBNETS}
 ```
 
-To deploy your own instance of Sleeper with a particular schema, go to the [deployment guide](02-deployment-guide.md).
+To deploy your own instance of Sleeper with a particular schema, follow the [deployment guide](02-deployment-guide.md).

--- a/docs/02-deployment-guide.md
+++ b/docs/02-deployment-guide.md
@@ -14,10 +14,10 @@ getting started guide, you get an EC2 with the Sleeper CLI installed, and the Gi
 deployed, you can connect to it and build Sleeper like this:
 
 ```bash
-sleeper environment connect # Get a shell in the EC2 you deployed
-sleeper builder # Get a shell in a builder Docker container (hosted in the EC2)
-cd sleeper # Change directory to the root of the Git repository
-./scripts/build/build.sh
+sleeper environment connect   # Get a shell in the EC2 you deployed
+cd sleeper                    # Change directory to the root of the Git repository
+nix-shell                     # Get a Nix shell with Sleeper's dependencies pre-installed
+scripts/build/build.sh
 ```
 
 If you used the system test deployment described in the getting started guide, you will have already built Sleeper.
@@ -87,11 +87,9 @@ You're now ready to build and deploy Sleeper.
 
 ### Deployment environment
 
-See [getting started](01-getting-started.md#deployment-environment) for information on setting up a VPC and EC2 instance
-to deploy Sleeper. You may want to follow the remaining instructions here from within the EC2 instance.
-
-When you use the Sleeper CLI described in [getting started](01-getting-started.md#deployment-environment), you can
-manage multiple environments.
+Please follow the [getting started guide](01-getting-started.md#deployment-environment) to set up a VPC and EC2 instance
+to deploy Sleeper. This also assumes you have [installed the Sleeper CLI](01-getting-started.md#install-sleeper-cli).
+This section adds more detail for the tools to set up this environment.
 
 If you run `sleeper environment`, you'll get a shell inside a Docker container where you can run `aws`, `cdk` and
 Sleeper `environment` commands directly, without prefixing with `sleeper`.
@@ -99,6 +97,8 @@ Sleeper `environment` commands directly, without prefixing with `sleeper`.
 You can use `aws` commands there to set the AWS account, region and authentication. You can also set AWS environment
 variables or configuration on the host machine, which will be propagated to the Docker container when you use
 `sleeper` commands.
+
+The Sleeper CLI also lets you manage multiple environments.
 
 #### Managing environments
 
@@ -143,6 +143,9 @@ Parameters after the environment ID will be passed to a `cdk destroy` command.
 
 There are two ways to deploy Sleeper: you can use the automated scripts or a more manual approach.
 
+Either approach should be done from within an EC2 instance set up as described above, to avoid lengthy uploads of large
+jar files and Docker images.
+
 ### Automated Deployment
 
 The automated deployment uses template files to provide a default configuration for Sleeper. It also deploys only one
@@ -174,31 +177,6 @@ ECR.
 
 The deployment scripts will create all of the required configuration files in a folder called `generated` in the scripts
 directory.
-
-#### Sleeper CLI Docker environment
-
-The Sleeper CLI runs commands inside a Docker container. This way you can avoid needing to install any of the
-dependencies or build Sleeper yourself.
-
-The `sleeper builder` command gets you a shell inside a Docker container. This docker container will have all the
-dependencies required to build and deploy an instance of Sleeper. Note that when you run this inside an environment EC2,
-the Sleeper Git repository will be cloned into the working directory of the container. If you are not using an
-environment EC2, you will need to manually clone the repository.
-
-If you have AWS CLI installed, it will use your configuration from the host. Otherwise, any configuration you set in
-the container will be persisted in the host home directory. AWS authentication environment variables will be propagated
-to the container as well.
-
-The host Docker environment will be propagated to the container via the Docker socket.
-
-The files generated for the Sleeper instance will be persisted in the host home directory under `~/.sleeper`, so that
-if you run the Docker container multiple times you will still have details of the last Sleeper instance you worked with.
-
-If you add a command on the end, you can run a specific script like this:
-
-```shell
-sleeper builder sleeper/scripts/test/deployAll/deployTest.sh myinstanceid myvpc mysubnet
-```
 
 ### Manual Deployment
 

--- a/docs/02-deployment-guide.md
+++ b/docs/02-deployment-guide.md
@@ -23,7 +23,7 @@ scripts/build/build.sh
 If you used the system test deployment described in the getting started guide, you will have already built Sleeper.
 
 To build Sleeper locally to interact with an instance from elsewhere, you can follow the instructions in
-the [dev guide](11-dev-guide.md#install-prerequisite-software).
+the [developer guide](11-dev-guide.md#install-prerequisite-software).
 
 ### Configure AWS
 

--- a/docs/11-dev-guide.md
+++ b/docs/11-dev-guide.md
@@ -21,11 +21,13 @@ You will need the following software:
 * [Maven](https://maven.apache.org/): Tested with v3.8.6
 * [NodeJS / NPM](https://github.com/nvm-sh/nvm#installing-and-updating): Tested with NodeJS v16.16.0 and npm v8.11.0
 
-You can use the [Nix package manager](https://nixos.org/download.html) to get up to date versions of all of these. When
-you have Nix installed, an easy way to get a development environment is to run `nix-shell` at the root of the Sleeper
-Git repository. This will start a shell with all the Sleeper dependencies installed, without installing them in your
-system. If you run your IDE from that shell, the dependencies will be available in your IDE. You can run `nix-shell`
-again whenever you want to work with Sleeper.
+#### Nix shell
+
+You can use the [Nix package manager](https://nixos.org/download.html) to get up to date versions of all the
+dependencies except Docker and Bash. When you have Nix installed, an easy way to get a development environment is to run
+`nix-shell` at the root of the Sleeper Git repository. This will start a shell with all the Sleeper dependencies
+installed, without installing them in your system. If you run your IDE from that shell, the dependencies will be
+available in your IDE. You can run `nix-shell` again whenever you want to work with Sleeper.
 
 You can also download [shell.nix](/shell.nix) directly if you'd like to avoid installing Git. You can then `git clone`
 the repository from the Nix shell. Here's an example to get the latest release:
@@ -38,11 +40,11 @@ cd sleeper
 git checkout --track origin/main
 ```
 
-If you're working with the Sleeper CLI as described in the [getting started guide](01-getting-started.md), you can
-use `sleeper builder` to get a shell inside a Docker container with the dependencies pre-installed.
+#### Sleeper CLI builder image
 
-If you run `sleeper builder` in an environment EC2 instance, you'll have the Git repository checked out at `/sleeper`.
-If you run `sleeper builder` locally, you'll need to clone the repository. You can use the commands below to do this:
+If you installed the Sleeper CLI from GitHub as described in the [getting started guide](01-getting-started.md), you can
+use `sleeper builder` to get a shell inside a Docker container with the dependencies pre-installed. You'll need to clone
+the repository in the container. You can use the commands below to do this:
 
 ```bash
 sleeper builder
@@ -51,6 +53,21 @@ cd sleeper
 ```
 
 Everything in the repository will be persisted between executions of `sleeper builder`.
+
+If you have AWS CLI installed in the host, the same configuration will be used in the builder container. Otherwise, any
+configuration you set in the container will be persisted in the host home directory. AWS authentication environment
+variables will be propagated to the container as well.
+
+The host Docker environment will be propagated to the container via the Docker socket.
+
+The files generated for the Sleeper instance will be persisted in the host home directory under `~/.sleeper`, so that
+if you run the Docker container multiple times you will still have details of the last Sleeper instance you worked with.
+
+If you add a command on the end, you can run a specific script like this:
+
+```shell
+sleeper builder sleeper/scripts/test/deployAll/deployTest.sh myinstanceid myvpc mysubnet
+```
 
 ## Building
 
@@ -62,7 +79,7 @@ Provided script (recommended) - this builds the code and copies the jars into th
 
 ### Sleeper CLI
 
-To build the Sleeper CLI, you can run this instead:
+To build the Sleeper CLI, you can run this script:
 
 ```bash
 ./scripts/cli/buildAll.sh

--- a/java/cdk-environment/src/main/resources/cloud-init.sh
+++ b/java/cdk-environment/src/main/resources/cloud-init.sh
@@ -58,9 +58,9 @@ chmod +x "$LOGIN_HOME/sleeper-install.sh"
 runuser --login "$LOGIN_USER" -c "$LOGIN_HOME/sleeper-install.sh $BRANCH"
 
 # Check out code
-REPOSITORY_DIR="$LOGIN_HOME/.sleeper/builder/$REPOSITORY"
-if [ ! -d "$REPOSITORY_DIR" ]; then
-  runuser --login "$LOGIN_USER" -c "sleeper builder git clone -b $BRANCH https://github.com/$FORK/$REPOSITORY.git"
+if [ ! -d "$LOGIN_HOME/$REPOSITORY" ]; then
+  runuser --login "$LOGIN_USER" -c "curl -O https://raw.githubusercontent.com/$FORK/$REPOSITORY/$BRANCH/shell.nix"
+  runuser --login "$LOGIN_USER" -c "nix-shell --run \"git clone -b $BRANCH https://github.com/$FORK/$REPOSITORY.git\""
 fi
 
 if [ -f /var/run/reboot-required ]; then

--- a/java/cdk-environment/src/main/resources/cloud-init.sh
+++ b/java/cdk-environment/src/main/resources/cloud-init.sh
@@ -52,11 +52,6 @@ sudo apt install -y docker-ce docker-ce-cli containerd.io binfmt-support qemu-us
 # Allow user to access docker socket
 usermod -aG docker "$LOGIN_USER"
 
-# Install Sleeper CLI
-curl "https://raw.githubusercontent.com/$FORK/$REPOSITORY/$BRANCH/scripts/cli/install.sh" -o "$LOGIN_HOME/sleeper-install.sh"
-chmod +x "$LOGIN_HOME/sleeper-install.sh"
-runuser --login "$LOGIN_USER" -c "$LOGIN_HOME/sleeper-install.sh $BRANCH"
-
 # Check out code
 if [ ! -d "$LOGIN_HOME/$REPOSITORY" ]; then
   runuser --login "$LOGIN_USER" -c "curl -O https://raw.githubusercontent.com/$FORK/$REPOSITORY/$BRANCH/shell.nix"

--- a/java/cdk-environment/src/main/resources/cloud-init.sh
+++ b/java/cdk-environment/src/main/resources/cloud-init.sh
@@ -30,11 +30,6 @@ LOGIN_HOME=/home/$LOGIN_USER
 export DEBIAN_FRONTEND=noninteractive
 sudo apt update && sudo apt -y dist-upgrade
 
-# Install Nix
-if [ ! -d /nix ]; then
-  runuser --login "$LOGIN_USER" -c "curl -L https://nixos.org/nix/install | sh -s -- --daemon --yes"
-fi
-
 # Install latest Docker
 sudo apt remove -y docker.io containerd runc
 sudo apt install -y ca-certificates curl gnupg lsb-release
@@ -52,10 +47,14 @@ sudo apt install -y docker-ce docker-ce-cli containerd.io binfmt-support qemu-us
 # Allow user to access docker socket
 usermod -aG docker "$LOGIN_USER"
 
+# Install Nix
+if [ ! -d /nix ]; then
+  runuser --login "$LOGIN_USER" -c "curl -L https://nixos.org/nix/install | sh -s -- --daemon --yes"
+fi
+
 # Check out code
 if [ ! -d "$LOGIN_HOME/$REPOSITORY" ]; then
-  runuser --login "$LOGIN_USER" -c "curl -O https://raw.githubusercontent.com/$FORK/$REPOSITORY/$BRANCH/shell.nix"
-  runuser --login "$LOGIN_USER" -c "nix-shell --run \"git clone -b $BRANCH https://github.com/$FORK/$REPOSITORY.git\""
+  runuser --login "$LOGIN_USER" -c "git clone -b $BRANCH https://github.com/$FORK/$REPOSITORY.git"
 fi
 
 if [ -f /var/run/reboot-required ]; then

--- a/scripts/cli/environment/scripts/subcommands/adduser.sh
+++ b/scripts/cli/environment/scripts/subcommands/adduser.sh
@@ -30,7 +30,5 @@ USERNAME="$1"
   "&&" sudo adduser --disabled-password --gecos "-" "$USERNAME" \
   "&&" sudo passwd -d "$USERNAME" \
   "&&" sudo usermod -aG sudo "$USERNAME" \
-  "&&" sudo usermod -aG docker "$USERNAME" \
-  "&&" sudo runuser --login "$USERNAME" -c "curl -O https://raw.githubusercontent.com/$FORK/$REPOSITORY/$BRANCH/shell.nix" \
-  "&&" sudo runuser --login "$USERNAME" -c "nix-shell --run \"git clone -b $BRANCH https://github.com/$FORK/$REPOSITORY.git\""
+  "&&" sudo usermod -aG docker "$USERNAME"
 "$THIS_DIR/setuser.sh" "$USERNAME"

--- a/scripts/cli/environment/scripts/subcommands/adduser.sh
+++ b/scripts/cli/environment/scripts/subcommands/adduser.sh
@@ -31,9 +31,6 @@ USERNAME="$1"
   "&&" sudo passwd -d "$USERNAME" \
   "&&" sudo usermod -aG sudo "$USERNAME" \
   "&&" sudo usermod -aG docker "$USERNAME" \
-  "&&" sudo runuser --login "$USERNAME" -c '"git clone https://github.com/gchq/sleeper.git ~/.sleeper/builder/sleeper"' \
-  "&&" sudo runuser --login "$USERNAME" -c '"~/.sleeper/builder/sleeper/scripts/cli/install.sh develop"' \
-  "&&" sudo runuser --login "$USERNAME" -c '"sudo chown -R root:root ~/.sleeper/builder"' \
-  "&&" sudo runuser --login "$USERNAME" -c '"mkdir ~/.m2"' \
-  "&&" sudo runuser --login "$USERNAME" -c '"mkdir ~/.aws"'
+  "&&" sudo runuser --login "$USERNAME" -c "curl -O https://raw.githubusercontent.com/$FORK/$REPOSITORY/$BRANCH/shell.nix" \
+  "&&" sudo runuser --login "$USERNAME" -c "nix-shell --run \"git clone -b $BRANCH https://github.com/$FORK/$REPOSITORY.git\""
 "$THIS_DIR/setuser.sh" "$USERNAME"

--- a/scripts/test/nightly/README.md
+++ b/scripts/test/nightly/README.md
@@ -7,6 +7,8 @@ and tear them down afterwards.
 
 ### Setup
 
+TODO rework to use Nix
+
 It's easiest to run this through the Sleeper CLI. You can bring the CLI up to date and check out the Git repository like
 this:
 

--- a/scripts/test/nightly/crontab.example
+++ b/scripts/test/nightly/crontab.example
@@ -23,5 +23,5 @@
 MAILTO=""
 SHELL=/usr/bin/bash
 PATH=$PATH:/usr/bin:/home/ubuntu/.local/bin
-0 3 * * TUE,THU,SAT,SUN docker system prune -af && sleeper cli upgrade develop && sleeper builder ./sleeper/scripts/test/nightly/updateAndRunTests.sh "/sleeper-builder/<settings-json-file-in-builder>" "functional" &> /tmp/sleeperFunctionalTests.log
-0 3 * * MON,WED,FRI docker system prune -af && sleeper cli upgrade develop && sleeper builder ./sleeper/scripts/test/nightly/updateAndRunTests.sh "/sleeper-builder/<settings-json-file-in-builder>" "performance" &> /tmp/sleeperPerformanceTests.log
+0 3 * * TUE,THU,SAT,SUN docker system prune -af && /home/ubuntu/sleeper/scripts/test/nightly/updateAndRunTestsInNix.sh /home/ubuntu/nightlyTestSettings.json functional &> /tmp/sleeperFunctionalTests.log
+0 3 * * MON,WED,FRI docker system prune -af && /home/ubuntu/sleeper/scripts/test/nightly/updateAndRunTestsInNix.sh /home/ubuntu/nightlyTestSettings.json performance &> /tmp/sleeperPerformanceTests.log

--- a/scripts/test/nightly/runTestsWithSettings.sh
+++ b/scripts/test/nightly/runTestsWithSettings.sh
@@ -36,10 +36,6 @@ MERGE_TO_MAIN=$(jq ".mergeToMainOnTestType.$TEST_TYPE" "$SETTINGS_FILE" --raw-ou
 
 pushd "$THIS_DIR"
 
-git remote set-url origin "https://github.com/$REPO_PATH.git"
-git fetch
-git switch --discard-changes -C develop origin/develop
-
 set +e
 ./runTests.sh "$VPC" "$SUBNETS" "$RESULTS_BUCKET" "$TEST_TYPE"
 EXIT_CODE=$?

--- a/scripts/test/nightly/update.sh
+++ b/scripts/test/nightly/update.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2022-2024 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+unset CDPATH
+
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$THIS_DIR" && cd ../../.. && pwd)
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <settings-json-file>"
+  exit 1
+fi
+
+SETTINGS_FILE=$1
+
+REPO_PATH=$(jq ".repoPath" "$SETTINGS_FILE" --raw-output)
+
+pushd "$REPO_DIR"
+
+git remote set-url origin "https://github.com/$REPO_PATH.git"
+git fetch
+git switch --discard-changes -C develop origin/develop
+
+popd

--- a/scripts/test/nightly/updateAndRunTestsInNix.sh
+++ b/scripts/test/nightly/updateAndRunTestsInNix.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2022-2024 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+unset CDPATH
+
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_DIR=$(cd "$THIS_DIR" && cd ../../.. && pwd)
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <settings-json-file> <test-type>"
+  echo "Valid test types are: performance, functional"
+  exit 1
+fi
+
+SETTINGS_FILE=$1
+TEST_TYPE=$2
+
+# Update as a separate command in case the Nix shell settings change
+nix-shell --run "$THIS_DIR/update.sh $SETTINGS_FILE" "$REPO_DIR/shell.nix"
+nix-shell --run "$THIS_DIR/runTestsWithSettings.sh $SETTINGS_FILE $TEST_TYPE" "$REPO_DIR/shell.nix"

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ in
 pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     bash
+    jq
     nodejs
     awscli2
     nodePackages.aws-cdk


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2827

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Testing in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.