### PR TITLE
Issue 2974 - Add support for storing state store commit requests in S3

### DIFF
--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionJobCommitRequestSerDe.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionJobCommitRequestSerDe.java
@@ -20,7 +20,7 @@ import com.google.gson.GsonBuilder;
 
 import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.job.CompactionJobJsonSerDe;
-import sleeper.core.statestore.CommitRequestType;
+import sleeper.core.statestore.commit.CommitRequestType;
 import sleeper.core.util.GsonConfig;
 
 public class CompactionJobCommitRequestSerDe {

--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionJobIdAssignmentCommitRequestSerDe.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/job/commit/CompactionJobIdAssignmentCommitRequestSerDe.java
@@ -20,7 +20,7 @@ import com.google.gson.GsonBuilder;
 
 import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.job.CompactionJobJsonSerDe;
-import sleeper.core.statestore.CommitRequestType;
+import sleeper.core.statestore.commit.CommitRequestType;
 import sleeper.core.util.GsonConfig;
 
 public class CompactionJobIdAssignmentCommitRequestSerDe {

--- a/java/core/src/main/java/sleeper/core/statestore/commit/CommitRequestType.java
+++ b/java/core/src/main/java/sleeper/core/statestore/commit/CommitRequestType.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.core.statestore;
+package sleeper.core.statestore.commit;
 
 /**
  * Represents the different types of state store commit requests that can be performed.
  */
 public enum CommitRequestType {
     COMPACTION_FINISHED,
-    INGEST_ADD_FILES
+    INGEST_ADD_FILES,
+    STORED_IN_S3
 }

--- a/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3.java
+++ b/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3.java
@@ -27,6 +27,18 @@ public class StateStoreCommitRequestInS3 {
         this.keyInS3 = keyInS3;
     }
 
+    /**
+     * Creates a key for a file in S3, to hold a commit request. Used when uploading a commit request to S3. This should
+     * be held in the Sleeper instance data bucket.
+     *
+     * @param  tableId  the Sleeper table unique ID
+     * @param  filename the filename without file type, can be a random UUID
+     * @return          the S3 object key
+     */
+    public static String createFileS3Key(String tableId, String filename) {
+        return tableId + "/statestore/commitrequests/" + filename + ".json";
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(keyInS3);

--- a/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3.java
+++ b/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3.java
@@ -39,6 +39,10 @@ public class StateStoreCommitRequestInS3 {
         return tableId + "/statestore/commitrequests/" + filename + ".json";
     }
 
+    public String getKeyInS3() {
+        return keyInS3;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(keyInS3);

--- a/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3.java
+++ b/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.statestore.commit;
+
+import java.util.Objects;
+
+/**
+ * A state store commit request stored in S3.
+ */
+public class StateStoreCommitRequestInS3 {
+    private final String keyInS3;
+
+    public StateStoreCommitRequestInS3(String keyInS3) {
+        this.keyInS3 = keyInS3;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keyInS3);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof StateStoreCommitRequestInS3)) {
+            return false;
+        }
+        StateStoreCommitRequestInS3 other = (StateStoreCommitRequestInS3) obj;
+        return Objects.equals(keyInS3, other.keyInS3);
+    }
+
+    @Override
+    public String toString() {
+        return "StateStoreCommitRequestInS3{keyInS3=" + keyInS3 + "}";
+    }
+
+}

--- a/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDe.java
+++ b/java/core/src/main/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDe.java
@@ -13,24 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package sleeper.ingest.job.commit;
+package sleeper.core.statestore.commit;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import sleeper.core.statestore.FileReferenceSerDe;
-import sleeper.core.statestore.commit.CommitRequestType;
 import sleeper.core.util.GsonConfig;
 
 /**
- * Serialises and deserialises an add files commit request to and from JSON.
+ * Serialises and deserialises a commit request stored in S3.
  */
-public class IngestAddFilesCommitRequestSerDe {
-
+public class StateStoreCommitRequestInS3SerDe {
     private final Gson gson;
     private final Gson gsonPrettyPrint;
 
-    public IngestAddFilesCommitRequestSerDe() {
+    public StateStoreCommitRequestInS3SerDe() {
         GsonBuilder builder = GsonConfig.standardBuilder()
                 .addSerializationExclusionStrategy(FileReferenceSerDe.excludeUpdateTimes());
         gson = builder.create();
@@ -38,49 +36,49 @@ public class IngestAddFilesCommitRequestSerDe {
     }
 
     /**
-     * Serialises an add files commit request to a JSON string.
+     * Serialises a commit request stored in S3 to a JSON string.
      *
      * @param  request the commit request
      * @return         the JSON string
      */
-    public String toJson(IngestAddFilesCommitRequest request) {
+    public String toJson(StateStoreCommitRequestInS3 request) {
         return gson.toJson(new WrappedCommitRequest(request), WrappedCommitRequest.class);
     }
 
     /**
-     * Serialises an add files commit request to a pretty-printed JSON string.
+     * Serialises a commit request stored in S3 to a pretty-printed JSON string.
      *
      * @param  request the commit request
      * @return         the pretty-printed JSON string
      */
-    public String toJsonPrettyPrint(IngestAddFilesCommitRequest request) {
+    public String toJsonPrettyPrint(StateStoreCommitRequestInS3 request) {
         return gsonPrettyPrint.toJson(new WrappedCommitRequest(request), WrappedCommitRequest.class);
     }
 
     /**
-     * Deserialises an add files commit request from a JSON string.
+     * Deserialises a commit request stored in S3 from a JSON string.
      *
      * @param  json the JSON string
      * @return      the commit request
      */
-    public IngestAddFilesCommitRequest fromJson(String json) {
+    public StateStoreCommitRequestInS3 fromJson(String json) {
         WrappedCommitRequest wrappedRequest = gson.fromJson(json, WrappedCommitRequest.class);
-        if (CommitRequestType.INGEST_ADD_FILES == wrappedRequest.type) {
+        if (CommitRequestType.STORED_IN_S3 == wrappedRequest.type) {
             return wrappedRequest.request;
         }
         throw new IllegalArgumentException("Unexpected request type");
     }
 
     /**
-     * Stores an add files commit request with the type of commit request. Used by the state store committer to
+     * Stores a commit request stored in S3 with the type of commit request. Used by the state store committer to
      * deserialise the correct commit request.
      */
     private static class WrappedCommitRequest {
         private final CommitRequestType type;
-        private final IngestAddFilesCommitRequest request;
+        private final StateStoreCommitRequestInS3 request;
 
-        WrappedCommitRequest(IngestAddFilesCommitRequest request) {
-            this.type = CommitRequestType.INGEST_ADD_FILES;
+        WrappedCommitRequest(StateStoreCommitRequestInS3 request) {
+            this.type = CommitRequestType.STORED_IN_S3;
             this.request = request;
         }
     }

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.java
@@ -19,6 +19,7 @@ import org.approvaltests.Approvals;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class StateStoreCommitRequestInS3SerDeTest {
     private final StateStoreCommitRequestInS3SerDe serDe = new StateStoreCommitRequestInS3SerDe();
@@ -35,5 +36,11 @@ public class StateStoreCommitRequestInS3SerDeTest {
         // Then
         assertThat(serDe.fromJson(json)).isEqualTo(commitRequest);
         Approvals.verify(json);
+    }
+
+    @Test
+    void shouldFailToDeserialiseNonStoredInS3CommitRequest() {
+        assertThatThrownBy(() -> serDe.fromJson("{\"type\": \"OTHER\", \"request\":{}}"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.java
@@ -26,7 +26,8 @@ public class StateStoreCommitRequestInS3SerDeTest {
     @Test
     void shouldSerialiseCommitRequestInS3() {
         // Given
-        StateStoreCommitRequestInS3 commitRequest = new StateStoreCommitRequestInS3("test-data-bucket/test-commit-request.json");
+        String s3Key = StateStoreCommitRequestInS3.createFileS3Key("test-table", "test-file");
+        StateStoreCommitRequestInS3 commitRequest = new StateStoreCommitRequestInS3(s3Key);
 
         // When
         String json = serDe.toJsonPrettyPrint(commitRequest);

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.statestore.commit;
+
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StateStoreCommitRequestInS3SerDeTest {
+    private final StateStoreCommitRequestInS3SerDe serDe = new StateStoreCommitRequestInS3SerDe();
+
+    @Test
+    void shouldSerialiseCommitRequestInS3() {
+        // Given
+        StateStoreCommitRequestInS3 commitRequest = new StateStoreCommitRequestInS3("test-data-bucket/test-commit-request.json");
+
+        // When
+        String json = serDe.toJsonPrettyPrint(commitRequest);
+
+        // Then
+        assertThat(serDe.fromJson(json)).isEqualTo(commitRequest);
+        Approvals.verify(json);
+    }
+}

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.shouldSerialiseCommitRequestInS3.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.shouldSerialiseCommitRequestInS3.approved.txt
@@ -1,0 +1,6 @@
+{
+  "type": "STORED_IN_S3",
+  "request": {
+    "keyInS3": "test-data-bucket/test-commit-request.json"
+  }
+}

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.shouldSerialiseCommitRequestInS3.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestInS3SerDeTest.shouldSerialiseCommitRequestInS3.approved.txt
@@ -1,6 +1,6 @@
 {
   "type": "STORED_IN_S3",
   "request": {
-    "keyInS3": "test-data-bucket/test-commit-request.json"
+    "keyInS3": "test-table/statestore/commitrequests/test-file.json"
   }
 }

--- a/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequest.java
+++ b/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequest.java
@@ -16,6 +16,7 @@
 package sleeper.commit;
 
 import sleeper.compaction.job.commit.CompactionJobCommitRequest;
+import sleeper.core.statestore.commit.StateStoreCommitRequestInS3;
 import sleeper.ingest.job.commit.IngestAddFilesCommitRequest;
 
 import java.util.Objects;
@@ -44,6 +45,16 @@ public class StateStoreCommitRequest {
      * @return         a state store commit request
      */
     public static StateStoreCommitRequest forIngestAddFiles(IngestAddFilesCommitRequest request) {
+        return new StateStoreCommitRequest(request);
+    }
+
+    /**
+     * Creates a request which is stored in S3.
+     *
+     * @param  request the commit request
+     * @return         a state store commit request
+     */
+    public static StateStoreCommitRequest storedInS3(StateStoreCommitRequestInS3 request) {
         return new StateStoreCommitRequest(request);
     }
 

--- a/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequestDeserialiser.java
+++ b/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequestDeserialiser.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.job.CompactionJobJsonSerDe;
 import sleeper.compaction.job.commit.CompactionJobCommitRequest;
-import sleeper.core.statestore.CommitRequestType;
+import sleeper.core.statestore.commit.CommitRequestType;
 import sleeper.core.util.GsonConfig;
 import sleeper.ingest.job.commit.IngestAddFilesCommitRequest;
 

--- a/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequestDeserialiser.java
+++ b/java/statestore-commit/src/main/java/sleeper/commit/StateStoreCommitRequestDeserialiser.java
@@ -28,6 +28,7 @@ import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.job.CompactionJobJsonSerDe;
 import sleeper.compaction.job.commit.CompactionJobCommitRequest;
 import sleeper.core.statestore.commit.CommitRequestType;
+import sleeper.core.statestore.commit.StateStoreCommitRequestInS3;
 import sleeper.core.util.GsonConfig;
 import sleeper.ingest.job.commit.IngestAddFilesCommitRequest;
 
@@ -76,6 +77,9 @@ public class StateStoreCommitRequestDeserialiser {
                 case INGEST_ADD_FILES:
                     return StateStoreCommitRequest.forIngestAddFiles(
                             context.deserialize(requestObj, IngestAddFilesCommitRequest.class));
+                case STORED_IN_S3:
+                    return StateStoreCommitRequest.storedInS3(
+                            context.deserialize(requestObj, StateStoreCommitRequestInS3.class));
                 default:
                     throw new CommitRequestValidationException("Unrecognised request type");
             }

--- a/java/statestore-commit/src/test/java/sleeper/commit/StateStoreCommitRequestDeserialiserTest.java
+++ b/java/statestore-commit/src/test/java/sleeper/commit/StateStoreCommitRequestDeserialiserTest.java
@@ -23,6 +23,8 @@ import sleeper.compaction.job.commit.CompactionJobCommitRequestSerDe;
 import sleeper.core.record.process.RecordsProcessed;
 import sleeper.core.record.process.RecordsProcessedSummary;
 import sleeper.core.statestore.FileReference;
+import sleeper.core.statestore.commit.StateStoreCommitRequestInS3;
+import sleeper.core.statestore.commit.StateStoreCommitRequestInS3SerDe;
 import sleeper.ingest.job.IngestJob;
 import sleeper.ingest.job.commit.IngestAddFilesCommitRequest;
 import sleeper.ingest.job.commit.IngestAddFilesCommitRequestSerDe;
@@ -118,6 +120,18 @@ public class StateStoreCommitRequestDeserialiserTest {
         // When / Then
         assertThat(commitRequestSerDe.fromJson(jsonString))
                 .isEqualTo(StateStoreCommitRequest.forIngestAddFiles(ingestJobCommitRequest));
+    }
+
+    @Test
+    void shouldDeserialiseCommitRequestInS3() {
+        // Given
+        String s3Key = StateStoreCommitRequestInS3.createFileS3Key("test-table", "test-file");
+        StateStoreCommitRequestInS3 commitRequest = new StateStoreCommitRequestInS3(s3Key);
+        String jsonString = new StateStoreCommitRequestInS3SerDe().toJson(commitRequest);
+
+        // When / Then
+        assertThat(commitRequestSerDe.fromJson(jsonString))
+                .isEqualTo(StateStoreCommitRequest.storedInS3(commitRequest));
     }
 
     @Test

--- a/java/statestore-lambda/src/main/java/sleeper/statestore/committer/lambda/StateStoreCommitterLambda.java
+++ b/java/statestore-lambda/src/main/java/sleeper/statestore/committer/lambda/StateStoreCommitterLambda.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
+import static sleeper.configuration.properties.instance.CdkDefinedInstanceProperty.DATA_BUCKET;
 
 /**
  * A lambda that allows for asynchronous commits to a state store.
@@ -99,6 +100,8 @@ public class StateStoreCommitterLambda implements RequestHandler<SQSEvent, SQSBa
         return new StateStoreCommitter(
                 CompactionJobStatusStoreFactory.getStatusStore(dynamoDBClient, instanceProperties),
                 IngestJobStatusStoreFactory.getStatusStore(dynamoDBClient, instanceProperties),
-                stateStoreProvider.byTableId(tablePropertiesProvider), Instant::now);
+                stateStoreProvider.byTableId(tablePropertiesProvider),
+                key -> s3Client.getObjectAsString(instanceProperties.get(DATA_BUCKET), key),
+                Instant::now);
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2974

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - StateStoreCommitRequestInS3SerDeTest
    - Updated StateStoreCommitRequestDeserialiserTest, StateStoreCommitterTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.