### PR TITLE
Issue 3247 - Avoid EMR rate limit in Maven teardown script

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/util/EmrUtils.java
+++ b/java/clients/src/main/java/sleeper/clients/util/EmrUtils.java
@@ -30,10 +30,10 @@ public class EmrUtils {
 
     private static final List<String> ACTIVE_STATES = List.of(ClusterState.STARTING.name(), ClusterState.BOOTSTRAPPING.name(),
             ClusterState.RUNNING.name(), ClusterState.WAITING.name(), ClusterState.TERMINATING.name());
-    private static final StaticRateLimit<ListClustersResult> LIST_ACTIVE_CLUSTERS_LIMIT = StaticRateLimit.forMaximumRatePerSecond(0.5);
+    public static final StaticRateLimit<ListClustersResult> LIST_ACTIVE_CLUSTERS_LIMIT = StaticRateLimit.forMaximumRatePerSecond(0.5);
 
-    public static ListClustersResult listActiveClusters(AmazonElasticMapReduce emrClient) {
-        return LIST_ACTIVE_CLUSTERS_LIMIT.requestOrGetLast(() -> emrClient.listClusters(
+    public static ListClustersResult listActiveClusters(AmazonElasticMapReduce emrClient, StaticRateLimit<ListClustersResult> rateLimit) {
+        return rateLimit.requestOrGetLast(() -> emrClient.listClusters(
                 new ListClustersRequest().withClusterStates(ACTIVE_STATES)));
     }
 }

--- a/java/clients/src/main/java/sleeper/clients/util/EmrUtils.java
+++ b/java/clients/src/main/java/sleeper/clients/util/EmrUtils.java
@@ -30,7 +30,7 @@ public class EmrUtils {
 
     private static final List<String> ACTIVE_STATES = List.of(ClusterState.STARTING.name(), ClusterState.BOOTSTRAPPING.name(),
             ClusterState.RUNNING.name(), ClusterState.WAITING.name(), ClusterState.TERMINATING.name());
-    private static final StaticRateLimit<ListClustersResult> LIST_ACTIVE_CLUSTERS_LIMIT = StaticRateLimit.forMaximumRatePerSecond(0.2);
+    private static final StaticRateLimit<ListClustersResult> LIST_ACTIVE_CLUSTERS_LIMIT = StaticRateLimit.forMaximumRatePerSecond(0.5);
 
     public static ListClustersResult listActiveClusters(AmazonElasticMapReduce emrClient) {
         return LIST_ACTIVE_CLUSTERS_LIMIT.requestOrGetLast(() -> emrClient.listClusters(

--- a/java/clients/src/test/java/sleeper/clients/status/report/ingest/job/PersistentEMRStepCountIT.java
+++ b/java/clients/src/test/java/sleeper/clients/status/report/ingest/job/PersistentEMRStepCountIT.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.Test;
 
 import sleeper.configuration.properties.instance.InstanceProperties;
+import sleeper.core.util.StaticRateLimit;
 
 import java.util.Collections;
 import java.util.Map;
@@ -168,6 +169,6 @@ class PersistentEMRStepCountIT {
     }
 
     private Map<String, Integer> getStepCountByStatus(WireMockRuntimeInfo runtimeInfo) {
-        return PersistentEMRStepCount.byStatus(properties, wiremockEmrClient(runtimeInfo));
+        return PersistentEMRStepCount.byStatus(properties, wiremockEmrClient(runtimeInfo), StaticRateLimit.none());
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/teardown/ShutdownSystemProcessesIT.java
+++ b/java/clients/src/test/java/sleeper/clients/teardown/ShutdownSystemProcessesIT.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.emrserverless.model.ApplicationState;
 import software.amazon.awssdk.services.emrserverless.model.JobRunState;
 
 import sleeper.configuration.properties.instance.InstanceProperties;
+import sleeper.core.util.StaticRateLimit;
 
 import java.util.List;
 
@@ -94,7 +95,7 @@ class ShutdownSystemProcessesIT {
     @BeforeEach
     void setUp(WireMockRuntimeInfo runtimeInfo) {
         shutdown = new ShutdownSystemProcesses(wiremockCloudWatchClient(runtimeInfo), wiremockEcsClient(runtimeInfo),
-                wiremockEmrClient(runtimeInfo), wiremockEmrServerlessClient(runtimeInfo));
+                wiremockEmrClient(runtimeInfo), wiremockEmrServerlessClient(runtimeInfo), StaticRateLimit.none());
     }
 
     private void shutdown() throws Exception {

--- a/java/core/src/main/java/sleeper/core/util/RateLimitUtils.java
+++ b/java/core/src/main/java/sleeper/core/util/RateLimitUtils.java
@@ -18,6 +18,8 @@ package sleeper.core.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+
 /**
  * Utilities to avoid rate limits in a remote API.
  */
@@ -51,5 +53,15 @@ public class RateLimitUtils {
      */
     public static long calculateMillisSleepForSustainedRatePerSecond(double ratePerSecond) {
         return (long) Math.ceil(1000.0 / ratePerSecond);
+    }
+
+    /**
+     * Calculates how long to sleep in order to achieve the target rate per second.
+     *
+     * @param  ratePerSecond the target rate per second
+     * @return               the duration to sleep for
+     */
+    public static Duration calculateSleepForSustainedRatePerSecond(double ratePerSecond) {
+        return Duration.ofMillis(calculateMillisSleepForSustainedRatePerSecond(ratePerSecond));
     }
 }

--- a/java/core/src/main/java/sleeper/core/util/StaticRateLimit.java
+++ b/java/core/src/main/java/sleeper/core/util/StaticRateLimit.java
@@ -22,6 +22,7 @@ import java.util.function.Supplier;
 
 /**
  * Avoids a rate limit by tracking the last result for a request. Will only repeat the request within the rate limit.
+ * This can be used thread safely as a static constant.
  *
  * @param <T> the request result type
  */
@@ -56,6 +57,16 @@ public class StaticRateLimit<T> {
      */
     public static <T> StaticRateLimit<T> withWaitBetweenRequests(Duration waitBetweenRequests, Supplier<Instant> timeSupplier) {
         return new StaticRateLimit<>(waitBetweenRequests, timeSupplier);
+    }
+
+    /**
+     * Creates an instance of this class which will always make the request.
+     *
+     * @param  <T> the request result type
+     * @return     the new instance
+     */
+    public static <T> StaticRateLimit<T> none() {
+        return withWaitBetweenRequests(Duration.ZERO, () -> Instant.MIN);
     }
 
     /**

--- a/java/core/src/main/java/sleeper/core/util/StaticRateLimit.java
+++ b/java/core/src/main/java/sleeper/core/util/StaticRateLimit.java
@@ -69,7 +69,8 @@ public class StaticRateLimit<T> {
     }
 
     /**
-     * Makes the request if the expected amount of time has passed since the last request.
+     * Makes the request if the expected amount of time has passed since the last request. If a request is ongoing,
+     * wait for that first.
      *
      * @param  request the request
      * @return         the result, or the last result if the time has not passed

--- a/java/core/src/main/java/sleeper/core/util/StaticRateLimit.java
+++ b/java/core/src/main/java/sleeper/core/util/StaticRateLimit.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.util;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Avoids a rate limit by tracking the last result for a request. Will only repeat the request within the rate limit.
+ *
+ * @param <T> the request result type
+ */
+public class StaticRateLimit<T> {
+
+    private final Duration waitBetweenRequests;
+    private final AtomicReference<LastResult> lastResult = new AtomicReference<>();
+    private final Supplier<Instant> timeSupplier;
+
+    private StaticRateLimit(Duration waitBetweenRequests, Supplier<Instant> timeSupplier) {
+        this.waitBetweenRequests = waitBetweenRequests;
+        this.timeSupplier = timeSupplier;
+    }
+
+    /**
+     * Creates an instance of this class to operate at the given maximum rate per second.
+     *
+     * @param  <T>           the request result type
+     * @param  ratePerSecond the number of requests per second to stay below
+     * @return               the new instance
+     */
+    public static <T> StaticRateLimit<T> forMaximumRatePerSecond(double ratePerSecond) {
+        return withWaitBetweenRequests(RateLimitUtils.calculateSleepForSustainedRatePerSecond(ratePerSecond), Instant::now);
+    }
+
+    /**
+     * Creates an instance of this class to wait for the given time between requests.
+     *
+     * @param  <T>                 the request result type
+     * @param  waitBetweenRequests the time to wait for between requests
+     * @return                     the new instance
+     */
+    public static <T> StaticRateLimit<T> withWaitBetweenRequests(Duration waitBetweenRequests, Supplier<Instant> timeSupplier) {
+        return new StaticRateLimit<>(waitBetweenRequests, timeSupplier);
+    }
+
+    /**
+     * Makes the request if the expected amount of time has passed since the last request.
+     *
+     * @param  request the request
+     * @return         the result, or the last result if the time has not passed
+     */
+    public T requestOrGetLast(Supplier<T> request) {
+        return lastResult.updateAndGet(last -> {
+            if (last == null || last.isRequestAgainAt(timeSupplier.get())) {
+                return new LastResult(request.get(), timeSupplier.get());
+            } else {
+                return last;
+            }
+        }).result;
+    }
+
+    /**
+     * Tracks the last result of the request.
+     */
+    private class LastResult {
+
+        private final T result;
+        private final Instant resultTime;
+
+        LastResult(T result, Instant resultTime) {
+            this.result = result;
+            this.resultTime = resultTime;
+        }
+
+        boolean isRequestAgainAt(Instant timeNow) {
+            return Duration.between(resultTime, timeNow).compareTo(waitBetweenRequests) >= 0;
+        }
+
+    }
+
+}

--- a/java/core/src/test/java/sleeper/core/util/StaticRateLimitTest.java
+++ b/java/core/src/test/java/sleeper/core/util/StaticRateLimitTest.java
@@ -30,12 +30,12 @@ public class StaticRateLimitTest {
     @Test
     void shouldRequestOnce() {
         // Given
-        AtomicInteger integer = new AtomicInteger();
+        AtomicInteger count = new AtomicInteger();
         Iterator<Instant> times = List.of(Instant.parse("2024-09-11T10:41:00Z")).iterator(); // Result time
         StaticRateLimit<Integer> limit = StaticRateLimit.withWaitBetweenRequests(Duration.ofSeconds(1), times::next);
 
         // When
-        Integer result = limit.requestOrGetLast(integer::incrementAndGet);
+        Integer result = limit.requestOrGetLast(count::incrementAndGet);
 
         // Then
         assertThat(result).isOne();
@@ -45,7 +45,7 @@ public class StaticRateLimitTest {
     @Test
     void shouldRequestTwiceWithExpectedWait() {
         // Given
-        AtomicInteger integer = new AtomicInteger();
+        AtomicInteger count = new AtomicInteger();
         Iterator<Instant> times = List.of(
                 Instant.parse("2024-09-11T10:41:00Z"), // First result time
                 Instant.parse("2024-09-11T10:41:01Z"), // Second check time
@@ -54,8 +54,8 @@ public class StaticRateLimitTest {
         StaticRateLimit<Integer> limit = StaticRateLimit.withWaitBetweenRequests(Duration.ofSeconds(1), times::next);
 
         // When
-        limit.requestOrGetLast(integer::incrementAndGet);
-        Integer result = limit.requestOrGetLast(integer::incrementAndGet);
+        limit.requestOrGetLast(count::incrementAndGet);
+        Integer result = limit.requestOrGetLast(count::incrementAndGet);
 
         // Then
         assertThat(result).isEqualTo(2);
@@ -65,7 +65,7 @@ public class StaticRateLimitTest {
     @Test
     void shouldRequestOnceWhenRepeatedWithinWaitTime() {
         // Given
-        AtomicInteger integer = new AtomicInteger();
+        AtomicInteger count = new AtomicInteger();
         Iterator<Instant> times = List.of(
                 Instant.parse("2024-09-11T10:41:00Z"), // First result time
                 Instant.parse("2024-09-11T10:41:00.900Z")) // Second check time
@@ -73,8 +73,8 @@ public class StaticRateLimitTest {
         StaticRateLimit<Integer> limit = StaticRateLimit.withWaitBetweenRequests(Duration.ofSeconds(1), times::next);
 
         // When
-        limit.requestOrGetLast(integer::incrementAndGet);
-        Integer result = limit.requestOrGetLast(integer::incrementAndGet);
+        limit.requestOrGetLast(count::incrementAndGet);
+        Integer result = limit.requestOrGetLast(count::incrementAndGet);
 
         // Then
         assertThat(result).isEqualTo(1);

--- a/java/core/src/test/java/sleeper/core/util/StaticRateLimitTest.java
+++ b/java/core/src/test/java/sleeper/core/util/StaticRateLimitTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StaticRateLimitTest {
+
+    @Test
+    void shouldRequestOnce() {
+        // Given
+        AtomicInteger integer = new AtomicInteger();
+        Iterator<Instant> times = List.of(Instant.parse("2024-09-11T10:41:00Z")).iterator(); // Result time
+        StaticRateLimit<Integer> limit = StaticRateLimit.withWaitBetweenRequests(Duration.ofSeconds(1), times::next);
+
+        // When
+        Integer result = limit.requestOrGetLast(integer::incrementAndGet);
+
+        // Then
+        assertThat(result).isOne();
+        assertThat(times).isExhausted();
+    }
+
+    @Test
+    void shouldRequestTwiceWithExpectedWait() {
+        // Given
+        AtomicInteger integer = new AtomicInteger();
+        Iterator<Instant> times = List.of(
+                Instant.parse("2024-09-11T10:41:00Z"), // First result time
+                Instant.parse("2024-09-11T10:41:01Z"), // Second check time
+                Instant.parse("2024-09-11T10:41:02Z")) // Second result time
+                .iterator();
+        StaticRateLimit<Integer> limit = StaticRateLimit.withWaitBetweenRequests(Duration.ofSeconds(1), times::next);
+
+        // When
+        limit.requestOrGetLast(integer::incrementAndGet);
+        Integer result = limit.requestOrGetLast(integer::incrementAndGet);
+
+        // Then
+        assertThat(result).isEqualTo(2);
+        assertThat(times).isExhausted();
+    }
+
+    @Test
+    void shouldRequestOnceWhenRepeatedWithinWaitTime() {
+        // Given
+        AtomicInteger integer = new AtomicInteger();
+        Iterator<Instant> times = List.of(
+                Instant.parse("2024-09-11T10:41:00Z"), // First result time
+                Instant.parse("2024-09-11T10:41:00.900Z")) // Second check time
+                .iterator();
+        StaticRateLimit<Integer> limit = StaticRateLimit.withWaitBetweenRequests(Duration.ofSeconds(1), times::next);
+
+        // When
+        limit.requestOrGetLast(integer::incrementAndGet);
+        Integer result = limit.requestOrGetLast(integer::incrementAndGet);
+
+        // Then
+        assertThat(result).isEqualTo(1);
+        assertThat(times).isExhausted();
+    }
+
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3247

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - StaticRateLimitTest
    - Tested tear down script manually

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.