### PR TITLE
Issue 3005 - Add DynamoDB helper for retrying code that throws throttling exception

### DIFF
--- a/java/common/dynamodb-tools/src/main/java/sleeper/dynamodb/tools/DynamoDBUtils.java
+++ b/java/common/dynamodb-tools/src/main/java/sleeper/dynamodb/tools/DynamoDBUtils.java
@@ -232,7 +232,10 @@ public class DynamoDBUtils {
     }
 
     public static void retryOnThrottlingException(Runnable runnable) throws InterruptedException {
-        PollWithRetries pollWithRetries = PollWithRetries.intervalAndPollingTimeout(Duration.ofMinutes(1), Duration.ofMinutes(10));
+        retryOnThrottlingException(PollWithRetries.intervalAndPollingTimeout(Duration.ofMinutes(1), Duration.ofMinutes(10)), runnable);
+    }
+
+    public static void retryOnThrottlingException(PollWithRetries pollWithRetries, Runnable runnable) throws InterruptedException {
         pollWithRetries.pollUntil("no throttling exception", () -> {
             try {
                 runnable.run();

--- a/java/common/dynamodb-tools/src/test/java/sleeper/dynamodb/tools/DynamoDBUtilsTest.java
+++ b/java/common/dynamodb-tools/src/test/java/sleeper/dynamodb/tools/DynamoDBUtilsTest.java
@@ -16,61 +16,84 @@
 package sleeper.dynamodb.tools;
 
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class DynamoDBUtilsTest {
 
-    @Test
-    void shouldFindThrottlingExceptionWithNoCauses() {
-        // Given
-        AmazonDynamoDBException exception = new AmazonDynamoDBException("Throttling exception");
-        exception.setErrorCode("ThrottlingException");
+    @Nested
+    @DisplayName("Find throttling exception")
+    class FindThrottlingException {
 
-        // When / Then
-        assertThat(DynamoDBUtils.isThrottlingException(exception)).isTrue();
+        @Test
+        void shouldFindThrottlingExceptionWithNoCauses() {
+            // Given
+            AmazonDynamoDBException exception = new AmazonDynamoDBException("Throttling exception");
+            exception.setErrorCode("ThrottlingException");
+
+            // When / Then
+            assertThat(DynamoDBUtils.isThrottlingException(exception)).isTrue();
+        }
+
+        @Test
+        void shouldFindThrottlingExceptionWhenItIsRootCause() {
+            // Given
+            AmazonDynamoDBException rootCause = new AmazonDynamoDBException("Throttling exception");
+            rootCause.setErrorCode("ThrottlingException");
+            Exception cause = new Exception("First cause exception", rootCause);
+            Exception exception = new Exception("Test exception", cause);
+
+            // When / Then
+            assertThat(DynamoDBUtils.isThrottlingException(exception)).isTrue();
+        }
+
+        @Test
+        void shouldNotFindThrottlingExceptionWithMultipleCauses() {
+            // Given
+            Exception rootCause = new Exception("Root cause exception");
+            Exception cause = new Exception("First cause exception", rootCause);
+            Exception exception = new Exception("Test exception", cause);
+
+            // When / Then
+            assertThat(DynamoDBUtils.isThrottlingException(exception)).isFalse();
+        }
+
+        @Test
+        void shouldNotFindThrottlingExceptionWithNoCause() {
+            // Given
+            Exception exception = new Exception("Test exception");
+
+            // When / Then
+            assertThat(DynamoDBUtils.isThrottlingException(exception)).isFalse();
+        }
+
+        @Test
+        void shouldNotFindThrottlingExceptionWhenExceptionHasDifferentErrorCode() {
+            // Given
+            AmazonDynamoDBException exception = new AmazonDynamoDBException("Conditional check exception");
+            exception.setErrorCode("ConditionalCheckFailedException");
+
+            // When / Then
+            assertThat(DynamoDBUtils.isThrottlingException(exception)).isFalse();
+        }
     }
 
-    @Test
-    void shouldFindThrottlingExceptionWhenItIsRootCause() {
-        // Given
-        AmazonDynamoDBException rootCause = new AmazonDynamoDBException("Throttling exception");
-        rootCause.setErrorCode("ThrottlingException");
-        Exception cause = new Exception("First cause exception", rootCause);
-        Exception exception = new Exception("Test exception", cause);
+    @Nested
+    @DisplayName("Retry on throttling exception")
+    class RetryOnThrottlingException {
+        @Test
+        void shouldNotTimeoutWhenNoExceptionsThrown() {
+            // Given
+            Runnable runnable = () -> {
+            };
 
-        // When / Then
-        assertThat(DynamoDBUtils.isThrottlingException(exception)).isTrue();
-    }
-
-    @Test
-    void shouldNotFindThrottlingExceptionWithMultipleCauses() {
-        // Given
-        Exception rootCause = new Exception("Root cause exception");
-        Exception cause = new Exception("First cause exception", rootCause);
-        Exception exception = new Exception("Test exception", cause);
-
-        // When / Then
-        assertThat(DynamoDBUtils.isThrottlingException(exception)).isFalse();
-    }
-
-    @Test
-    void shouldNotFindThrottlingExceptionWithNoCause() {
-        // Given
-        Exception exception = new Exception("Test exception");
-
-        // When / Then
-        assertThat(DynamoDBUtils.isThrottlingException(exception)).isFalse();
-    }
-
-    @Test
-    void shouldNotFindThrottlingExceptionWhenExceptionHasDifferentErrorCode() {
-        // Given
-        AmazonDynamoDBException exception = new AmazonDynamoDBException("Conditional check exception");
-        exception.setErrorCode("ConditionalCheckFailedException");
-
-        // When / Then
-        assertThat(DynamoDBUtils.isThrottlingException(exception)).isFalse();
+            // When / Then
+            assertThatCode(() -> DynamoDBUtils.retryOnThrottlingException(runnable))
+                    .doesNotThrowAnyException();
+        }
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3005

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - DynamoDBUtilsTest.RetryOnThrottlingException

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.