### PR TITLE
Issue 2933 - Support compaction input file assignment in state store committer lambda

### DIFF
--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionFileAssignmentCommitRequest.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionFileAssignmentCommitRequest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.compaction.job.commit;
+
+import sleeper.compaction.job.CompactionJob;
+import sleeper.core.statestore.AssignJobIdRequest;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static sleeper.core.statestore.AssignJobIdRequest.assignJobOnPartitionToFiles;
+
+public class CompactionFileAssignmentCommitRequest {
+    private List<AssignJobIdRequest> assignJobIdRequests;
+
+    public static CompactionFileAssignmentCommitRequest forJobs(List<CompactionJob> jobs) {
+        return new CompactionFileAssignmentCommitRequest(jobs.stream()
+                .map(job -> assignJobOnPartitionToFiles(job.getId(), job.getPartitionId(), job.getInputFiles()))
+                .collect(Collectors.toList()));
+    }
+
+    public CompactionFileAssignmentCommitRequest(List<AssignJobIdRequest> assignJobIdRequests) {
+        this.assignJobIdRequests = assignJobIdRequests;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(assignJobIdRequests);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof CompactionFileAssignmentCommitRequest)) {
+            return false;
+        }
+        CompactionFileAssignmentCommitRequest other = (CompactionFileAssignmentCommitRequest) obj;
+        return Objects.equals(assignJobIdRequests, other.assignJobIdRequests);
+    }
+
+    @Override
+    public String toString() {
+        return "CompactionFileAssignmentCommitRequest{assignJobIdRequests=" + assignJobIdRequests + "}";
+    }
+
+}

--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionFileAssignmentCommitRequestSerDe.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionFileAssignmentCommitRequestSerDe.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.compaction.job.commit;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import sleeper.compaction.job.CompactionJob;
+import sleeper.compaction.job.CompactionJobJsonSerDe;
+import sleeper.core.statestore.CommitRequestType;
+import sleeper.core.util.GsonConfig;
+
+public class CompactionFileAssignmentCommitRequestSerDe {
+    private final Gson gson;
+    private final Gson gsonPrettyPrint;
+
+    public CompactionFileAssignmentCommitRequestSerDe() {
+        GsonBuilder builder = GsonConfig.standardBuilder()
+                .registerTypeAdapter(CompactionJob.class, new CompactionJobJsonSerDe())
+                .serializeNulls();
+        gson = builder.create();
+        gsonPrettyPrint = builder.setPrettyPrinting().create();
+    }
+
+    public String toJson(CompactionFileAssignmentCommitRequest compactionJobCommitRequest) {
+        return gson.toJson(new WrappedCommitRequest(compactionJobCommitRequest), WrappedCommitRequest.class);
+    }
+
+    public String toJsonPrettyPrint(CompactionFileAssignmentCommitRequest compactionJobCommitRequest) {
+        return gsonPrettyPrint.toJson(new WrappedCommitRequest(compactionJobCommitRequest), WrappedCommitRequest.class);
+    }
+
+    public CompactionFileAssignmentCommitRequest fromJson(String json) {
+        WrappedCommitRequest wrappedRequest = gson.fromJson(json, WrappedCommitRequest.class);
+        if (CommitRequestType.COMPACTION_FILE_ASSIGNMENT == wrappedRequest.type) {
+            return wrappedRequest.request;
+        }
+        throw new IllegalArgumentException("Unexpected request type");
+    }
+
+    private static class WrappedCommitRequest {
+        private final CommitRequestType type;
+        private final CompactionFileAssignmentCommitRequest request;
+
+        WrappedCommitRequest(CompactionFileAssignmentCommitRequest request) {
+            this.type = CommitRequestType.COMPACTION_FILE_ASSIGNMENT;
+            this.request = request;
+        }
+    }
+}

--- a/java/core/src/main/java/sleeper/core/statestore/CommitRequestType.java
+++ b/java/core/src/main/java/sleeper/core/statestore/CommitRequestType.java
@@ -20,5 +20,6 @@ package sleeper.core.statestore;
  */
 public enum CommitRequestType {
     COMPACTION_FINISHED,
-    INGEST_ADD_FILES
+    INGEST_ADD_FILES,
+    COMPACTION_FILE_ASSIGNMENT
 }

--- a/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequest.java
+++ b/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequest.java
@@ -15,6 +15,7 @@
  */
 package sleeper.commit;
 
+import sleeper.compaction.job.commit.CompactionFileAssignmentCommitRequest;
 import sleeper.compaction.job.commit.CompactionJobCommitRequest;
 import sleeper.ingest.job.commit.IngestAddFilesCommitRequest;
 
@@ -34,6 +35,16 @@ public class StateStoreCommitRequest {
      * @return         a state store commit request
      */
     public static StateStoreCommitRequest forCompactionJob(CompactionJobCommitRequest request) {
+        return new StateStoreCommitRequest(request);
+    }
+
+    /**
+     * Creates a request to commit the assignment of files to a compaction job.
+     *
+     * @param  request the compaction job commit request
+     * @return         a state store commit request
+     */
+    public static StateStoreCommitRequest forCompactionFileAssignment(CompactionFileAssignmentCommitRequest request) {
         return new StateStoreCommitRequest(request);
     }
 

--- a/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequestDeserialiser.java
+++ b/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequestDeserialiser.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.job.CompactionJobJsonSerDe;
+import sleeper.compaction.job.commit.CompactionFileAssignmentCommitRequest;
 import sleeper.compaction.job.commit.CompactionJobCommitRequest;
 import sleeper.core.statestore.CommitRequestType;
 import sleeper.core.util.GsonConfig;
@@ -76,6 +77,9 @@ public class StateStoreCommitRequestDeserialiser {
                 case INGEST_ADD_FILES:
                     return StateStoreCommitRequest.forIngestAddFiles(
                             context.deserialize(requestObj, IngestAddFilesCommitRequest.class));
+                case COMPACTION_FILE_ASSIGNMENT:
+                    return StateStoreCommitRequest.forCompactionFileAssignment(
+                            context.deserialize(requestObj, CompactionFileAssignmentCommitRequest.class));
                 default:
                     throw new CommitRequestValidationException("Unrecognised request type");
             }

--- a/java/statestore-commit/src/test/java/sleeper/commit/StateStoreCommitRequestDeserialiserTest.java
+++ b/java/statestore-commit/src/test/java/sleeper/commit/StateStoreCommitRequestDeserialiserTest.java
@@ -18,6 +18,8 @@ package sleeper.commit;
 import org.junit.jupiter.api.Test;
 
 import sleeper.compaction.job.CompactionJob;
+import sleeper.compaction.job.commit.CompactionFileAssignmentCommitRequest;
+import sleeper.compaction.job.commit.CompactionFileAssignmentCommitRequestSerDe;
 import sleeper.compaction.job.commit.CompactionJobCommitRequest;
 import sleeper.compaction.job.commit.CompactionJobCommitRequestSerDe;
 import sleeper.core.record.process.RecordsProcessed;
@@ -57,6 +59,31 @@ public class StateStoreCommitRequestDeserialiserTest {
         // When / Then
         assertThat(commitRequestSerDe.fromJson(jsonString))
                 .isEqualTo(StateStoreCommitRequest.forCompactionJob(compactionJobCommitRequest));
+    }
+
+    @Test
+    void shouldDeserialiseCompactionFileAssignmentCommitRequest() {
+        // Given
+        CompactionJob job1 = CompactionJob.builder()
+                .tableId("test-table")
+                .jobId("test-job-1")
+                .inputFiles(List.of("file1.parquet", "file2.parquet"))
+                .outputFile("test-output-1.parquet")
+                .partitionId("test-partition-id")
+                .build();
+        CompactionJob job2 = CompactionJob.builder()
+                .tableId("test-table")
+                .jobId("test-job-2")
+                .inputFiles(List.of("file3.parquet", "file4.parquet"))
+                .outputFile("test-output-2.parquet")
+                .partitionId("test-partition-id")
+                .build();
+        CompactionFileAssignmentCommitRequest fileAssignmentRequest = CompactionFileAssignmentCommitRequest.forJobs(List.of(job1, job2));
+        String jsonString = new CompactionFileAssignmentCommitRequestSerDe().toJson(fileAssignmentRequest);
+
+        // When / Then
+        assertThat(commitRequestSerDe.fromJson(jsonString))
+                .isEqualTo(StateStoreCommitRequest.forCompactionFileAssignment(fileAssignmentRequest));
     }
 
     @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2933

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Added test in `StateStoreCommitRequestDeserialiserTest`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.