### PR TITLE
Issue 2899 - Use Bash as the entrypoint for CLI Docker images

### DIFF
--- a/scripts/cli/builder/Dockerfile
+++ b/scripts/cli/builder/Dockerfile
@@ -54,4 +54,4 @@ RUN echo 'export HOSTNAME=$(cat /tmp/container.id)' >> ~/.bashrc
 
 WORKDIR /sleeper-builder
 
-CMD [ "bash" ]
+ENTRYPOINT [ "bash" ]

--- a/scripts/cli/environment/Dockerfile
+++ b/scripts/cli/environment/Dockerfile
@@ -37,4 +37,4 @@ WORKDIR /sleeper
 COPY . .
 
 ENV PATH=/sleeper/bin:$PATH
-CMD [ "bash" ]
+ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2899

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Tested manually running `scripts/cli/builder/build.sh` then `sleeper builder ./scripts/build/buildForTest.sh`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.