### PR TITLE
Issue 3312 - Increase timeout for slow compaction performance test

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceST.java
@@ -62,7 +62,7 @@ public class CompactionPerformanceST {
                 .waitForTotalFileReferences(110);
 
         sleeper.compaction().createJobs(10).invokeTasks(10)
-                .waitForJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofMinutes(40)));
+                .waitForJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofHours(1)));
 
         assertThat(sleeper.tableFiles().references())
                 .hasSize(10)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3312

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated CompactionPerformanceST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.