### PR TITLE
Issue 3118 - Avoid wait on first retry in state store committer

### DIFF
--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStore.java
@@ -93,7 +93,7 @@ public class InMemoryTransactionLogStore implements TransactionLogStore {
      * @param action the operation to occur before the next time transactions are read
      */
     public void atStartOfNextReadTransactions(ThrowingRunnable action) {
-        startOfAdd.onNext(action);
+        startOfRead.onNext(action);
     }
 
     public long getLastTransactionNumber() {

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStore.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/InMemoryTransactionLogStore.java
@@ -31,6 +31,7 @@ public class InMemoryTransactionLogStore implements TransactionLogStore {
     private List<TransactionLogEntry> transactions = new ArrayList<>();
     private TriggerActions startOfAdd = new TriggerActions();
     private TriggerActions startOfRead = new TriggerActions();
+    private boolean runningTrigger = false;
 
     @Override
     public void addTransaction(TransactionLogEntry entry) throws DuplicateTransactionNumberException {
@@ -138,7 +139,7 @@ public class InMemoryTransactionLogStore implements TransactionLogStore {
     /**
      * Tracks actions that will be done when some trigger is met.
      */
-    private static class TriggerActions {
+    private class TriggerActions {
 
         private final Queue<Runnable> queue = new LinkedList<>();
 
@@ -156,9 +157,14 @@ public class InMemoryTransactionLogStore implements TransactionLogStore {
         }
 
         void run() {
+            if (runningTrigger) {
+                return;
+            }
             Runnable runnable = queue.poll();
             if (runnable != null) {
+                runningTrigger = true;
                 runnable.run();
+                runningTrigger = false;
             }
         }
     }

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
@@ -31,14 +31,20 @@ import sleeper.core.statestore.SplitFileReferences;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.core.statestore.transactionlog.InMemoryTransactionLogStore.ThrowingRunnable;
+import sleeper.core.util.ExponentialBackoffWithJitter;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 import static sleeper.core.statestore.FileReferenceTestData.DEFAULT_UPDATE_TIME;
+import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.constantJitterFraction;
+import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.recordWaits;
 
 public class TransactionLogStateStoreLogSpecificTest extends InMemoryTransactionLogStateStoreTestBase {
 
@@ -228,6 +234,81 @@ public class TransactionLogStateStoreLogSpecificTest extends InMemoryTransaction
             assertThat(store.getFileReferences())
                     .isEmpty();
             assertThat(retryWaits).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Exponential backoff for retries")
+    class ExponentialBackoffRetries {
+
+        @Test
+        void shouldBackoffExponentiallyOnRetries() throws Exception {
+            // Given
+            store = stateStore(builder -> builder
+                    .maxAddTransactionAttempts(TransactionLogStateStore.DEFAULT_MAX_ADD_TRANSACTION_ATTEMPTS)
+                    .retryBackoff(new ExponentialBackoffWithJitter(
+                            TransactionLogStateStore.DEFAULT_RETRY_WAIT_RANGE,
+                            constantJitterFraction(0.5), recordWaits(retryWaits))));
+            // And we cause a transaction conflict by adding another file during each update
+            FileReference file = fileFactory().rootFile("file.parquet", 100);
+            List<FileReference> otherProcessFiles = IntStream.rangeClosed(1, TransactionLogStateStore.DEFAULT_MAX_ADD_TRANSACTION_ATTEMPTS)
+                    .mapToObj(i -> fileFactory().rootFile("file-" + i + ".parquet", i * 100))
+                    .collect(toUnmodifiableList());
+            filesLogStore.atStartOfNextAddTransactions(otherProcessFiles.stream()
+                    .<ThrowingRunnable>map(otherProcessFile -> () -> otherProcess().addFile(otherProcessFile))
+                    .collect(toUnmodifiableList()));
+
+            // When / Then
+            assertThatThrownBy(() -> store.addFile(file))
+                    .isInstanceOf(StateStoreException.class)
+                    .hasCauseInstanceOf(DuplicateTransactionNumberException.class);
+            assertThat(store.getFileReferences())
+                    .containsExactlyInAnyOrderElementsOf(otherProcessFiles);
+            assertThat(retryWaits).containsExactly(
+                    Duration.parse("PT0.1S"),
+                    Duration.parse("PT0.2S"),
+                    Duration.parse("PT0.4S"),
+                    Duration.parse("PT0.8S"),
+                    Duration.parse("PT1.6S"),
+                    Duration.parse("PT3.2S"),
+                    Duration.parse("PT6.4S"),
+                    Duration.parse("PT12.8S"),
+                    Duration.parse("PT15S"));
+        }
+
+        @Test
+        void shouldSkipFirstWaitWhenNotUpdatingLogBeforeAddingTransaction() throws Exception {
+            // Given
+            store = stateStore(builder -> builder
+                    .maxAddTransactionAttempts(TransactionLogStateStore.DEFAULT_MAX_ADD_TRANSACTION_ATTEMPTS)
+                    .retryBackoff(new ExponentialBackoffWithJitter(
+                            TransactionLogStateStore.DEFAULT_RETRY_WAIT_RANGE,
+                            constantJitterFraction(0.5), recordWaits(retryWaits)))
+                    .updateLogBeforeAddTransaction(false));
+            // And we cause a transaction conflict by adding another file during each update
+            FileReference file = fileFactory().rootFile("file.parquet", 100);
+            List<FileReference> otherProcessFiles = IntStream.rangeClosed(1, TransactionLogStateStore.DEFAULT_MAX_ADD_TRANSACTION_ATTEMPTS)
+                    .mapToObj(i -> fileFactory().rootFile("file-" + i + ".parquet", i * 100))
+                    .collect(toUnmodifiableList());
+            filesLogStore.atStartOfNextAddTransactions(otherProcessFiles.stream()
+                    .<ThrowingRunnable>map(otherProcessFile -> () -> otherProcess().addFile(otherProcessFile))
+                    .collect(toUnmodifiableList()));
+
+            // When / Then
+            assertThatThrownBy(() -> store.addFile(file))
+                    .isInstanceOf(StateStoreException.class)
+                    .hasCauseInstanceOf(DuplicateTransactionNumberException.class);
+            assertThat(store.getFileReferences())
+                    .containsExactlyInAnyOrderElementsOf(otherProcessFiles);
+            assertThat(retryWaits).containsExactly(
+                    Duration.parse("PT0.1S"),
+                    Duration.parse("PT0.2S"),
+                    Duration.parse("PT0.4S"),
+                    Duration.parse("PT0.8S"),
+                    Duration.parse("PT1.6S"),
+                    Duration.parse("PT3.2S"),
+                    Duration.parse("PT6.4S"),
+                    Duration.parse("PT12.8S"));
         }
     }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3118

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated TransactionLogStateStoreLogSpecificTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.