### PR TITLE
Issue 3310 - Suppress vulnerability in WireMock dependency

### DIFF
--- a/code-style/dependency-check-suppressions.xml
+++ b/code-style/dependency-check-suppressions.xml
@@ -275,4 +275,13 @@
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty-servlets@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-36479</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        DOMPurify is only used by WireMock, which is only used for tests. We're not able to upgrade to a later version
+        of WireMock that doesn't use this. Later versions of WireMock use Jetty 11 or 12, and the version of Hadoop
+        we're using uses Jetty 9.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-45801</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3310

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Just dependency check suppression

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.