### PR TITLE
Issue 2969 - Store add files commit requests in S3 if they are too large

### DIFF
--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/job/runner/BulkImportJobDriverIT.java
@@ -119,7 +119,6 @@ import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
 import static sleeper.configuration.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.record.process.RecordsProcessedSummaryTestHelper.summary;
-import static sleeper.core.statestore.commit.StateStoreCommitRequestInS3.createFileS3Key;
 import static sleeper.ingest.job.status.IngestJobStatusTestHelper.ingestAcceptedStatus;
 import static sleeper.ingest.job.status.IngestJobStatusTestHelper.ingestFinishedStatus;
 import static sleeper.ingest.job.status.IngestJobStatusTestHelper.ingestFinishedStatusUncommitted;
@@ -548,7 +547,8 @@ class BulkImportJobDriverIT {
                         .build());
 
         // Then
-        String expectedS3Key = createFileS3Key(tableProperties.get(TABLE_ID), "test-add-files-commit");
+        String expectedS3Key = StateStoreCommitRequestInS3.createFileS3Key(
+                tableProperties.get(TABLE_ID), "test-add-files-commit");
         assertThat(receiveCommitRequestStoredInS3Messages())
                 .containsExactly(new StateStoreCommitRequestInS3(expectedS3Key));
         assertThat(readAddFilesCommitRequestFromDataBucket(expectedS3Key))

--- a/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/ECSIngestTaskRunner.java
+++ b/java/ingest/ingest-runner/src/main/java/sleeper/ingest/job/ECSIngestTaskRunner.java
@@ -111,7 +111,8 @@ public class ECSIngestTaskRunner {
         PropertiesReloader propertiesReloader = PropertiesReloader.ifConfigured(
                 s3Client, instanceProperties, tablePropertiesProvider);
         IngestJobRunner ingestJobRunner = new IngestJobRunner(objectFactory, instanceProperties, tablePropertiesProvider,
-                propertiesReloader, stateStoreProvider, jobStore, taskId, localDir, s3AsyncClient, sqsClient, hadoopConfiguration, Instant::now);
+                propertiesReloader, stateStoreProvider, jobStore, taskId, localDir,
+                s3Client, s3AsyncClient, sqsClient, hadoopConfiguration, Instant::now);
         IngestJobQueueConsumer queueConsumer = new IngestJobQueueConsumer(
                 sqsClient, cloudWatchClient, instanceProperties, hadoopConfiguration,
                 new DynamoDBTableIndex(instanceProperties, dynamoDBClient), jobStore);

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/commit/AddFilesToStateStoreIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/commit/AddFilesToStateStoreIT.java
@@ -99,8 +99,8 @@ public class AddFilesToStateStoreIT {
     @Test
     void shouldUploadCommitRequestToS3WhenRequestIsTooLarge() throws Exception {
         // Given
-        List<FileReference> fileReferences = IntStream.range(0, 100)
-                .mapToObj(i -> factory.rootFile("file" + i + ".parquet", 100L))
+        List<FileReference> fileReferences = IntStream.range(0, 1350)
+                .mapToObj(i -> factory.rootFile("s3a://test-data-bucket/test-table/data/partition_root/test-file" + i + ".parquet", 100L))
                 .collect(Collectors.toList());
         Supplier<String> s3FileNameSupplier = () -> "test-add-files-commit";
 
@@ -130,7 +130,8 @@ public class AddFilesToStateStoreIT {
     }
 
     private AddFilesToStateStore bySqs(Supplier<String> filenameSupplier) {
-        return AddFilesToStateStore.bySqs(sqs, instanceProperties, request -> request.tableId(tableProperties.get(TABLE_ID)));
+        return AddFilesToStateStore.bySqs(sqs, s3, instanceProperties, filenameSupplier,
+                request -> request.tableId(tableProperties.get(TABLE_ID)));
     }
 
     private List<StateStoreCommitRequestInS3> receiveCommitRequestStoredInS3Messages() {

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/commit/AddFilesToStateStoreIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/commit/AddFilesToStateStoreIT.java
@@ -58,7 +58,6 @@ import static sleeper.configuration.properties.table.TablePropertiesTestHelper.c
 import static sleeper.configuration.properties.table.TableProperty.TABLE_ID;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
-import static sleeper.core.statestore.commit.StateStoreCommitRequestInS3.createFileS3Key;
 
 @Testcontainers
 public class AddFilesToStateStoreIT {
@@ -108,7 +107,8 @@ public class AddFilesToStateStoreIT {
         bySqs(s3FileNameSupplier).addFiles(fileReferences);
 
         // Then
-        String expectedS3Key = createFileS3Key(tableProperties.get(TABLE_ID), "test-add-files-commit");
+        String expectedS3Key = StateStoreCommitRequestInS3.createFileS3Key(
+                tableProperties.get(TABLE_ID), "test-add-files-commit");
         assertThat(receiveCommitRequestStoredInS3Messages())
                 .containsExactly(new StateStoreCommitRequestInS3(expectedS3Key));
         assertThat(readAddFilesCommitRequestFromDataBucket(expectedS3Key))

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/commit/AddFilesToStateStoreIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/impl/commit/AddFilesToStateStoreIT.java
@@ -24,7 +24,6 @@ import com.amazonaws.services.sqs.model.CreateQueueResult;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -98,7 +97,6 @@ public class AddFilesToStateStoreIT {
     }
 
     @Test
-    @Disabled("TODO")
     void shouldUploadCommitRequestToS3WhenRequestIsTooLarge() throws Exception {
         // Given
         List<FileReference> fileReferences = IntStream.range(0, 100)
@@ -137,13 +135,13 @@ public class AddFilesToStateStoreIT {
 
     private List<StateStoreCommitRequestInS3> receiveCommitRequestStoredInS3Messages() {
         return receiveCommitMessages().stream()
-                .map(AddFilesToStateStoreIT::readCommitRequestStoredInS3)
+                .map(message -> new StateStoreCommitRequestInS3SerDe().fromJson(message.getBody()))
                 .collect(Collectors.toList());
     }
 
     private List<IngestAddFilesCommitRequest> receiveAddFilesCommitMessages() {
         return receiveCommitMessages().stream()
-                .map(AddFilesToStateStoreIT::readAddFilesCommitRequest)
+                .map(message -> new IngestAddFilesCommitRequestSerDe().fromJson(message.getBody()))
                 .collect(Collectors.toList());
     }
 
@@ -152,14 +150,6 @@ public class AddFilesToStateStoreIT {
                 .withQueueUrl(instanceProperties.get(STATESTORE_COMMITTER_QUEUE_URL))
                 .withMaxNumberOfMessages(10);
         return sqs.receiveMessage(receiveMessageRequest).getMessages();
-    }
-
-    private static IngestAddFilesCommitRequest readAddFilesCommitRequest(Message message) {
-        return new IngestAddFilesCommitRequestSerDe().fromJson(message.getBody());
-    }
-
-    private static StateStoreCommitRequestInS3 readCommitRequestStoredInS3(Message message) {
-        return new StateStoreCommitRequestInS3SerDe().fromJson(message.getBody());
     }
 
     private IngestAddFilesCommitRequest readAddFilesCommitRequestFromDataBucket(String s3Key) {

--- a/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobRunnerIT.java
+++ b/java/ingest/ingest-runner/src/test/java/sleeper/ingest/job/IngestJobRunnerIT.java
@@ -374,7 +374,7 @@ class IngestJobRunnerIT {
                 stateStoreProvider, statusStore,
                 "test-task",
                 localDir.toString(),
-                s3Async, sqs,
+                s3, s3Async, sqs,
                 hadoopConfiguration,
                 timeSupplier);
     }

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/InstanceIngestSession.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/InstanceIngestSession.java
@@ -70,6 +70,10 @@ public class InstanceIngestSession implements AutoCloseable {
         return new InstanceIngestSession(assumeRole, stsClientV1, stsClientV2, instanceProperties, tableName);
     }
 
+    public AmazonS3 s3() {
+        return s3;
+    }
+
     public S3AsyncClient s3Async() {
         return s3Async;
     }

--- a/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
+++ b/java/system-test/system-test-data-generation/src/main/java/sleeper/systemtest/datageneration/WriteRandomDataDirect.java
@@ -15,6 +15,7 @@
  */
 package sleeper.systemtest.datageneration;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.sqs.AmazonSQS;
 
 import sleeper.configuration.jars.ObjectFactory;
@@ -56,7 +57,8 @@ public class WriteRandomDataDirect {
                         .hadoopConfiguration(session.hadoopConfiguration())
                         .s3AsyncClient(session.s3Async())
                         .build(),
-                addFilesToStateStore(session.sqs(), session.instanceProperties(), session.tableProperties(), stateStoreProvider),
+                addFilesToStateStore(session.sqs(), session.s3(),
+                        session.instanceProperties(), session.tableProperties(), stateStoreProvider),
                 systemTestProperties, session.tableProperties());
     }
 
@@ -75,10 +77,10 @@ public class WriteRandomDataDirect {
     }
 
     private static AddFilesToStateStore addFilesToStateStore(
-            AmazonSQS sqsClient, InstanceProperties instanceProperties, TableProperties tableProperties,
+            AmazonSQS sqsClient, AmazonS3 s3Client, InstanceProperties instanceProperties, TableProperties tableProperties,
             StateStoreProvider stateStoreProvider) {
         if (tableProperties.getBoolean(INGEST_FILES_COMMIT_ASYNC)) {
-            return AddFilesToStateStore.bySqs(sqsClient, instanceProperties,
+            return AddFilesToStateStore.bySqs(sqsClient, s3Client, instanceProperties,
                     requestBuilder -> requestBuilder.tableId(tableProperties.get(TABLE_ID)));
         } else {
             return AddFilesToStateStore.synchronous(stateStoreProvider.getStateStore(tableProperties));


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2969

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Added AddFilesToStateStoreIT
    - Updated BulkImportJobDriverIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.