### PR TITLE
Issue 3408 - Don't validate instance properties during teardown

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/teardown/TearDownInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/teardown/TearDownInstance.java
@@ -126,7 +126,8 @@ public class TearDownInstance {
 
     private static InstanceProperties loadInstancePropertiesOrGenerateDefaults(AmazonS3 s3, String instanceId, Path scriptsDir) {
         if (instanceId == null) {
-            InstanceProperties instanceProperties = LoadLocalProperties.loadInstancePropertiesFromDirectory(scriptsDir.resolve("generated"));
+            InstanceProperties instanceProperties = LoadLocalProperties
+                    .loadInstancePropertiesNoValidationFromDirectory(scriptsDir.resolve("generated"));
             instanceId = instanceProperties.get(ID);
         }
         return loadInstancePropertiesOrGenerateDefaults(s3, instanceId);
@@ -135,7 +136,7 @@ public class TearDownInstance {
     public static InstanceProperties loadInstancePropertiesOrGenerateDefaults(AmazonS3 s3, String instanceId) {
         LOGGER.info("Loading configuration for instance {}", instanceId);
         try {
-            return S3InstanceProperties.loadGivenInstanceId(s3, instanceId);
+            return S3InstanceProperties.loadGivenInstanceIdNoValidation(s3, instanceId);
         } catch (AmazonS3Exception e) {
             LOGGER.info("Failed to download configuration, using default properties");
             return PopulateInstanceProperties.generateTearDownDefaultsFromInstanceId(instanceId);

--- a/java/core/src/main/java/sleeper/core/properties/local/LoadLocalProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/local/LoadLocalProperties.java
@@ -64,6 +64,18 @@ public class LoadLocalProperties {
     }
 
     /**
+     * Loads instance properties from a given directory, with no validation. Looks for an instance properties file and a
+     * tags file.
+     *
+     * @param  directory the directory
+     * @return           the instance properties
+     */
+    public static InstanceProperties loadInstancePropertiesNoValidationFromDirectory(Path directory) {
+        Path file = directory.resolve("instance.properties");
+        return loadInstancePropertiesNoValidation(file);
+    }
+
+    /**
      * Loads instance properties from a given instance properties file, with no validation. Also loads a tags file if
      * present.
      *


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3408

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Tested manually

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.