### PR TITLE
Issue 3396 - Handle failures waiting for compaction input files to be assigned

### DIFF
--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/task/StateStoreWaitForFiles.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/task/StateStoreWaitForFiles.java
@@ -19,12 +19,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import sleeper.compaction.job.CompactionJob;
+import sleeper.compaction.job.CompactionJobStatusStore;
 import sleeper.core.properties.table.TableProperties;
 import sleeper.core.properties.table.TablePropertiesProvider;
+import sleeper.core.record.process.ProcessRunTime;
 import sleeper.core.statestore.FileReference;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
 import sleeper.core.statestore.StateStoreProvider;
+import sleeper.core.statestore.UncheckedStateStoreException;
+import sleeper.core.statestore.exception.FileReferenceAssignedToJobException;
+import sleeper.core.statestore.exception.FileReferenceNotFoundException;
 import sleeper.core.util.ExponentialBackoffWithJitter;
 import sleeper.core.util.ExponentialBackoffWithJitter.WaitRange;
 import sleeper.core.util.LoggedDuration;
@@ -34,7 +39,14 @@ import sleeper.dynamodb.tools.DynamoDBUtils;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static java.util.stream.Collectors.toMap;
+import static sleeper.compaction.job.status.CompactionJobFailedEvent.compactionJobFailed;
+import static sleeper.compaction.job.status.CompactionJobStartedEvent.compactionJobStarted;
 
 public class StateStoreWaitForFiles {
 
@@ -49,25 +61,36 @@ public class StateStoreWaitForFiles {
     private final PollWithRetries throttlingRetriesConfig;
     private final TablePropertiesProvider tablePropertiesProvider;
     private final StateStoreProvider stateStoreProvider;
+    private final CompactionJobStatusStore jobStatusStore;
+    private final Supplier<Instant> timeSupplier;
 
-    public StateStoreWaitForFiles(TablePropertiesProvider tablePropertiesProvider, StateStoreProvider stateStoreProvider) {
+    public StateStoreWaitForFiles(
+            TablePropertiesProvider tablePropertiesProvider,
+            StateStoreProvider stateStoreProvider,
+            CompactionJobStatusStore jobStatusStore) {
         this(JOB_ASSIGNMENT_WAIT_ATTEMPTS, new ExponentialBackoffWithJitter(JOB_ASSIGNMENT_WAIT_RANGE),
-                JOB_ASSIGNMENT_THROTTLING_RETRIES, tablePropertiesProvider, stateStoreProvider);
+                JOB_ASSIGNMENT_THROTTLING_RETRIES, tablePropertiesProvider, stateStoreProvider, jobStatusStore, Instant::now);
     }
 
     public StateStoreWaitForFiles(
-            int jobAssignmentWaitAttempts, ExponentialBackoffWithJitter jobAssignmentWaitBackoff,
+            int jobAssignmentWaitAttempts,
+            ExponentialBackoffWithJitter jobAssignmentWaitBackoff,
             PollWithRetries throttlingRetriesConfig,
-            TablePropertiesProvider tablePropertiesProvider, StateStoreProvider stateStoreProvider) {
+            TablePropertiesProvider tablePropertiesProvider,
+            StateStoreProvider stateStoreProvider,
+            CompactionJobStatusStore jobStatusStore,
+            Supplier<Instant> timeSupplier) {
         this.jobAssignmentWaitAttempts = jobAssignmentWaitAttempts;
         this.jobAssignmentWaitBackoff = jobAssignmentWaitBackoff;
         this.throttlingRetriesConfig = throttlingRetriesConfig;
         this.tablePropertiesProvider = tablePropertiesProvider;
         this.stateStoreProvider = stateStoreProvider;
+        this.jobStatusStore = jobStatusStore;
+        this.timeSupplier = timeSupplier;
     }
 
-    public void wait(CompactionJob job) throws InterruptedException {
-        Instant startTime = Instant.now();
+    public void wait(CompactionJob job, String taskId, String jobRunId) throws StateStoreException, InterruptedException {
+        Instant startTime = timeSupplier.get();
         TableProperties tableProperties = tablePropertiesProvider.getById(job.getTableId());
         LOGGER.info("Waiting for {} file{} to be assigned to compaction job {} for table {}",
                 job.getInputFiles().size(), job.getInputFiles().size() > 1 ? "s" : "", job.getId(), tableProperties.getStatus());
@@ -78,33 +101,64 @@ public class StateStoreWaitForFiles {
                 .build();
         for (int attempt = 1; attempt <= jobAssignmentWaitAttempts; attempt++) {
             jobAssignmentWaitBackoff.waitBeforeAttempt(attempt);
-            if (allFilesAssignedToJob(throttlingRetries, stateStore, job)) {
+            if (allFilesAssignedToJob(throttlingRetries, stateStore, job, taskId, jobRunId, startTime)) {
                 LOGGER.info("All files are assigned to job. Checked {} time{} and took {}",
                         attempt, attempt > 1 ? "s" : "", LoggedDuration.withFullOutput(startTime, Instant.now()));
                 return;
             }
         }
         LOGGER.info("Reached maximum attempts of {} for checking if files are assigned to job", jobAssignmentWaitAttempts);
-        throw new TimedOutWaitingForFileAssignmentsException();
+        TimedOutWaitingForFileAssignmentsException e = new TimedOutWaitingForFileAssignmentsException();
+        reportFailure(job, taskId, jobRunId, startTime, e);
+        throw e;
     }
 
-    private boolean allFilesAssignedToJob(PollWithRetries throttlingRetries, StateStore stateStore, CompactionJob job) throws InterruptedException {
+    private boolean allFilesAssignedToJob(
+            PollWithRetries throttlingRetries, StateStore stateStore, CompactionJob job,
+            String taskId, String jobRunId, Instant startTime) throws StateStoreException, InterruptedException {
         AtomicReference<List<FileReference>> files = new AtomicReference<>();
-        DynamoDBUtils.retryOnThrottlingException(throttlingRetries, () -> {
-            try {
-                files.set(stateStore.getFileReferences());
-            } catch (StateStoreException e) {
-                throw new RuntimeException(e);
-            }
-        });
-        return files.get().stream()
-                .filter(file -> isInputFileForJob(file, job))
-                .allMatch(file -> job.getId().equals(file.getJobId()));
+        try {
+            DynamoDBUtils.retryOnThrottlingException(throttlingRetries, () -> {
+                try {
+                    files.set(stateStore.getFileReferences());
+                } catch (StateStoreException e) {
+                    throw new UncheckedStateStoreException(e);
+                }
+            });
+            return isPartitionFilesAssignedToJob(files.get(), job.getPartitionId(), job.getInputFiles(), job.getId());
+        } catch (UncheckedStateStoreException e) {
+            reportFailure(job, taskId, jobRunId, startTime, e.getStateStoreException());
+            throw e.getStateStoreException();
+        } catch (StateStoreException | RuntimeException e) {
+            reportFailure(job, taskId, jobRunId, startTime, e);
+            throw e;
+        }
     }
 
-    private static boolean isInputFileForJob(FileReference file, CompactionJob job) {
-        return job.getInputFiles().contains(file.getFilename()) &&
-                job.getPartitionId().equals(file.getPartitionId());
+    private static boolean isPartitionFilesAssignedToJob(List<FileReference> fileReferences, String partitionId, List<String> filenames, String jobId) throws StateStoreException {
+        Map<String, FileReference> partitionFileByName = fileReferences.stream()
+                .filter(reference -> Objects.equals(partitionId, reference.getPartitionId()))
+                .collect(toMap(FileReference::getFilename, f -> f));
+        boolean allAssigned = true;
+        for (String filename : filenames) {
+            FileReference reference = partitionFileByName.get(filename);
+            if (reference == null) {
+                throw new FileReferenceNotFoundException(filename, partitionId);
+            } else if (reference.getJobId() == null) {
+                allAssigned = false;
+            } else if (!reference.getJobId().equals(jobId)) {
+                throw new FileReferenceAssignedToJobException(reference);
+            }
+        }
+        return allAssigned;
+    }
+
+    private void reportFailure(CompactionJob job, String taskId, String jobRunId, Instant startTime, Exception e) {
+        Instant finishTime = timeSupplier.get();
+        jobStatusStore.jobStarted(compactionJobStarted(job, startTime).taskId(taskId).jobRunId(jobRunId).build());
+        jobStatusStore.jobFailed(compactionJobFailed(job,
+                new ProcessRunTime(startTime, finishTime))
+                .failure(e).taskId(taskId).jobRunId(jobRunId).build());
     }
 
 }

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskCommitTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskCommitTest.java
@@ -313,7 +313,7 @@ public class CompactionTaskCommitTest extends CompactionTaskTestBase {
         }
 
         @Test
-        void shouldFailWhenFileDoesNotExistInStateStore() throws Exception {
+        void shouldFailWhenFileDeletedDuringJob() throws Exception {
             // Given
             Instant startTime = Instant.parse("2024-02-22T13:50:01Z");
             Instant finishTime = Instant.parse("2024-02-22T13:50:02Z");

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskCommitTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskCommitTest.java
@@ -322,11 +322,13 @@ public class CompactionTaskCommitTest extends CompactionTaskTestBase {
                     Instant.parse("2024-02-22T13:50:00Z"), // Start
                     startTime, finishTime, failTime,
                     Instant.parse("2024-02-22T13:50:04Z"))); // Finish
-            CompactionJob job = createJobNotInStateStore("test-job");
+            CompactionJob job = createJob("test-job");
             send(job);
 
             // When
-            runTask("test-task", processJobs(jobSucceeds()), timesInTask::poll);
+            runTask("test-task", processJobs(jobSucceeds().withAction(() -> {
+                stateStore.clearFileData();
+            })), timesInTask::poll);
 
             // Then
             assertThat(stateStore.getFileReferences()).isEmpty();

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
@@ -26,7 +26,6 @@ import sleeper.compaction.task.CompactionTask.MessageReceiver;
 import sleeper.compaction.testutils.InMemoryCompactionJobStatusStore;
 import sleeper.compaction.testutils.InMemoryCompactionTaskStatusStore;
 import sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper;
-import sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper.WaitAction;
 import sleeper.core.properties.PropertiesReloader;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.table.TableProperties;
@@ -39,6 +38,7 @@ import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreProvider;
 import sleeper.core.statestore.testutils.FixedStateStoreProvider;
 import sleeper.core.util.ExponentialBackoffWithJitter.Waiter;
+import sleeper.core.util.ExponentialBackoffWithJitterTestHelper.WaitAction;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -66,6 +66,7 @@ import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
 import static sleeper.core.statestore.AssignJobIdRequest.assignJobOnPartitionToFiles;
 import static sleeper.core.statestore.testutils.StateStoreTestHelper.inMemoryStateStoreWithSinglePartition;
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.recordWaits;
+import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.withActionAfterWait;
 
 public class CompactionTaskTestBase {
     protected static final String DEFAULT_TABLE_ID = "test-table-id";
@@ -231,7 +232,7 @@ public class CompactionTaskTestBase {
     }
 
     protected void actionAfterWaitForFileAssignment(WaitAction action) throws Exception {
-        waiterForFileAssignment = StateStoreWaitForFilesTestHelper.withActionAfterWait(waiterForFileAssignment, action);
+        waiterForFileAssignment = withActionAfterWait(waiterForFileAssignment, action);
     }
 
     private MessageReceiver pollQueue() {

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
@@ -114,15 +114,15 @@ public class CompactionTaskTestBase {
     }
 
     protected void runTask(CompactionRunner compactor, Supplier<Instant> timeSupplier) throws Exception {
-        runTask(pollQueue(), waitForFileAssignment(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
+        runTask(pollQueue(), noWaitForFileAssignment(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
     }
 
     protected void runTask(String taskId, CompactionRunner compactor, Supplier<Instant> timeSupplier) throws Exception {
-        runTask(pollQueue(), waitForFileAssignment(), compactor, timeSupplier, taskId, jobRunIdsInSequence());
+        runTask(pollQueue(), noWaitForFileAssignment(), compactor, timeSupplier, taskId, jobRunIdsInSequence());
     }
 
     protected void runTask(String taskId, CompactionRunner compactor, Supplier<String> jobRunIdSupplier, Supplier<Instant> timeSupplier) throws Exception {
-        runTask(pollQueue(), waitForFileAssignment(), compactor, timeSupplier, taskId, jobRunIdSupplier);
+        runTask(pollQueue(), noWaitForFileAssignment(), compactor, timeSupplier, taskId, jobRunIdSupplier);
     }
 
     protected void runTaskCheckingFiles(StateStoreWaitForFiles fileAssignmentCheck, CompactionRunner compactor) throws Exception {
@@ -133,7 +133,7 @@ public class CompactionTaskTestBase {
             MessageReceiver messageReceiver,
             CompactionRunner compactor,
             Supplier<Instant> timeSupplier) throws Exception {
-        runTask(messageReceiver, waitForFileAssignment(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
+        runTask(messageReceiver, noWaitForFileAssignment(), compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
     }
 
     private void runTask(
@@ -152,13 +152,16 @@ public class CompactionTaskTestBase {
                 .run();
     }
 
-    private StateStoreWaitForFiles waitForFileAssignment() {
-        return waitForFileAssignmentWithAttempts(1);
+    private StateStoreWaitForFiles noWaitForFileAssignment() {
+        return waitForFileAssignment().withAttempts(1);
     }
 
-    protected StateStoreWaitForFiles waitForFileAssignmentWithAttempts(int attempts) {
-        return StateStoreWaitForFilesTestHelper.waitForFileAssignmentWithAttempts(
-                attempts, waiterForFileAssignment, tablePropertiesProvider(), stateStoreProvider());
+    protected StateStoreWaitForFilesTestHelper waitForFileAssignment() {
+        return waitForFileAssignment(timePassesAMinuteAtATime());
+    }
+
+    protected StateStoreWaitForFilesTestHelper waitForFileAssignment(Supplier<Instant> timeSupplier) {
+        return new StateStoreWaitForFilesTestHelper(tablePropertiesProvider(), stateStoreProvider(), jobStore, waiterForFileAssignment, timeSupplier);
     }
 
     private TablePropertiesProvider tablePropertiesProvider() {

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
@@ -202,10 +202,6 @@ public class CompactionTaskTestBase {
         return job;
     }
 
-    protected CompactionJob createJobNotInStateStore(String jobId) throws Exception {
-        return createJobNotInStateStore(jobId, tableProperties);
-    }
-
     protected CompactionJob createJobNotInStateStore(String jobId, TableProperties tableProperties) throws Exception {
         CompactionJob job = CompactionJob.builder()
                 .tableId(tableProperties.get(TABLE_ID))

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/StateStoreWaitForFilesTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/StateStoreWaitForFilesTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.job.CompactionJobFactory;
+import sleeper.compaction.job.CompactionJobStatusStore;
+import sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper;
 import sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper.WaitAction;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.table.TableProperties;
@@ -36,6 +38,7 @@ import sleeper.core.statestore.testutils.InMemoryPartitionStore;
 import sleeper.core.util.ExponentialBackoffWithJitter.Waiter;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +48,6 @@ import static java.util.stream.Collectors.reducing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.compaction.task.StateStoreWaitForFiles.JOB_ASSIGNMENT_WAIT_ATTEMPTS;
-import static sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper.waitForFileAssignmentWithAttemptsAndThrottlingRetries;
 import static sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper.withActionAfterWait;
 import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
@@ -119,7 +121,7 @@ public class StateStoreWaitForFilesTest {
 
         // When / Then
         StateStoreWaitForFiles waiter = waiterWithAttempts(JOB_ASSIGNMENT_WAIT_ATTEMPTS);
-        assertThatThrownBy(() -> waiter.wait(job))
+        assertThatThrownBy(() -> waiter.wait(job, "test-task", "test-job-run"))
                 .isInstanceOf(TimedOutWaitingForFileAssignmentsException.class);
         assertThat(foundWaits).containsExactly(
                 Duration.parse("PT2.923S"),
@@ -145,7 +147,7 @@ public class StateStoreWaitForFilesTest {
         // When / Then
         StateStoreWaitForFiles waiter = waiterWithAttempts(
                 JOB_ASSIGNMENT_WAIT_ATTEMPTS, constantJitterFraction(0.5));
-        assertThatThrownBy(() -> waiter.wait(job))
+        assertThatThrownBy(() -> waiter.wait(job, "test-task", "test-job-run"))
                 .isInstanceOf(TimedOutWaitingForFileAssignmentsException.class);
         assertThat(foundWaits).containsExactly(
                 Duration.ofSeconds(2),
@@ -178,7 +180,7 @@ public class StateStoreWaitForFilesTest {
                 Optional.empty()));
 
         // When
-        waiterWithAttempts(1).wait(job);
+        waiterWithAttempts(1).wait(job, "test-task", "test-job-run");
 
         // Then
         assertThat(foundWaits).containsExactly(
@@ -196,7 +198,7 @@ public class StateStoreWaitForFilesTest {
     }
 
     private void waitForFilesWithAttempts(int attempts, CompactionJob job) throws Exception {
-        waiterWithAttempts(attempts).wait(job);
+        waiterWithAttempts(attempts).wait(job, "test-task", "test-job-run");
     }
 
     private StateStoreWaitForFiles waiterWithAttempts(int attempts) {
@@ -204,10 +206,11 @@ public class StateStoreWaitForFilesTest {
     }
 
     private StateStoreWaitForFiles waiterWithAttempts(int attempts, DoubleSupplier jitter) {
-        return waitForFileAssignmentWithAttemptsAndThrottlingRetries(
-                attempts, jitter, waiter,
+        return new StateStoreWaitForFilesTestHelper(
                 new FixedTablePropertiesProvider(tableProperties),
-                new FixedStateStoreProvider(tableProperties, stateStore));
+                new FixedStateStoreProvider(tableProperties, stateStore),
+                CompactionJobStatusStore.NONE, waiter, Instant::now)
+                .withAttemptsAndThrottlingRetries(attempts, jitter);
     }
 
     protected void actionAfterWait(WaitAction action) throws Exception {

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/StateStoreWaitForFilesTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/StateStoreWaitForFilesTest.java
@@ -22,7 +22,6 @@ import sleeper.compaction.job.CompactionJob;
 import sleeper.compaction.job.CompactionJobFactory;
 import sleeper.compaction.job.CompactionJobStatusStore;
 import sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper;
-import sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper.WaitAction;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.table.TableProperties;
 import sleeper.core.properties.testutils.FixedTablePropertiesProvider;
@@ -36,6 +35,7 @@ import sleeper.core.statestore.testutils.FixedStateStoreProvider;
 import sleeper.core.statestore.testutils.InMemoryFileReferenceStore;
 import sleeper.core.statestore.testutils.InMemoryPartitionStore;
 import sleeper.core.util.ExponentialBackoffWithJitter.Waiter;
+import sleeper.core.util.ExponentialBackoffWithJitterTestHelper.WaitAction;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -48,7 +48,6 @@ import static java.util.stream.Collectors.reducing;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.compaction.task.StateStoreWaitForFiles.JOB_ASSIGNMENT_WAIT_ATTEMPTS;
-import static sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper.withActionAfterWait;
 import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
@@ -56,6 +55,7 @@ import static sleeper.core.statestore.AssignJobIdRequest.assignJobOnPartitionToF
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.constantJitterFraction;
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.fixJitterSeed;
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.recordWaits;
+import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.withActionAfterWait;
 
 public class StateStoreWaitForFilesTest {
     private final InstanceProperties instanceProperties = createTestInstanceProperties();

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/testutils/StateStoreWaitForFilesTestHelper.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/testutils/StateStoreWaitForFilesTestHelper.java
@@ -15,6 +15,7 @@
  */
 package sleeper.compaction.testutils;
 
+import sleeper.compaction.job.CompactionJobStatusStore;
 import sleeper.compaction.task.StateStoreWaitForFiles;
 import sleeper.core.properties.table.TablePropertiesProvider;
 import sleeper.core.statestore.StateStoreProvider;
@@ -22,30 +23,38 @@ import sleeper.core.util.ExponentialBackoffWithJitter;
 import sleeper.core.util.ExponentialBackoffWithJitter.Waiter;
 import sleeper.core.util.PollWithRetries;
 
+import java.time.Instant;
 import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
 
 import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.noJitter;
-import static sleeper.core.util.ExponentialBackoffWithJitterTestHelper.noWaits;
 
 public class StateStoreWaitForFilesTestHelper {
-    private StateStoreWaitForFilesTestHelper() {
+
+    private final TablePropertiesProvider tablePropertiesProvider;
+    private final StateStoreProvider stateStoreProvider;
+    private final CompactionJobStatusStore jobStatusStore;
+    private final Waiter waiter;
+    private final Supplier<Instant> timeSupplier;
+
+    public StateStoreWaitForFilesTestHelper(
+            TablePropertiesProvider tablePropertiesProvider,
+            StateStoreProvider stateStoreProvider, CompactionJobStatusStore jobStatusStore,
+            Waiter waiter, Supplier<Instant> timeSupplier) {
+        this.tablePropertiesProvider = tablePropertiesProvider;
+        this.stateStoreProvider = stateStoreProvider;
+        this.jobStatusStore = jobStatusStore;
+        this.waiter = waiter;
+        this.timeSupplier = timeSupplier;
     }
 
-    public static StateStoreWaitForFiles waitForFileAssignmentWithAttempts(
-            int attempts, StateStoreProvider stateStoreProvider, TablePropertiesProvider tablePropertiesProvider) {
-        return waitWithAttempts(attempts, noJitter(), noWaits(), PollWithRetries.noRetries(), tablePropertiesProvider, stateStoreProvider);
+    public StateStoreWaitForFiles withAttempts(int attempts) {
+        return waitWithAttempts(attempts, noJitter(), PollWithRetries.noRetries());
     }
 
-    public static StateStoreWaitForFiles waitForFileAssignmentWithAttempts(
-            int attempts, Waiter waiter,
-            TablePropertiesProvider tablePropertiesProvider, StateStoreProvider stateStoreProvider) {
-        return waitWithAttempts(attempts, noJitter(), waiter, PollWithRetries.noRetries(), tablePropertiesProvider, stateStoreProvider);
-    }
-
-    public static StateStoreWaitForFiles waitForFileAssignmentWithAttemptsAndThrottlingRetries(
-            int attempts, DoubleSupplier jitter, Waiter waiter,
-            TablePropertiesProvider tablePropertiesProvider, StateStoreProvider stateStoreProvider) {
-        return waitWithAttempts(attempts, jitter, waiter, StateStoreWaitForFiles.JOB_ASSIGNMENT_THROTTLING_RETRIES, tablePropertiesProvider, stateStoreProvider);
+    public StateStoreWaitForFiles withAttemptsAndThrottlingRetries(
+            int attempts, DoubleSupplier jitter) {
+        return waitWithAttempts(attempts, jitter, StateStoreWaitForFiles.JOB_ASSIGNMENT_THROTTLING_RETRIES);
     }
 
     public static Waiter withActionAfterWait(Waiter waiter, WaitAction action) throws Exception {
@@ -59,15 +68,14 @@ public class StateStoreWaitForFilesTestHelper {
         };
     }
 
-    private static StateStoreWaitForFiles waitWithAttempts(
-            int attempts, DoubleSupplier jitter, Waiter waiter, PollWithRetries throttlingRetries,
-            TablePropertiesProvider tablePropertiesProvider, StateStoreProvider stateStoreProvider) {
+    private StateStoreWaitForFiles waitWithAttempts(
+            int attempts, DoubleSupplier jitter, PollWithRetries throttlingRetries) {
         return new StateStoreWaitForFiles(attempts,
                 new ExponentialBackoffWithJitter(StateStoreWaitForFiles.JOB_ASSIGNMENT_WAIT_RANGE, jitter, waiter),
                 throttlingRetries.toBuilder()
                         .sleepInInterval(waiter::waitForMillis)
                         .build(),
-                tablePropertiesProvider, stateStoreProvider);
+                tablePropertiesProvider, stateStoreProvider, jobStatusStore, timeSupplier);
     }
 
     public interface WaitAction {

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/testutils/StateStoreWaitForFilesTestHelper.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/testutils/StateStoreWaitForFilesTestHelper.java
@@ -57,17 +57,6 @@ public class StateStoreWaitForFilesTestHelper {
         return waitWithAttempts(attempts, jitter, StateStoreWaitForFiles.JOB_ASSIGNMENT_THROTTLING_RETRIES);
     }
 
-    public static Waiter withActionAfterWait(Waiter waiter, WaitAction action) throws Exception {
-        return millis -> {
-            try {
-                action.run();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            waiter.waitForMillis(millis);
-        };
-    }
-
     private StateStoreWaitForFiles waitWithAttempts(
             int attempts, DoubleSupplier jitter, PollWithRetries throttlingRetries) {
         return new StateStoreWaitForFiles(attempts,
@@ -76,9 +65,5 @@ public class StateStoreWaitForFilesTestHelper {
                         .sleepInInterval(waiter::waitForMillis)
                         .build(),
                 tablePropertiesProvider, stateStoreProvider, jobStatusStore, timeSupplier);
-    }
-
-    public interface WaitAction {
-        void run() throws Exception;
     }
 }

--- a/java/compaction/compaction-job-execution/pom.xml
+++ b/java/compaction/compaction-job-execution/pom.xml
@@ -95,13 +95,6 @@
         </dependency>
         <dependency>
             <groupId>sleeper</groupId>
-            <artifactId>compaction-core</artifactId>
-            <version>${project.parent.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>sleeper</groupId>
             <artifactId>parquet</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/job/execution/ECSCompactionTaskRunner.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/job/execution/ECSCompactionTaskRunner.java
@@ -102,7 +102,7 @@ public class ECSCompactionTaskRunner {
             DefaultCompactionRunnerFactory compactionSelector = new DefaultCompactionRunnerFactory(objectFactory,
                     HadoopConfigurationProvider.getConfigurationForECS(instanceProperties));
 
-            StateStoreWaitForFiles waitForFiles = new StateStoreWaitForFiles(tablePropertiesProvider, stateStoreProvider);
+            StateStoreWaitForFiles waitForFiles = new StateStoreWaitForFiles(tablePropertiesProvider, stateStoreProvider, jobStatusStore);
 
             CompactionJobCommitterOrSendToLambda committerOrLambda = committerOrSendToLambda(
                     tablePropertiesProvider, stateStoreProvider, jobStatusStore, instanceProperties, sqsClient);

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
@@ -286,8 +286,6 @@ public class ECSCompactionTaskRunnerLocalStackIT {
             assertThat(messagesOnQueue(COMPACTION_JOB_QUEUE_URL))
                     .map(Message::getBody)
                     .containsExactly(jobJson);
-            // - No file references should be in the state store
-            assertThat(stateStore.getFileReferences()).isEmpty();
         }
 
         @Test
@@ -315,8 +313,6 @@ public class ECSCompactionTaskRunnerLocalStackIT {
             assertThat(messagesOnQueue(COMPACTION_JOB_DLQ_URL))
                     .map(Message::getBody)
                     .containsExactly(jobJson);
-            // - No file references should be in the state store
-            assertThat(stateStore.getFileReferences()).isEmpty();
         }
     }
 

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
@@ -53,6 +53,7 @@ import sleeper.compaction.status.store.task.CompactionTaskStatusStoreFactory;
 import sleeper.compaction.status.store.task.DynamoDBCompactionTaskStatusStoreCreator;
 import sleeper.compaction.task.CompactionTask;
 import sleeper.compaction.task.CompactionTaskStatusStore;
+import sleeper.compaction.task.StateStoreWaitForFiles;
 import sleeper.configuration.jars.ObjectFactory;
 import sleeper.configuration.properties.S3InstanceProperties;
 import sleeper.configuration.properties.S3TableProperties;
@@ -102,8 +103,8 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static sleeper.compaction.job.execution.testutils.CompactionRunnerTestUtils.assignJobIdsToInputFiles;
-import static sleeper.compaction.testutils.StateStoreWaitForFilesTestHelper.waitForFileAssignmentWithAttempts;
 import static sleeper.configuration.testutils.LocalStackAwsV1ClientHelper.buildAwsV1Client;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.COMPACTION_JOB_DLQ_URL;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.COMPACTION_JOB_QUEUE_URL;
@@ -122,6 +123,7 @@ import static sleeper.core.properties.table.TableProperty.COMPACTION_JOB_COMMIT_
 import static sleeper.core.properties.table.TableProperty.TABLE_ID;
 import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
+import static sleeper.core.statestore.FileReferenceTestData.withJobId;
 import static sleeper.io.parquet.utils.HadoopConfigurationLocalStackUtils.getHadoopConfiguration;
 
 @Testcontainers
@@ -273,6 +275,7 @@ public class ECSCompactionTaskRunnerLocalStackIT {
             }).when(stateStore).atomicallyReplaceFileReferencesWithNewOnes(anyList());
             FileReference fileReference1 = ingestFileWith100Records();
             FileReference fileReference2 = ingestFileWith100Records();
+            when(stateStore.getFileReferences()).thenReturn(List.of(withJobId("job1", fileReference1), withJobId("job1", fileReference2)));
             String jobJson = sendCompactionJobForFilesGetJson("job1", "output1.parquet", fileReference1, fileReference2);
 
             // When
@@ -298,6 +301,7 @@ public class ECSCompactionTaskRunnerLocalStackIT {
             }).when(stateStore).atomicallyReplaceFileReferencesWithNewOnes(anyList());
             FileReference fileReference1 = ingestFileWith100Records();
             FileReference fileReference2 = ingestFileWith100Records();
+            when(stateStore.getFileReferences()).thenReturn(List.of(withJobId("job1", fileReference1), withJobId("job1", fileReference2)));
             String jobJson = sendCompactionJobForFilesGetJson("job1", "output1.parquet", fileReference1, fileReference2);
 
             // When
@@ -461,10 +465,10 @@ public class ECSCompactionTaskRunnerLocalStackIT {
         CompactionJobCommitterOrSendToLambda committer = ECSCompactionTaskRunner.committerOrSendToLambda(
                 tablePropertiesProvider, stateStoreProvider, jobStatusStore,
                 instanceProperties, sqs);
+        StateStoreWaitForFiles waitForFiles = new StateStoreWaitForFiles(tablePropertiesProvider, stateStoreProvider, jobStatusStore);
         CompactionTask task = new CompactionTask(instanceProperties, tablePropertiesProvider,
                 PropertiesReloader.neverReload(), stateStoreProvider, new SqsCompactionQueueHandler(sqs, instanceProperties),
-                waitForFileAssignmentWithAttempts(1, stateStoreProvider, tablePropertiesProvider),
-                committer, jobStatusStore, taskStatusStore, selector, taskId,
+                waitForFiles, committer, jobStatusStore, taskStatusStore, selector, taskId,
                 jobRunIdSupplier, timeSupplier, duration -> {
                 });
         return task;

--- a/java/core/src/main/java/sleeper/core/statestore/UncheckedStateStoreException.java
+++ b/java/core/src/main/java/sleeper/core/statestore/UncheckedStateStoreException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.statestore;
+
+/**
+ * A runtime exception to wrap failures in methods on a Sleeper state store.
+ */
+public class UncheckedStateStoreException extends RuntimeException {
+
+    private final StateStoreException stateStoreException;
+
+    public UncheckedStateStoreException(StateStoreException stateStoreException) {
+        super(stateStoreException);
+        this.stateStoreException = stateStoreException;
+    }
+
+    public StateStoreException getStateStoreException() {
+        return stateStoreException;
+    }
+}

--- a/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTestHelper.java
+++ b/java/core/src/test/java/sleeper/core/util/ExponentialBackoffWithJitterTestHelper.java
@@ -91,4 +91,35 @@ public class ExponentialBackoffWithJitterTestHelper {
         return millis -> {
         };
     }
+
+    /**
+     * Extends an implementation of a waiter to also perform another action.
+     *
+     * @param  waiter the waiter to extend
+     * @param  action the action to perform
+     * @return        a waiter which will behave like the original waiter but perform the action first
+     */
+    public static Waiter withActionAfterWait(Waiter waiter, WaitAction action) {
+        return millis -> {
+            try {
+                action.run();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            waiter.waitForMillis(millis);
+        };
+    }
+
+    /**
+     * An action to perform during a wait.
+     */
+    public interface WaitAction {
+
+        /**
+         * Perform the action.
+         *
+         * @throws Exception if anything went wrong
+         */
+        void run() throws Exception;
+    }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3396

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated StateStoreWaitForFilesTest, CompactionTaskAssignFilesTest, CompactionTaskCommitTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.