### PR TITLE
Issue 2883 - Remove full Maven build from CLI build

### DIFF
--- a/scripts/cli/buildAll.sh
+++ b/scripts/cli/buildAll.sh
@@ -22,14 +22,10 @@ SCRIPTS_DIR=$(cd "$THIS_DIR" && cd .. && pwd)
 source "$SCRIPTS_DIR/functions/timeUtils.sh"
 START_TIME=$(record_time)
 
-"$SCRIPTS_DIR/build/buildForTest.sh"
-
-END_MAVEN_TIME=$(record_time)
-
 "$THIS_DIR/dependencies/build.sh"
 
 END_DEPENDENCIES_TIME=$(record_time)
-echo "Finished dependencies Docker build at $(recorded_time_str "$END_DEPENDENCIES_TIME"), took $(elapsed_time_str "$END_MAVEN_TIME" "$END_DEPENDENCIES_TIME")"
+echo "Finished dependencies Docker build at $(recorded_time_str "$END_DEPENDENCIES_TIME"), took $(elapsed_time_str "$START_TIME" "$END_DEPENDENCIES_TIME")"
 
 "$THIS_DIR/builder/build.sh"
 
@@ -50,9 +46,8 @@ echo "--------------------------------------------------------------------------
 echo "Finished build"
 echo "-------------------------------------------------------------------------------"
 echo "Started at $(recorded_time_str "$START_TIME")"
-echo "Finished Maven build at $(recorded_time_str "$END_MAVEN_TIME"), took $(elapsed_time_str "$START_TIME" "$END_MAVEN_TIME")"
-echo "Finished dependencies Docker build at $(recorded_time_str "$END_DEPENDENCIES_TIME"), took $(elapsed_time_str "$END_MAVEN_TIME" "$END_DEPENDENCIES_TIME")"
+echo "Finished dependencies Docker build at $(recorded_time_str "$END_DEPENDENCIES_TIME"), took $(elapsed_time_str "$START_TIME" "$END_DEPENDENCIES_TIME")"
 echo "Finished builder Docker build at $(recorded_time_str "$END_BUILDER_TIME"), took $(elapsed_time_str "$END_DEPENDENCIES_TIME" "$END_BUILDER_TIME")"
 echo "Finished environment Maven build at $(recorded_time_str "$END_ENVIRONMENT_MAVEN_TIME"), took $(elapsed_time_str "$END_BUILDER_TIME" "$END_ENVIRONMENT_MAVEN_TIME")"
-echo "Finished environment Docker build at $(recorded_time_str "$END_TIME"), took $(elapsed_time_str "$END_BUILDER_TIME" "$END_TIME")"
+echo "Finished environment Docker build at $(recorded_time_str "$END_TIME"), took $(elapsed_time_str "$END_ENVIRONMENT_MAVEN_TIME" "$END_TIME")"
 echo "Overall, took $(elapsed_time_str "$START_TIME" "$END_TIME")"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2883

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Ran full build script locally

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.