### PR TITLE
Issue 2855 - Add JDK and sources to builder Docker image

### DIFF
--- a/scripts/cli/builder/Dockerfile
+++ b/scripts/cli/builder/Dockerfile
@@ -17,6 +17,8 @@ FROM ${DEPENDENCIES_IMAGE}
 
 RUN apt-get update && apt-get install -y \
     maven \
+    openjdk-17-jdk \
+    openjdk-17-source \
     git \
     python3 \
     pip \
@@ -30,4 +32,4 @@ RUN echo 'export PS1="\[🐳\] \[\e[0;36m\]\u@sleeper-builder\[\e[0m\]: \w # "' 
 
 WORKDIR /sleeper-builder
 
-CMD bash
+CMD [ "bash" ]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2855

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Tested manually

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.