### PR TITLE
Default Reserved/max concurrency for lambdas scaling across sleeper tables

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1350,3 +1350,18 @@ sleeper.default.statestore.committer.update.every.commit=false
 # When using the transaction log state store, this sets whether to update from the transaction log
 # before adding a batch of transactions in the asynchronous state store committer.
 sleeper.default.statestore.committer.update.every.batch=true
+
+# Default value for the concurrency assigned to the lambdas across the entire of the sleeper instance.
+# Each lambda also has its own implementation of the property which will override the value found
+# here.
+#  Default to value of 1.
+# See reserved concurrency overview at:
+# https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
+sleeper.default.lambda.concurrency.reserved=1
+
+# Default value for the maximum concurrency assigned to the lambdas across the entire of the sleeper
+# instance. Each lambda has its own property that overrides the value found here.
+#  Default value is set to 1000
+# See maximum concurrency overview at:
+# https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/
+sleeper.default.lambda.concurrency.max=1000

--- a/java/configuration/src/main/java/sleeper/configuration/Utils.java
+++ b/java/configuration/src/main/java/sleeper/configuration/Utils.java
@@ -62,6 +62,10 @@ public class Utils {
         return parseAndCheckInteger(integer, num -> num > 0 && num <= 15);
     }
 
+    public static boolean isPositiveIntegerLtEq1000(String integer) {
+        return parseAndCheckInteger(integer, num -> num > 0 && num <= 1000);
+    }
+
     public static boolean isNonNegativeInteger(String integer) {
         return parseAndCheckInteger(integer, num -> num >= 0);
     }

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CdkDefinedInstancePropertyImpl.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CdkDefinedInstancePropertyImpl.java
@@ -19,6 +19,7 @@ package sleeper.configuration.properties.instance;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import sleeper.configuration.properties.PropertyGroup;
+import sleeper.configuration.properties.SleeperProperty;
 
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -28,11 +29,13 @@ class CdkDefinedInstancePropertyImpl implements CdkDefinedInstanceProperty {
     private final String propertyName;
     private final String description;
     private final PropertyGroup group;
+    private final SleeperProperty defaultProperty;
 
     private CdkDefinedInstancePropertyImpl(Builder builder) {
         propertyName = Objects.requireNonNull(builder.propertyName, "propertyName must not be null");
         description = Objects.requireNonNull(builder.description, "description must not be null");
         group = Objects.requireNonNull(builder.group, "group must not be null");
+        defaultProperty = builder.defaultProperty;
     }
 
     public static Builder builder() {
@@ -51,6 +54,11 @@ class CdkDefinedInstancePropertyImpl implements CdkDefinedInstanceProperty {
     @Override
     public String getDefaultValue() {
         return null;
+    }
+
+    @Override
+    public SleeperProperty getDefaultProperty() {
+        return defaultProperty;
     }
 
     public String toString() {
@@ -77,6 +85,7 @@ class CdkDefinedInstancePropertyImpl implements CdkDefinedInstanceProperty {
         private String description;
         private PropertyGroup group;
         private Consumer<CdkDefinedInstanceProperty> addToIndex;
+        private SleeperProperty defaultProperty;
 
         private Builder() {
         }
@@ -93,6 +102,11 @@ class CdkDefinedInstancePropertyImpl implements CdkDefinedInstanceProperty {
 
         public Builder propertyGroup(PropertyGroup group) {
             this.group = group;
+            return this;
+        }
+
+        public Builder defaultProperty(SleeperProperty property) {
+            this.defaultProperty = property;
             return this;
         }
 

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CommonProperty.java
@@ -22,6 +22,9 @@ import sleeper.configuration.properties.SleeperPropertyIndex;
 import java.util.List;
 import java.util.Objects;
 
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM;
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_LAMBDA_CONCURRENCY_RESERVED;
+
 public interface CommonProperty {
     int ID_MAX_LENGTH = 20;
     UserDefinedInstanceProperty ID = Index.propertyBuilder("sleeper.id")
@@ -157,11 +160,13 @@ public interface CommonProperty {
             .propertyGroup(InstancePropertyGroup.COMMON)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty METRICS_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.metrics.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_RESERVED)
             .description("The reserved concurrency for the table metrics lambda.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.COMMON).build();
     UserDefinedInstanceProperty METRICS_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.metrics.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the table metrics lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
@@ -225,11 +230,13 @@ public interface CommonProperty {
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
     UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.creation.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_RESERVED)
             .description("The reserved concurrency for the snapshot creation lambda.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.COMMON).build();
     UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_CREATION_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.creation.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the snapshot creation lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
@@ -248,11 +255,13 @@ public interface CommonProperty {
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
     UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.deletion.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_RESERVED)
             .description("The reserved concurrency for the snapshot deletion lambda.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.COMMON).build();
     UserDefinedInstanceProperty TRANSACTION_LOG_SNAPSHOT_DELETION_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.statestore.transactionlog.snapshot.deletion.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the snapshot deletion lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
@@ -271,11 +280,13 @@ public interface CommonProperty {
             .propertyGroup(InstancePropertyGroup.COMMON)
             .build();
     UserDefinedInstanceProperty TRANSACTION_LOG_TRANSACTION_DELETION_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.statestore.transactionlog.transaction.deletion.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_RESERVED)
             .description("The reserved concurrency for the transaction deletion lambda.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.COMMON).build();
     UserDefinedInstanceProperty TRANSACTION_LOG_TRANSACTION_DELETION_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.statestore.transactionlog.transaction.deletion.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the transaction deletion lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
@@ -333,11 +344,13 @@ public interface CommonProperty {
             .validationPredicate(Utils::isPositiveIntegerLtEq10)
             .propertyGroup(InstancePropertyGroup.COMMON).build();
     UserDefinedInstanceProperty STATESTORE_COMMITTER_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.statestore.committer.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_RESERVED)
             .description("The reserved concurrency for the state store committer lambda.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.COMMON).build();
     UserDefinedInstanceProperty STATESTORE_COMMITTER_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.statestore.committer.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the state store committer lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/CompactionProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/CompactionProperty.java
@@ -24,6 +24,8 @@ import sleeper.configuration.properties.validation.CompactionMethod;
 import java.util.List;
 
 import static sleeper.configuration.Utils.describeEnumValuesInLowerCase;
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM;
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_LAMBDA_CONCURRENCY_RESERVED;
 
 public interface CompactionProperty {
     UserDefinedInstanceProperty ECR_COMPACTION_REPO = Index.propertyBuilder("sleeper.compaction.repo")
@@ -116,11 +118,13 @@ public interface CompactionProperty {
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_JOB_CREATION_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.compaction.job.creation.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_RESERVED)
             .description("The reserved concurrency for the lambda used to create compaction jobs.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.COMPACTION).build();
     UserDefinedInstanceProperty COMPACTION_JOB_CREATION_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.compaction.job.creation.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the lambda used to create compaction jobs.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/DefaultProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/DefaultProperty.java
@@ -334,6 +334,20 @@ public interface DefaultProperty {
             .defaultValue("true")
             .validationPredicate(Utils::isTrueOrFalse)
             .propertyGroup(InstancePropertyGroup.DEFAULT).build();
+    UserDefinedInstanceProperty DEFAULT_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.default.lambda.concurrency.reserved")
+            .description("Default value for the concurrency assigned to the lambdas across the entire of the sleeper instance. Each lambda also has its own " +
+                    "implementation of the property which will override the value found here.\n Default to value of 1.\n" +
+                    "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
+            .defaultValue("1")
+            .validationPredicate(Utils::isPositiveInteger)
+            .propertyGroup(InstancePropertyGroup.DEFAULT).build();
+    UserDefinedInstanceProperty DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.default.lambda.concurrency.max")
+            .description("Default value for the maximum concurrency assigned to the lambdas across the entire of the sleeper instance. Each lambda " +
+                    "has its own property that overrides the value found here.\n Default value is set to 1000\n" +
+                    "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
+            .defaultValue("1000")
+            .validationPredicate(Utils::isPositiveIntegerLtEq1000)
+            .propertyGroup(InstancePropertyGroup.DEFAULT).build();
 
     static List<UserDefinedInstanceProperty> getAll() {
         return Index.INSTANCE.getAll();

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/GarbageCollectionProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/GarbageCollectionProperty.java
@@ -21,6 +21,8 @@ import sleeper.configuration.properties.SleeperPropertyIndex;
 
 import java.util.List;
 
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM;
+
 public interface GarbageCollectionProperty {
     UserDefinedInstanceProperty GARBAGE_COLLECTOR_PERIOD_IN_MINUTES = Index.propertyBuilder("sleeper.gc.period.minutes")
             .description("The frequency in minutes with which the garbage collector lambda is run.")
@@ -39,11 +41,13 @@ public interface GarbageCollectionProperty {
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty GARBAGE_COLLECTOR_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.gc.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The reserved concurrency for the garbage collection lambda.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
     UserDefinedInstanceProperty GARBAGE_COLLECTOR_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.gc.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the garbage collection lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/InstanceProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/InstanceProperty.java
@@ -35,6 +35,8 @@ public interface InstanceProperty extends SleeperProperty {
         return Index.INSTANCE.getByName(propertyName);
     }
 
+    SleeperProperty getDefaultProperty();
+
     class Index {
         private Index() {
         }

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/PartitionSplittingProperty.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/PartitionSplittingProperty.java
@@ -21,6 +21,9 @@ import sleeper.configuration.properties.SleeperPropertyIndex;
 
 import java.util.List;
 
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM;
+import static sleeper.configuration.properties.instance.DefaultProperty.DEFAULT_LAMBDA_CONCURRENCY_RESERVED;
+
 public interface PartitionSplittingProperty {
     UserDefinedInstanceProperty PARTITION_SPLITTING_TRIGGER_PERIOD_IN_MINUTES = Index.propertyBuilder("sleeper.partition.splitting.period.minutes")
             .description("The frequency in minutes with which the lambda runs to find partitions that need splitting " +
@@ -52,11 +55,13 @@ public interface PartitionSplittingProperty {
             .propertyGroup(InstancePropertyGroup.PARTITION_SPLITTING)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty FIND_PARTITIONS_TO_SPLIT_LAMBDA_CONCURRENCY_RESERVED = Index.propertyBuilder("sleeper.partition.splitting.finder.concurrency.reserved")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_RESERVED)
             .description("The reserved concurrency for the find partitions to split lambda.\n" +
                     "See reserved concurrency overview at: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html")
             .validationPredicate(Utils::isPositiveIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.PARTITION_SPLITTING).build();
     UserDefinedInstanceProperty FIND_PARTITIONS_TO_SPLIT_LAMBDA_CONCURRENCY_MAXIMUM = Index.propertyBuilder("sleeper.partition.splitting.finder.concurrency.max")
+            .defafultProperty(DEFAULT_LAMBDA_CONCURRENCY_MAXIMUM)
             .description("The maximum given concurrency allowed for the find partitions to split lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .validationPredicate(Utils::isPositiveIntegerOrNull)

--- a/java/configuration/src/main/java/sleeper/configuration/properties/instance/UserDefinedInstancePropertyImpl.java
+++ b/java/configuration/src/main/java/sleeper/configuration/properties/instance/UserDefinedInstancePropertyImpl.java
@@ -19,6 +19,7 @@ package sleeper.configuration.properties.instance;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import sleeper.configuration.properties.PropertyGroup;
+import sleeper.configuration.properties.SleeperProperty;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -36,6 +37,7 @@ class UserDefinedInstancePropertyImpl implements UserDefinedInstanceProperty {
     private final boolean includedInTemplate;
     private final boolean includedInBasicTemplate;
     private final boolean ignoreEmptyValue;
+    private final SleeperProperty defaultProperty;
 
     private UserDefinedInstancePropertyImpl(Builder builder) {
         propertyName = Objects.requireNonNull(builder.propertyName, "propertyName must not be null");
@@ -49,6 +51,7 @@ class UserDefinedInstancePropertyImpl implements UserDefinedInstanceProperty {
         includedInBasicTemplate = Optional.ofNullable(builder.includedInBasicTemplate)
                 .orElseGet(UserDefinedInstanceProperty.super::isIncludedInBasicTemplate);
         ignoreEmptyValue = builder.ignoreEmptyValue;
+        defaultProperty = builder.defaultProperty;
     }
 
     public static Builder builder() {
@@ -113,6 +116,11 @@ class UserDefinedInstancePropertyImpl implements UserDefinedInstanceProperty {
         return ignoreEmptyValue;
     }
 
+    @Override
+    public SleeperProperty getDefaultProperty() {
+        return defaultProperty;
+    }
+
     static final class Builder {
         private String propertyName;
         private String defaultValue;
@@ -125,6 +133,7 @@ class UserDefinedInstancePropertyImpl implements UserDefinedInstanceProperty {
         private Boolean includedInBasicTemplate;
         private boolean ignoreEmptyValue = true;
         private Consumer<UserDefinedInstanceProperty> addToIndex;
+        private SleeperProperty defaultProperty;
 
         private Builder() {
         }
@@ -151,6 +160,11 @@ class UserDefinedInstancePropertyImpl implements UserDefinedInstanceProperty {
 
         public Builder propertyGroup(PropertyGroup propertyGroup) {
             this.propertyGroup = propertyGroup;
+            return this;
+        }
+
+        public Builder defafultProperty(SleeperProperty property) {
+            this.defaultProperty = property;
             return this;
         }
 

--- a/java/configuration/src/test/java/sleeper/configuration/properties/DummyInstanceProperty.java
+++ b/java/configuration/src/test/java/sleeper/configuration/properties/DummyInstanceProperty.java
@@ -21,9 +21,11 @@ import sleeper.configuration.properties.instance.InstancePropertyGroup;
 
 public class DummyInstanceProperty implements InstanceProperty {
     private final String propertyName;
+    private final SleeperProperty defaultProperty;
 
     public DummyInstanceProperty(String propertyName) {
         this.propertyName = propertyName;
+        this.defaultProperty = null;
     }
 
     @Override
@@ -49,5 +51,10 @@ public class DummyInstanceProperty implements InstanceProperty {
     @Override
     public boolean isRunCdkDeployWhenChanged() {
         return false;
+    }
+
+    @Override
+    public SleeperProperty getDefaultProperty() {
+        return this.defaultProperty;
     }
 }

--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestPropertyImpl.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestPropertyImpl.java
@@ -19,6 +19,7 @@ package sleeper.systemtest.configuration;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import sleeper.configuration.properties.PropertyGroup;
+import sleeper.configuration.properties.SleeperProperty;
 import sleeper.configuration.properties.instance.InstancePropertyGroup;
 
 import java.util.Objects;
@@ -33,6 +34,7 @@ public class SystemTestPropertyImpl implements SystemTestProperty {
     private final boolean runCdkDeployWhenChanged;
     private final boolean setByCdk;
     private final boolean editable;
+    private final SleeperProperty defaultProperty;
 
     private SystemTestPropertyImpl(Builder builder) {
         propertyName = Objects.requireNonNull(builder.propertyName, "propertyName must not be null");
@@ -42,6 +44,7 @@ public class SystemTestPropertyImpl implements SystemTestProperty {
         runCdkDeployWhenChanged = builder.runCdkDeployWhenChanged;
         setByCdk = builder.setByCdk;
         editable = builder.editable;
+        defaultProperty = builder.defaultProperty;
     }
 
     public static Builder builder() {
@@ -78,6 +81,11 @@ public class SystemTestPropertyImpl implements SystemTestProperty {
     }
 
     @Override
+    public SleeperProperty getDefaultProperty() {
+        return defaultProperty;
+    }
+
+    @Override
     public boolean isRunCdkDeployWhenChanged() {
         return runCdkDeployWhenChanged;
     }
@@ -105,6 +113,7 @@ public class SystemTestPropertyImpl implements SystemTestProperty {
         private boolean setByCdk;
         private boolean editable;
         private Consumer<SystemTestProperty> addToIndex;
+        private SleeperProperty defaultProperty;
 
         private Builder() {
         }
@@ -126,6 +135,11 @@ public class SystemTestPropertyImpl implements SystemTestProperty {
 
         public Builder description(String description) {
             this.description = description;
+            return this;
+        }
+
+        public Builder defaBuilder(SleeperProperty property) {
+            this.defaultProperty = property;
             return this;
         }
 

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1374,3 +1374,18 @@ sleeper.default.statestore.committer.update.every.commit=false
 # When using the transaction log state store, this sets whether to update from the transaction log
 # before adding a batch of transactions in the asynchronous state store committer.
 sleeper.default.statestore.committer.update.every.batch=true
+
+# Default value for the concurrency assigned to the lambdas across the entire of the sleeper instance.
+# Each lambda also has its own implementation of the property which will override the value found
+# here.
+#  Default to value of 1.
+# See reserved concurrency overview at:
+# https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
+sleeper.default.lambda.concurrency.reserved=1
+
+# Default value for the maximum concurrency assigned to the lambdas across the entire of the sleeper
+# instance. Each lambda has its own property that overrides the value found here.
+#  Default value is set to 1000
+# See maximum concurrency overview at:
+# https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/
+sleeper.default.lambda.concurrency.max=1000


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3195

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Exisiting build executed

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.