### PR TITLE
Issue 2846 - Restore old Hadoop configuration behaviour

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SQSQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/query/SQSQueryDriver.java
@@ -19,7 +19,6 @@ package sleeper.systemtest.drivers.query;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.sqs.AmazonSQS;
-import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,12 +109,11 @@ public class SQSQueryDriver implements QuerySendAndWaitDriver {
     public List<Record> getResults(Query query) {
         LOGGER.info("Loading results for query: {}", query.getQueryId());
         Schema schema = instance.getTablePropertiesByDeployedName(query.getTableName()).orElseThrow().getSchema();
-        Configuration conf = clients.createHadoopConf();
         return s3Client.listObjects(
                 instance.getInstanceProperties().get(QUERY_RESULTS_BUCKET),
                 "query-" + query.getQueryId())
                 .getObjectSummaries().stream()
-                .flatMap(object -> ReadRecordsFromS3.getRecords(schema, object, conf))
+                .flatMap(object -> ReadRecordsFromS3.getRecords(schema, object, clients.createHadoopConf()))
                 .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/sourcedata/AwsIngestSourceFilesDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/sourcedata/AwsIngestSourceFilesDriver.java
@@ -29,6 +29,7 @@ import sleeper.core.schema.Schema;
 import sleeper.io.parquet.record.ParquetRecordWriterFactory;
 import sleeper.sketches.Sketches;
 import sleeper.sketches.s3.SketchesSerDeToS3;
+import sleeper.systemtest.drivers.util.SystemTestClients;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 
 import java.io.IOException;
@@ -39,20 +40,21 @@ import static sleeper.sketches.s3.SketchesSerDeToS3.sketchesPathForDataFile;
 
 public class AwsIngestSourceFilesDriver implements IngestSourceFilesDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsIngestSourceFilesDriver.class);
-    private final Configuration configuration;
+    private final SystemTestClients clients;
 
-    public AwsIngestSourceFilesDriver(Configuration configuration) {
-        this.configuration = configuration;
+    public AwsIngestSourceFilesDriver(SystemTestClients clients) {
+        this.clients = clients;
     }
 
     public void writeFile(
             InstanceProperties instanceProperties, TableProperties tableProperties,
             String path, boolean writeSketches, Iterator<Record> records) {
         Schema schema = tableProperties.getSchema();
+        Configuration conf = clients.createHadoopConf(instanceProperties, tableProperties);
         Sketches sketches = Sketches.from(schema);
         LOGGER.info("Writing to {}", path);
         try (ParquetWriter<Record> writer = ParquetRecordWriterFactory.createParquetRecordWriter(
-                new Path(path), tableProperties, configuration)) {
+                new Path(path), tableProperties, conf)) {
             for (Record record : (Iterable<Record>) () -> records) {
                 sketches.update(schema, record);
                 writer.write(record);
@@ -63,7 +65,7 @@ public class AwsIngestSourceFilesDriver implements IngestSourceFilesDriver {
         if (writeSketches) {
             LOGGER.info("Writing sketches");
             try {
-                new SketchesSerDeToS3(schema).saveToHadoopFS(sketchesPathForDataFile(path), sketches, configuration);
+                new SketchesSerDeToS3(schema).saveToHadoopFS(sketchesPathForDataFile(path), sketches, conf);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
Trying to roll back to before the following PR:
- https://github.com/gchq/sleeper/pull/2754

Still uses instance admin credentials by assuming role with TemporaryAWSCredentialsProvider. If that's caused the problem we can do a more complete revert.

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2846

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Will run full nightly functional test suite in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.