### PR TITLE
Issue 2966 - Do not report on failure waiting for compaction input file assignment

### DIFF
--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskAssignFilesTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskAssignFilesTest.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.compaction.job.CompactionJobStatusTestData.jobCreated;
 
 public class CompactionTaskAssignFilesTest extends CompactionTaskTestBase {
     private final List<CompactionJob> assignmentCheckRetries = new ArrayList<>();
@@ -62,6 +63,21 @@ public class CompactionTaskAssignFilesTest extends CompactionTaskTestBase {
         assertThat(failedJobs).containsExactly(job);
         assertThat(jobsOnQueue).isEmpty();
         assertThat(assignmentCheckRetries).containsExactly(job);
+    }
+
+    @Test
+    void shouldNotUpdateStatusStoreWhenTimingOutWaitingForFilesToBeAssignedToJob() throws Exception {
+        // Given
+        CompactionJob job = createJobOnQueue("job1");
+
+        // When
+        runTaskCheckingFiles(
+                waitForFilesAssignment(false),
+                jobsSucceed(1));
+
+        // Then
+        assertThat(jobStore.getAllJobs(DEFAULT_TABLE_ID)).containsExactly(
+                jobCreated(job, DEFAULT_CREATED_TIME));
     }
 
     private WaitForFileAssignment waitForFilesAssignment(Boolean... checkResults) {

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
@@ -105,15 +105,15 @@ public class CompactionTaskTestBase {
     }
 
     protected void runTask(CompactionRunner compactor, Supplier<Instant> timeSupplier) throws Exception {
-        runTask(pollQueue(), filesImmediatelyAssigned(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
+        runTask(pollQueue(), waitForFileAssignment(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
     }
 
     protected void runTask(String taskId, CompactionRunner compactor, Supplier<Instant> timeSupplier) throws Exception {
-        runTask(pollQueue(), filesImmediatelyAssigned(), compactor, timeSupplier, taskId, jobRunIdsInSequence());
+        runTask(pollQueue(), waitForFileAssignment(), compactor, timeSupplier, taskId, jobRunIdsInSequence());
     }
 
     protected void runTask(String taskId, CompactionRunner compactor, Supplier<String> jobRunIdSupplier, Supplier<Instant> timeSupplier) throws Exception {
-        runTask(pollQueue(), filesImmediatelyAssigned(), compactor, timeSupplier, taskId, jobRunIdSupplier);
+        runTask(pollQueue(), waitForFileAssignment(), compactor, timeSupplier, taskId, jobRunIdSupplier);
     }
 
     protected void runTaskCheckingFiles(WaitForFileAssignment fileAssignmentCheck, CompactionRunner compactor) throws Exception {
@@ -124,7 +124,7 @@ public class CompactionTaskTestBase {
             MessageReceiver messageReceiver,
             CompactionRunner compactor,
             Supplier<Instant> timeSupplier) throws Exception {
-        runTask(messageReceiver, filesImmediatelyAssigned(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
+        runTask(messageReceiver, waitForFileAssignment(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
     }
 
     private void runTask(
@@ -143,9 +143,8 @@ public class CompactionTaskTestBase {
                 .run();
     }
 
-    private WaitForFileAssignment filesImmediatelyAssigned() {
-        return job -> {
-        };
+    private WaitForFileAssignment waitForFileAssignment() {
+        return new StateStoreWaitForFiles(stateStoreByTableId::get);
     }
 
     private Supplier<String> jobRunIdsInSequence() {

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
@@ -34,6 +34,7 @@ import sleeper.core.record.process.RecordsProcessed;
 import sleeper.core.schema.Schema;
 import sleeper.core.statestore.FileReferenceFactory;
 import sleeper.core.statestore.StateStore;
+import sleeper.core.util.ExponentialBackoffWithJitter;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -50,6 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static sleeper.compaction.task.StateStoreWaitForFiles.JOB_ASSIGNMENT_WAIT_RANGE;
 import static sleeper.configuration.properties.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.configuration.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_CONSECUTIVE_FAILURES;
 import static sleeper.configuration.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_IDLE_TIME_IN_SECONDS;
@@ -144,7 +146,9 @@ public class CompactionTaskTestBase {
     }
 
     private WaitForFileAssignment waitForFileAssignment() {
-        return new StateStoreWaitForFiles(stateStoreByTableId::get);
+        return new StateStoreWaitForFiles(1,
+                new ExponentialBackoffWithJitter(JOB_ASSIGNMENT_WAIT_RANGE),
+                stateStoreByTableId::get);
     }
 
     private Supplier<String> jobRunIdsInSequence() {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2966

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated CompactionTaskAssignFilesTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.