### PR TITLE
Issue 2932 - Avoid extra reads in state store committer

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1234,3 +1234,11 @@ sleeper.default.ingest.job.files.commit.async=true
 # If true, bulk import will add files via requests sent to the state store committer lambda
 # asynchronously. If false, bulk import will commit new files at the end of the job synchronously.
 sleeper.default.bulk.import.job.files.commit.async=true
+
+# When using the transaction log state store, this sets whether to update from the transaction log
+# before adding a transaction in the asynchronous state store committer.
+# If asynchronous commits are used for all or almost all state store updates, this can be false to
+# avoid the extra queries.
+# If the state store is commonly updated directly outside of the asynchronous committer, this can be
+# true to avoid conflicts and retries.
+sleeper.default.statestore.committer.update.every.commit=false

--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -148,6 +148,14 @@ sleeper.table.compaction.method=JAVA
 # sleeper.statestore.dynamodb.DynamoDBStateStore
 sleeper.table.statestore.classname=sleeper.statestore.transactionlog.DynamoDBTransactionLogStateStore
 
+# When using the transaction log state store, this sets whether to update from the transaction log
+# before adding a transaction in the asynchronous state store committer.
+# If asynchronous commits are used for all or almost all state store updates, this can be false to
+# avoid the extra queries.
+# If the state store is commonly updated directly outside of the asynchronous committer, this can be
+# true to avoid conflicts and retries.
+sleeper.table.statestore.committer.update.every.commit=false
+
 # The number of attempts to make when applying a transaction to the state store.
 sleeper.table.statestore.transactionlog.add.transaction.max.attempts=10
 

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/DefaultProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/DefaultProperty.java
@@ -282,6 +282,16 @@ public interface DefaultProperty {
             .defaultValue("true")
             .validationPredicate(Utils::isTrueOrFalse)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
+    UserDefinedInstanceProperty DEFAULT_STATESTORE_COMMITTER_UPDATE_ON_EVERY_COMMIT = Index.propertyBuilder("sleeper.default.statestore.committer.update.every.commit")
+            .description("When using the transaction log state store, this sets whether to update from the " +
+                    "transaction log before adding a transaction in the asynchronous state store committer.\n" +
+                    "If asynchronous commits are used for all or almost all state store updates, this can be false " +
+                    "to avoid the extra queries.\n" +
+                    "If the state store is commonly updated directly outside of the asynchronous committer, this can " +
+                    "be true to avoid conflicts and retries.")
+            .defaultValue("false")
+            .validationPredicate(Utils::isTrueOrFalse)
+            .propertyGroup(InstancePropertyGroup.DEFAULT).build();
 
     static List<UserDefinedInstanceProperty> getAll() {
         return Index.INSTANCE.getAll();

--- a/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/table/TableProperty.java
@@ -63,6 +63,7 @@ import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_PARQUET_WRITER_VERSION;
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_ROW_GROUP_SIZE;
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_S3A_READAHEAD_RANGE;
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_STATESTORE_COMMITTER_UPDATE_ON_EVERY_COMMIT;
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_STATISTICS_TRUNCATE_LENGTH;
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_TIME_BETWEEN_SNAPSHOT_CHECKS_SECS;
 import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_TIME_BETWEEN_TRANSACTION_CHECKS_MS;
@@ -288,6 +289,15 @@ public interface TableProperty extends SleeperProperty {
                     "sleeper.statestore.dynamodb.DynamoDBStateStore")
             .propertyGroup(TablePropertyGroup.METADATA)
             .editable(false).build();
+    TableProperty STATESTORE_COMMITTER_UPDATE_ON_EVERY_COMMIT = Index.propertyBuilder("sleeper.table.statestore.committer.update.every.commit")
+            .defaultProperty(DEFAULT_STATESTORE_COMMITTER_UPDATE_ON_EVERY_COMMIT)
+            .description("When using the transaction log state store, this sets whether to update from the " +
+                    "transaction log before adding a transaction in the asynchronous state store committer.\n" +
+                    "If asynchronous commits are used for all or almost all state store updates, this can be false " +
+                    "to avoid the extra queries.\n" +
+                    "If the state store is commonly updated directly outside of the asynchronous committer, this can " +
+                    "be true to avoid conflicts and retries.")
+            .propertyGroup(TablePropertyGroup.METADATA).build();
     TableProperty ADD_TRANSACTION_MAX_ATTEMPTS = Index.propertyBuilder("sleeper.table.statestore.transactionlog.add.transaction.max.attempts")
             .defaultProperty(DEFAULT_ADD_TRANSACTION_MAX_ATTEMPTS)
             .description("The number of attempts to make when applying a transaction to the state store.")

--- a/java/statestore-lambda/src/main/java/sleeper/statestore/committer/lambda/StateStoreCommitterLambda.java
+++ b/java/statestore-lambda/src/main/java/sleeper/statestore/committer/lambda/StateStoreCommitterLambda.java
@@ -39,6 +39,7 @@ import sleeper.core.util.PollWithRetries;
 import sleeper.dynamodb.tools.DynamoDBUtils;
 import sleeper.ingest.status.store.job.IngestJobStatusStoreFactory;
 import sleeper.io.parquet.utils.HadoopConfigurationProvider;
+import sleeper.statestore.StateStoreFactory;
 import sleeper.statestore.StateStoreProvider;
 
 import java.time.Duration;
@@ -105,7 +106,8 @@ public class StateStoreCommitterLambda implements RequestHandler<SQSEvent, SQSBa
         Configuration hadoopConf = HadoopConfigurationProvider.getConfigurationForLambdas(instanceProperties);
 
         TablePropertiesProvider tablePropertiesProvider = new TablePropertiesProvider(instanceProperties, s3Client, dynamoDBClient);
-        StateStoreProvider stateStoreProvider = new StateStoreProvider(instanceProperties, s3Client, dynamoDBClient, hadoopConf);
+        StateStoreFactory stateStoreFactory = StateStoreFactory.forSingleCommitter(instanceProperties, s3Client, dynamoDBClient, hadoopConf);
+        StateStoreProvider stateStoreProvider = new StateStoreProvider(instanceProperties, stateStoreFactory);
         return new StateStoreCommitter(
                 tablePropertiesProvider,
                 CompactionJobStatusStoreFactory.getStatusStore(dynamoDBClient, instanceProperties),

--- a/java/statestore-lambda/src/main/java/sleeper/statestore/committer/lambda/StateStoreCommitterLambda.java
+++ b/java/statestore-lambda/src/main/java/sleeper/statestore/committer/lambda/StateStoreCommitterLambda.java
@@ -106,7 +106,7 @@ public class StateStoreCommitterLambda implements RequestHandler<SQSEvent, SQSBa
         Configuration hadoopConf = HadoopConfigurationProvider.getConfigurationForLambdas(instanceProperties);
 
         TablePropertiesProvider tablePropertiesProvider = new TablePropertiesProvider(instanceProperties, s3Client, dynamoDBClient);
-        StateStoreFactory stateStoreFactory = StateStoreFactory.forSingleCommitter(instanceProperties, s3Client, dynamoDBClient, hadoopConf);
+        StateStoreFactory stateStoreFactory = StateStoreFactory.forCommitterProcess(instanceProperties, s3Client, dynamoDBClient, hadoopConf);
         StateStoreProvider stateStoreProvider = new StateStoreProvider(instanceProperties, stateStoreFactory);
         return new StateStoreCommitter(
                 tablePropertiesProvider,

--- a/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
+++ b/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
@@ -33,7 +33,7 @@ import static sleeper.configuration.properties.table.TableProperty.STATESTORE_CL
  * Creates a client to access the state store for a Sleeper table. The client may not be thread safe, as it may cache
  * the state.
  */
-public class StateStoreFactory {
+public class StateStoreFactory implements StateStoreProvider.Factory {
     private final InstanceProperties instanceProperties;
     private final AmazonS3 s3;
     private final AmazonDynamoDB dynamoDB;
@@ -72,6 +72,7 @@ public class StateStoreFactory {
      * @param  tableProperties the Sleeper table properties
      * @return                 the state store
      */
+    @Override
     public StateStore getStateStore(TableProperties tableProperties) {
         String stateStoreClassName = tableProperties.get(STATESTORE_CLASSNAME);
         if (stateStoreClassName.equals(DynamoDBStateStore.class.getName())) {

--- a/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
+++ b/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
@@ -60,7 +60,8 @@ public class StateStoreFactory implements StateStoreProvider.Factory {
      * This will detect depending on the Sleeper table, whether that table's state store is updated by a single process
      * asynchronously, or whether updates are made directly by multiple processes. This will configure the state store
      * client appropriately if only a single process updates that state store, and will assume that this is that
-     * process.
+     * process. The current process should handle almost all updates to that state store across the whole Sleeper
+     * instance.
      *
      * @param  instanceProperties the Sleeper instance properties
      * @param  s3                 the S3 client

--- a/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
+++ b/java/statestore/src/main/java/sleeper/statestore/StateStoreFactory.java
@@ -56,6 +56,11 @@ public class StateStoreFactory implements StateStoreProvider.Factory {
     /**
      * Creates a factory for state stores which will be updated by a single process. Used in the state store committer,
      * to avoid the need to check constantly for new transactions in the transaction log implementation.
+     * <p>
+     * This will detect depending on the Sleeper table, whether that table's state store is updated by a single process
+     * asynchronously, or whether updates are made directly by multiple processes. This will configure the state store
+     * client appropriately if only a single process updates that state store, and will assume that this is that
+     * process.
      *
      * @param  instanceProperties the Sleeper instance properties
      * @param  s3                 the S3 client

--- a/java/statestore/src/main/java/sleeper/statestore/StateStoreProvider.java
+++ b/java/statestore/src/main/java/sleeper/statestore/StateStoreProvider.java
@@ -46,7 +46,7 @@ public class StateStoreProvider {
 
     public StateStoreProvider(
             InstanceProperties instanceProperties, AmazonS3 s3Client, AmazonDynamoDB dynamoDBClient, Configuration configuration) {
-        this(instanceProperties, new StateStoreFactory(instanceProperties, s3Client, dynamoDBClient, configuration)::getStateStore);
+        this(instanceProperties, new StateStoreFactory(instanceProperties, s3Client, dynamoDBClient, configuration));
     }
 
     public StateStoreProvider(InstanceProperties instanceProperties, Factory stateStoreFactory) {

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStore.java
@@ -37,21 +37,6 @@ public class DynamoDBTransactionLogStateStore {
     }
 
     /**
-     * Creates the state store for the given Sleeper table.
-     *
-     * @param  instanceProperties the Sleeper instance properties
-     * @param  tableProperties    the Sleeper table properties
-     * @param  dynamoDB           the client for interacting with DynamoDB
-     * @param  s3                 the client for interacting with S3
-     * @param  configuration      the Hadoop configuration for interacting with Parquet
-     * @return                    the state store
-     */
-    public static TransactionLogStateStore create(
-            InstanceProperties instanceProperties, TableProperties tableProperties, AmazonDynamoDB dynamoDB, AmazonS3 s3, Configuration configuration) {
-        return builderFrom(instanceProperties, tableProperties, dynamoDB, s3, configuration).build();
-    }
-
-    /**
      * Creates a builder for the state store for the given Sleeper table.
      *
      * @param  instanceProperties the Sleeper instance properties

--- a/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStoreNoSnapshots.java
+++ b/java/statestore/src/main/java/sleeper/statestore/transactionlog/DynamoDBTransactionLogStateStoreNoSnapshots.java
@@ -44,21 +44,6 @@ public class DynamoDBTransactionLogStateStoreNoSnapshots {
     }
 
     /**
-     * Creates the state store for the given Sleeper table.
-     *
-     * @param  instanceProperties the Sleeper instance properties
-     * @param  tableProperties    the Sleeper table properties
-     * @param  dynamoDB           the client for interacting with DynamoDB
-     * @param  s3                 the client for interacting with S3
-     * @return                    the state store
-     */
-    public static TransactionLogStateStore create(
-            InstanceProperties instanceProperties, TableProperties tableProperties,
-            AmazonDynamoDB dynamoDB, AmazonS3 s3) {
-        return builderFrom(instanceProperties, tableProperties, dynamoDB, s3).build();
-    }
-
-    /**
      * Creates a builder for the state store for the given Sleeper table.
      *
      * @param  instanceProperties the Sleeper instance properties

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreatorIT.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogSnapshotCreatorIT.java
@@ -305,7 +305,7 @@ public class TransactionLogSnapshotCreatorIT extends TransactionLogSnapshotTestB
     }
 
     private StateStore createStateStore(TableProperties tableProperties) {
-        StateStore stateStore = DynamoDBTransactionLogStateStore.create(instanceProperties, tableProperties, dynamoDBClient, s3Client, configuration);
+        StateStore stateStore = DynamoDBTransactionLogStateStore.builderFrom(instanceProperties, tableProperties, dynamoDBClient, s3Client, configuration).build();
         stateStore.fixFileUpdateTime(DEFAULT_UPDATE_TIME);
         stateStore.fixPartitionUpdateTime(DEFAULT_UPDATE_TIME);
         return stateStore;

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreTestBase.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreTestBase.java
@@ -69,7 +69,7 @@ public class TransactionLogStateStoreTestBase {
     }
 
     public StateStore createStateStore(TableProperties tableProperties) {
-        StateStore stateStore = DynamoDBTransactionLogStateStore.create(instanceProperties, tableProperties, dynamoDBClient, s3Client, configuration);
+        StateStore stateStore = stateStoreBuilder(tableProperties).build();
         stateStore.fixFileUpdateTime(DEFAULT_UPDATE_TIME);
         stateStore.fixPartitionUpdateTime(DEFAULT_UPDATE_TIME);
         return stateStore;

--- a/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreTestBase.java
+++ b/java/statestore/src/test/java/sleeper/statestore/transactionlog/TransactionLogStateStoreTestBase.java
@@ -69,10 +69,7 @@ public class TransactionLogStateStoreTestBase {
     }
 
     public StateStore createStateStore(TableProperties tableProperties) {
-        StateStore stateStore = stateStoreBuilder(tableProperties).build();
-        stateStore.fixFileUpdateTime(DEFAULT_UPDATE_TIME);
-        stateStore.fixPartitionUpdateTime(DEFAULT_UPDATE_TIME);
-        return stateStore;
+        return stateStore(stateStoreBuilder(tableProperties));
     }
 
     protected StateStore stateStore(TransactionLogStateStore.Builder builder) {

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterThroughputST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterThroughputST.java
@@ -58,7 +58,7 @@ public class StateStoreCommitterThroughputST {
         // Then
         assertThat(sleeper.tableFiles().references()).hasSize(1000);
         assertThat(sleeper.stateStore().commitsPerSecondForTable())
-                .isBetween(70.0, 110.0);
+                .isBetween(90.0, 120.0); // Lambda limits throughput to 100/s but we usually see slightly higher
     }
 
     @Test
@@ -79,7 +79,7 @@ public class StateStoreCommitterThroughputST {
         // Then
         assertThat(sleeper.tableFiles().references()).hasSize(1000);
         assertThat(sleeper.stateStore().commitsPerSecondForTable())
-                .isBetween(30.0, 50.0);
+                .isBetween(40.0, 60.0);
     }
 
     @Test
@@ -107,7 +107,7 @@ public class StateStoreCommitterThroughputST {
         assertThat(sleeper.stateStore().commitsPerSecondByTable())
                 .hasSize(10)
                 .allSatisfy((table, commitsPerSecond) -> assertThat(commitsPerSecond)
-                        .isBetween(20.0, 110.0));
+                        .isBetween(15.0, 120.0));
     }
 
 }

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1258,3 +1258,11 @@ sleeper.default.ingest.job.files.commit.async=true
 # If true, bulk import will add files via requests sent to the state store committer lambda
 # asynchronously. If false, bulk import will commit new files at the end of the job synchronously.
 sleeper.default.bulk.import.job.files.commit.async=true
+
+# When using the transaction log state store, this sets whether to update from the transaction log
+# before adding a transaction in the asynchronous state store committer.
+# If asynchronous commits are used for all or almost all state store updates, this can be false to
+# avoid the extra queries.
+# If the state store is commonly updated directly outside of the asynchronous committer, this can be
+# true to avoid conflicts and retries.
+sleeper.default.statestore.committer.update.every.commit=false


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/2932

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated TransactionLogStateStoreLogSpecificTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.