### PR TITLE
Issue 2846 - Separate Hadoop config per parallel query

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/AwsSleeperTablesDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/instance/AwsSleeperTablesDriver.java
@@ -81,7 +81,7 @@ public class AwsSleeperTablesDriver implements SleeperTablesDriver {
     private final Configuration hadoopConfiguration;
 
     public AwsSleeperTablesDriver(SystemTestClients clients) {
-        this(clients.getS3(), clients.getS3V2(), clients.getDynamoDB(), clients.getConfiguration());
+        this(clients.getS3(), clients.getS3V2(), clients.getDynamoDB(), clients.createHadoopConf());
     }
 
     public AwsSleeperTablesDriver(

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
@@ -37,12 +37,15 @@ import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterators;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class DirectQueryDriver implements QueryDriver {
+    private static final ExecutorService EXECUTOR_SERVICE = Executors.newCachedThreadPool();
+
     private final SystemTestInstanceContext instance;
     private final SystemTestClients clients;
 
@@ -80,7 +83,7 @@ public class DirectQueryDriver implements QueryDriver {
     private QueryExecutor executor(TableProperties tableProperties, StateStore stateStore, PartitionTree partitionTree) {
         try {
             QueryExecutor executor = new QueryExecutor(ObjectFactory.noUserJars(), tableProperties,
-                    stateStore, clients.createHadoopConf(), Executors.newSingleThreadExecutor());
+                    stateStore, clients.createHadoopConf(), EXECUTOR_SERVICE);
             executor.init(partitionTree.getAllPartitions(), stateStore.getPartitionToReferencedFilesMap());
             return executor;
         } catch (StateStoreException e) {

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
@@ -16,8 +16,6 @@
 
 package sleeper.systemtest.drivers.query;
 
-import org.apache.hadoop.conf.Configuration;
-
 import sleeper.configuration.jars.ObjectFactory;
 import sleeper.configuration.properties.table.TableProperties;
 import sleeper.core.iterator.CloseableIterator;
@@ -46,15 +44,15 @@ import java.util.stream.StreamSupport;
 
 public class DirectQueryDriver implements QueryDriver {
     private final SystemTestInstanceContext instance;
-    private final Configuration configuration;
+    private final SystemTestClients clients;
 
-    public DirectQueryDriver(SystemTestInstanceContext instance, Configuration configuration) {
+    public DirectQueryDriver(SystemTestInstanceContext instance, SystemTestClients clients) {
         this.instance = instance;
-        this.configuration = configuration;
+        this.clients = clients;
     }
 
     public static QueryAllTablesDriver allTablesDriver(SystemTestInstanceContext instance, SystemTestClients clients) {
-        return new QueryAllTablesInParallelDriver(instance, new DirectQueryDriver(instance, clients.createHadoopConf()));
+        return new QueryAllTablesInParallelDriver(instance, new DirectQueryDriver(instance, clients));
     }
 
     public List<Record> run(Query query) {
@@ -82,7 +80,7 @@ public class DirectQueryDriver implements QueryDriver {
     private QueryExecutor executor(TableProperties tableProperties, StateStore stateStore, PartitionTree partitionTree) {
         try {
             QueryExecutor executor = new QueryExecutor(ObjectFactory.noUserJars(), tableProperties,
-                    stateStore, configuration, Executors.newSingleThreadExecutor());
+                    stateStore, clients.createHadoopConf(), Executors.newSingleThreadExecutor());
             executor.init(partitionTree.getAllPartitions(), stateStore.getPartitionToReferencedFilesMap());
             return executor;
         } catch (StateStoreException e) {

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/DirectQueryDriver.java
@@ -54,7 +54,7 @@ public class DirectQueryDriver implements QueryDriver {
     }
 
     public static QueryAllTablesDriver allTablesDriver(SystemTestInstanceContext instance, SystemTestClients clients) {
-        return new QueryAllTablesInParallelDriver(instance, new DirectQueryDriver(instance, clients.getConfiguration()));
+        return new QueryAllTablesInParallelDriver(instance, new DirectQueryDriver(instance, clients.createHadoopConf()));
     }
 
     public List<Record> run(Query query) {

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SQSQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SQSQueryDriver.java
@@ -69,7 +69,7 @@ public class SQSQueryDriver implements QuerySendAndWaitDriver {
 
     public static QueryAllTablesDriver allTablesDriver(SystemTestInstanceContext instance, SystemTestClients clients) {
         return new QueryAllTablesSendAndWaitDriver(instance,
-                new SQSQueryDriver(instance, clients.getSqs(), clients.getDynamoDB(), clients.getS3(), clients.getConfiguration()));
+                new SQSQueryDriver(instance, clients.getSqs(), clients.getDynamoDB(), clients.getS3(), clients.createHadoopConf()));
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/AwsSystemTestDrivers.java
@@ -115,7 +115,7 @@ public class AwsSystemTestDrivers implements SystemTestDrivers {
 
     @Override
     public IngestSourceFilesDriver sourceFiles(SystemTestContext context) {
-        return new AwsIngestSourceFilesDriver(clients.getConfiguration());
+        return new AwsIngestSourceFilesDriver(clients.createHadoopConf());
     }
 
     @Override

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/SystemTestClients.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/SystemTestClients.java
@@ -175,7 +175,7 @@ public class SystemTestClients {
         return authEnvVars;
     }
 
-    public Configuration getConfiguration() {
+    public Configuration createHadoopConf() {
         return hadoopConfSupplier.get();
     }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2846

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Ran MultipleTablesIT in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.