### PR TITLE
Issue 3099 - Handle singular & negative in LoggedDuration

### DIFF
--- a/java/core/src/main/java/sleeper/core/util/LoggedDuration.java
+++ b/java/core/src/main/java/sleeper/core/util/LoggedDuration.java
@@ -96,7 +96,11 @@ public class LoggedDuration {
 
     private String getLongString() {
         String output = "";
-        long seconds = duration.getSeconds();
+        boolean negative = duration.getSeconds() < 0;
+        if (negative) {
+            output += "-";
+        }
+        long seconds = Math.abs(duration.getSeconds());
         if (seconds >= 3600) {
             output += (seconds / 3600) + " hour" + ((seconds / 3600) > 1 ? "s " : " ");
             seconds %= 3600;
@@ -105,8 +109,13 @@ public class LoggedDuration {
             output += (seconds / 60) + " minute" + ((seconds / 60) > 1 ? "s " : " ");
             seconds %= 60;
         }
-        output += FORMATTER.format(seconds + (double) duration.getNano() / 1_000_000_000) + " second"
-                + (seconds > 1 || seconds == 0 ? "s" : "");
+        double fraction = duration.getNano() / 1_000_000_000.0;
+        if (negative) {
+            fraction = -fraction;
+        }
+        double secondsWithFraction = seconds + fraction;
+        output += FORMATTER.format(secondsWithFraction) + " second"
+                + (secondsWithFraction == 1 ? "" : "s");
         return output;
     }
 

--- a/java/core/src/main/java/sleeper/core/util/LoggedDuration.java
+++ b/java/core/src/main/java/sleeper/core/util/LoggedDuration.java
@@ -121,7 +121,11 @@ public class LoggedDuration {
 
     private String getShortString() {
         String output = "";
-        long seconds = duration.getSeconds();
+        boolean negative = duration.getSeconds() < 0;
+        if (negative) {
+            output += "-";
+        }
+        long seconds = Math.abs(duration.getSeconds());
         if (seconds >= 3600) {
             output += (seconds / 3600) + "h ";
             seconds %= 3600;
@@ -130,7 +134,11 @@ public class LoggedDuration {
             output += (seconds / 60) + "m ";
             seconds %= 60;
         }
-        output += FORMATTER.format(seconds + (double) duration.getNano() / 1_000_000_000) + "s";
+        double fraction = duration.getNano() / 1_000_000_000.0;
+        if (negative) {
+            fraction = -fraction;
+        }
+        output += FORMATTER.format(seconds + fraction) + "s";
         return output;
     }
 }

--- a/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
+++ b/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
@@ -118,6 +118,19 @@ public class LoggedDurationTest {
             // Then
             assertThat(output).isEqualTo("12 hours 0 seconds");
         }
+
+        @Test
+        void shouldOutputNegativeDuration() {
+            // Given
+            Instant startTime = Instant.parse("2023-11-21T19:34:56.789Z");
+            Instant stopTime = Instant.parse("2023-11-21T07:00:00Z");
+
+            // When
+            String output = LoggedDuration.withFullOutput(startTime, stopTime).toString();
+
+            // Then
+            assertThat(output).isEqualTo("-12 hours 34 minutes 56.789 seconds");
+        }
     }
 
     @Nested

--- a/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
+++ b/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
@@ -218,5 +218,18 @@ public class LoggedDurationTest {
             // Then
             assertThat(output).isEqualTo("-12h 34m 56.789s");
         }
+
+        @Test
+        void shouldOutputDurationWithOnlyHours() {
+            // Given
+            Instant startTime = Instant.parse("2023-11-21T07:00:00Z");
+            Instant stopTime = Instant.parse("2023-11-21T19:00:00Z");
+
+            // When
+            String output = LoggedDuration.withShortOutput(startTime, stopTime).toString();
+
+            // Then
+            assertThat(output).isEqualTo("12h 0s");
+        }
     }
 }

--- a/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
+++ b/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LoggedDurationTest {
     @Nested
-    @DisplayName("Output long duration format")
+    @DisplayName("Output long format")
     class LongFormat {
         @Test
         void shouldOutputDurationWithOnlySeconds() {
@@ -105,6 +105,11 @@ public class LoggedDurationTest {
             // Then
             assertThat(output).isEqualTo("12 hours 34 minutes 56.789 seconds");
         }
+    }
+
+    @Nested
+    @DisplayName("Output long format with singular or plural")
+    class LongFormatSingular {
 
         @Test
         void shouldOutputDurationWithSingleUnits() {
@@ -131,10 +136,49 @@ public class LoggedDurationTest {
             // Then
             assertThat(output).isEqualTo("0 seconds");
         }
+
+        @Test
+        void shouldOutputDurationWithSingleUnitsAndFraction() {
+            // Given
+            Instant startTime = Instant.parse("2023-11-21T17:10:00Z");
+            Instant stopTime = Instant.parse("2023-11-21T18:11:01.123Z");
+
+            // When
+            String output = LoggedDuration.withFullOutput(startTime, stopTime).toString();
+
+            // Then
+            assertThat(output).isEqualTo("1 hour 1 minute 1.123 seconds");
+        }
+
+        @Test
+        void shouldOutputNegativeDurationWithSingleUnits() {
+            // Given
+            Instant startTime = Instant.parse("2023-11-21T19:12:01Z");
+            Instant stopTime = Instant.parse("2023-11-21T18:11:00Z");
+
+            // When
+            String output = LoggedDuration.withFullOutput(startTime, stopTime).toString();
+
+            // Then
+            assertThat(output).isEqualTo("-1 hour 1 minute 1 second");
+        }
+
+        @Test
+        void shouldOutputNegativeDurationWithSingleUnitsAndFraction() {
+            // Given
+            Instant startTime = Instant.parse("2023-11-21T19:12:01.123Z");
+            Instant stopTime = Instant.parse("2023-11-21T18:11:00Z");
+
+            // When
+            String output = LoggedDuration.withFullOutput(startTime, stopTime).toString();
+
+            // Then
+            assertThat(output).isEqualTo("-1 hour 1 minute 1.123 seconds");
+        }
     }
 
     @Nested
-    @DisplayName("Output short duration format")
+    @DisplayName("Output short format")
     class ShortFormat {
         @Test
         void shouldOutputStringInShortFormat() {

--- a/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
+++ b/java/core/src/test/java/sleeper/core/util/LoggedDurationTest.java
@@ -105,6 +105,19 @@ public class LoggedDurationTest {
             // Then
             assertThat(output).isEqualTo("12 hours 34 minutes 56.789 seconds");
         }
+
+        @Test
+        void shouldOutputDurationWithOnlyHours() {
+            // Given
+            Instant startTime = Instant.parse("2023-11-21T07:00:00Z");
+            Instant stopTime = Instant.parse("2023-11-21T19:00:00Z");
+
+            // When
+            String output = LoggedDuration.withFullOutput(startTime, stopTime).toString();
+
+            // Then
+            assertThat(output).isEqualTo("12 hours 0 seconds");
+        }
     }
 
     @Nested
@@ -191,6 +204,19 @@ public class LoggedDurationTest {
 
             // Then
             assertThat(output).isEqualTo("12h 34m 56.789s");
+        }
+
+        @Test
+        void shouldOutputNegativeDurationInShortFormat() {
+            // Given
+            Instant startTime = Instant.parse("2023-11-21T19:34:56.789Z");
+            Instant stopTime = Instant.parse("2023-11-21T07:00:00Z");
+
+            // When
+            String output = LoggedDuration.withShortOutput(startTime, stopTime).toString();
+
+            // Then
+            assertThat(output).isEqualTo("-12h 34m 56.789s");
         }
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3099

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated LoggedDurationTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.