### PR TITLE
Issue 3025 - Remove reserved concurrency on find partitions to split lambda

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -739,13 +739,6 @@ sleeper.partition.splitting.finder.memory=2048
 # The timeout in seconds for the lambda function used to identify partitions that need to be split.
 sleeper.partition.splitting.finder.timeout.seconds=900
 
-# The number of lambda instances to reserve from your AWS account's quota for finding partitions to
-# split. Note that this will not provision instances until they are needed. Each time partition
-# splitting runs, a separate lambda invocation will be made for each Sleeper table, to check for
-# partitions that need splitting. If the reserved concurrency is less than the number of Sleeper
-# tables in the instance, these invocations will queue up.
-sleeper.partition.splitting.finder.reserved.concurrency=2
-
 # The amount of memory in MB for the lambda function used to split partitions.
 sleeper.partition.splitting.memory=2048
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/PartitionSplittingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/PartitionSplittingStack.java
@@ -60,7 +60,6 @@ import static sleeper.configuration.properties.instance.CommonProperty.TABLE_BAT
 import static sleeper.configuration.properties.instance.CommonProperty.TABLE_BATCHING_LAMBDAS_TIMEOUT_IN_SECONDS;
 import static sleeper.configuration.properties.instance.PartitionSplittingProperty.FIND_PARTITIONS_TO_SPLIT_BATCH_SIZE;
 import static sleeper.configuration.properties.instance.PartitionSplittingProperty.FIND_PARTITIONS_TO_SPLIT_LAMBDA_MEMORY_IN_MB;
-import static sleeper.configuration.properties.instance.PartitionSplittingProperty.FIND_PARTITIONS_TO_SPLIT_RESERVED_CONCURRENCY;
 import static sleeper.configuration.properties.instance.PartitionSplittingProperty.FIND_PARTITIONS_TO_SPLIT_TIMEOUT_IN_SECONDS;
 import static sleeper.configuration.properties.instance.PartitionSplittingProperty.PARTITION_SPLITTING_TRIGGER_PERIOD_IN_MINUTES;
 import static sleeper.configuration.properties.instance.PartitionSplittingProperty.SPLIT_PARTITIONS_LAMBDA_MEMORY_IN_MB;
@@ -221,7 +220,6 @@ public class PartitionSplittingStack extends NestedStack {
                 .runtime(software.amazon.awscdk.services.lambda.Runtime.JAVA_11)
                 .memorySize(instanceProperties.getInt(FIND_PARTITIONS_TO_SPLIT_LAMBDA_MEMORY_IN_MB))
                 .timeout(Duration.seconds(instanceProperties.getInt(FIND_PARTITIONS_TO_SPLIT_TIMEOUT_IN_SECONDS)))
-                .reservedConcurrentExecutions(instanceProperties.getInt(FIND_PARTITIONS_TO_SPLIT_RESERVED_CONCURRENCY))
                 .handler("sleeper.splitter.lambda.FindPartitionsToSplitLambda::handleRequest")
                 .environment(environmentVariables)
                 .logGroup(createLambdaLogGroup(this, "FindPartitionsToSplitLogGroup", functionName, instanceProperties)));

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/PartitionSplittingProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/PartitionSplittingProperty.java
@@ -51,15 +51,6 @@ public interface PartitionSplittingProperty {
             .defaultValue("900")
             .propertyGroup(InstancePropertyGroup.PARTITION_SPLITTING)
             .runCdkDeployWhenChanged(true).build();
-    UserDefinedInstanceProperty FIND_PARTITIONS_TO_SPLIT_RESERVED_CONCURRENCY = Index.propertyBuilder("sleeper.partition.splitting.finder.reserved.concurrency")
-            .description("The number of lambda instances to reserve from your AWS account's quota for finding " +
-                    "partitions to split. Note that this will not provision instances until they are needed. Each " +
-                    "time partition splitting runs, a separate lambda invocation will be made for each Sleeper " +
-                    "table, to check for partitions that need splitting. If the reserved concurrency is less than " +
-                    "the number of Sleeper tables in the instance, these invocations will queue up.")
-            .defaultValue("2")
-            .propertyGroup(InstancePropertyGroup.PARTITION_SPLITTING)
-            .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty SPLIT_PARTITIONS_LAMBDA_MEMORY_IN_MB = Index.propertyBuilder("sleeper.partition.splitting.memory")
             .description("The amount of memory in MB for the lambda function used to split partitions.")
             .defaultValue("2048")

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -768,13 +768,6 @@ sleeper.partition.splitting.finder.memory=2048
 # The timeout in seconds for the lambda function used to identify partitions that need to be split.
 sleeper.partition.splitting.finder.timeout.seconds=900
 
-# The number of lambda instances to reserve from your AWS account's quota for finding partitions to
-# split. Note that this will not provision instances until they are needed. Each time partition
-# splitting runs, a separate lambda invocation will be made for each Sleeper table, to check for
-# partitions that need splitting. If the reserved concurrency is less than the number of Sleeper
-# tables in the instance, these invocations will queue up.
-sleeper.partition.splitting.finder.reserved.concurrency=2
-
 # The amount of memory in MB for the lambda function used to split partitions.
 sleeper.partition.splitting.memory=2048
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3025

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by system tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.