### PR TITLE
Issue 3347 - Add percentiles to compaction job statistics

### DIFF
--- a/java/clients/src/test/resources/reports/compaction/job/standard/all/jobWithMultipleRuns.txt
+++ b/java/clients/src/test/resources/reports/compaction/job/standard/all/jobWithMultipleRuns.txt
@@ -12,9 +12,9 @@ Jobs finished successfully: 2
 Jobs finished successfully with more than one run: 2
 Average compaction rate: 10.00 read/s, 5.00 write/s
 Statistics for delay between creation and input files assignment time:
-  avg: 1s, min: 1s, max: 1s, std dev: 0s
+  avg: 1s, min: 1s, 99%: 1s, 99.9%: 1s, max: 1s, std dev: 0s
 Statistics for delay between finish and commit time:
-  avg: 13.333s, min: 10s, max: 15s, std dev: 2.357s
+  avg: 13.333s, min: 10s, 99%: 15s, 99.9%: 15s, max: 15s, std dev: 2.357s
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | STATE       | CREATE_TIME              | FILES_ASSIGNED_TIME      | JOB_ID                               | INPUT_FILES | PARTITION_ID | TASK_ID                              | START_TIME               | FINISH_TIME              | COMMIT_TIME              | DURATION | RECORDS_READ | RECORDS_WRITTEN | READ_RATE (s) | WRITE_RATE (s) |
 | IN_PROGRESS | 2022-10-12T10:00:00.001Z | 2022-10-12T10:00:01.001Z | job33333-3333-3333-3333-333333333333 |           1 | root         | task1111-1111-1111-1111-111111111111 | 2022-10-12T10:02:00.001Z |                          |                          |          |              |                 |               |                |

--- a/java/clients/src/test/resources/reports/compaction/job/standard/all/jobsWithLargeAndDecimalStatistics.txt
+++ b/java/clients/src/test/resources/reports/compaction/job/standard/all/jobsWithLargeAndDecimalStatistics.txt
@@ -12,9 +12,9 @@ Jobs finished successfully: 2
 Jobs finished successfully with more than one run: 0
 Average compaction rate: 2,508.51 read/s, 1,254.26 write/s
 Statistics for delay between creation and input files assignment time:
-  avg: 3.061s, min: 1.123s, max: 5s, std dev: 1.938s
+  avg: 3.061s, min: 1.123s, 99%: 5s, 99.9%: 5s, max: 5s, std dev: 1.938s
 Statistics for delay between finish and commit time:
-  avg: 19.938s, min: 19.877s, max: 20s, std dev: 0.061s
+  avg: 19.938s, min: 19.877s, 99%: 20s, 99.9%: 20s, max: 20s, std dev: 0.061s
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | STATE    | CREATE_TIME          | FILES_ASSIGNED_TIME      | JOB_ID                               | INPUT_FILES | PARTITION_ID                         | TASK_ID | START_TIME           | FINISH_TIME              | COMMIT_TIME          | DURATION | RECORDS_READ | RECORDS_WRITTEN | READ_RATE (s) | WRITE_RATE (s) |
 | FINISHED | 2022-10-13T12:01:00Z | 2022-10-13T12:01:05Z     | job22222-2222-2222-2222-222222222222 |           1 | partnCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC | task-id | 2022-10-13T12:01:10Z | 2022-10-13T14:01:10Z     | 2022-10-13T14:01:30Z |       2h |    1,000,600 |         500,300 |        138.97 |          69.49 |

--- a/java/clients/src/test/resources/reports/compaction/job/standard/all/mixedJobs.txt
+++ b/java/clients/src/test/resources/reports/compaction/job/standard/all/mixedJobs.txt
@@ -12,9 +12,9 @@ Jobs finished successfully: 2
 Jobs finished successfully with more than one run: 0
 Average compaction rate: 10.00 read/s, 5.00 write/s
 Statistics for delay between creation and input files assignment time:
-  avg: 1s, min: 1s, max: 1s, std dev: 0s
+  avg: 1s, min: 1s, 99%: 1s, 99.9%: 1s, max: 1s, std dev: 0s
 Statistics for delay between finish and commit time:
-  avg: 1m 0s, min: 1m 0s, max: 1m 0s, std dev: 0s
+  avg: 1m 0s, min: 1m 0s, 99%: 1m 0s, 99.9%: 1m 0s, max: 1m 0s, std dev: 0s
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | STATE          | CREATE_TIME              | FILES_ASSIGNED_TIME      | JOB_ID                               | INPUT_FILES | PARTITION_ID                         | TASK_ID                              | START_TIME               | FINISH_TIME              | COMMIT_TIME              | DURATION | RECORDS_READ | RECORDS_WRITTEN | READ_RATE (s) | WRITE_RATE (s) |
 | FINISHED       | 2022-09-22T13:33:12.001Z | 2022-09-22T13:33:13.001Z | job77777-7777-7777-7777-777777777777 |           1 | partnFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF | task1111-1111-1111-1111-111111111111 | 2022-09-22T13:34:12.001Z |                          | 2022-09-22T13:36:12.001Z |          |              |                 |               |                |

--- a/java/clients/src/test/resources/reports/compaction/job/standard/range/mixedJobs.txt
+++ b/java/clients/src/test/resources/reports/compaction/job/standard/range/mixedJobs.txt
@@ -12,9 +12,9 @@ Jobs finished successfully: 2
 Jobs finished successfully with more than one run: 0
 Average compaction rate: 10.00 read/s, 5.00 write/s
 Statistics for delay between creation and input files assignment time:
-  avg: 1s, min: 1s, max: 1s, std dev: 0s
+  avg: 1s, min: 1s, 99%: 1s, 99.9%: 1s, max: 1s, std dev: 0s
 Statistics for delay between finish and commit time:
-  avg: 1m 0s, min: 1m 0s, max: 1m 0s, std dev: 0s
+  avg: 1m 0s, min: 1m 0s, 99%: 1m 0s, 99.9%: 1m 0s, max: 1m 0s, std dev: 0s
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | STATE          | CREATE_TIME              | FILES_ASSIGNED_TIME      | JOB_ID                               | INPUT_FILES | PARTITION_ID                         | TASK_ID                              | START_TIME               | FINISH_TIME              | COMMIT_TIME              | DURATION | RECORDS_READ | RECORDS_WRITTEN | READ_RATE (s) | WRITE_RATE (s) |
 | FINISHED       | 2022-09-22T13:33:12.001Z | 2022-09-22T13:33:13.001Z | job77777-7777-7777-7777-777777777777 |           1 | partnFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF | task1111-1111-1111-1111-111111111111 | 2022-09-22T13:34:12.001Z |                          | 2022-09-22T13:36:12.001Z |          |              |                 |               |                |

--- a/java/clients/src/test/resources/reports/compaction/job/standard/unfinished/mixedUnfinishedJobs.txt
+++ b/java/clients/src/test/resources/reports/compaction/job/standard/unfinished/mixedUnfinishedJobs.txt
@@ -9,7 +9,7 @@ Failed jobs (may be retried): 1
 Runs in progress: 1
 Runs awaiting commit: 1
 Statistics for delay between creation and input files assignment time:
-  avg: 1s, min: 1s, max: 1s, std dev: 0s
+  avg: 1s, min: 1s, 99%: 1s, 99.9%: 1s, max: 1s, std dev: 0s
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 | STATE          | CREATE_TIME              | FILES_ASSIGNED_TIME      | JOB_ID                               | INPUT_FILES | PARTITION_ID                         | TASK_ID                              | START_TIME               |
 | UNCOMMITTED    | 2022-09-20T13:33:12.001Z | 2022-09-20T13:33:13.001Z | job55555-5555-5555-5555-555555555555 |           1 | partnDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD | task1111-1111-1111-1111-111111111111 | 2022-09-20T13:34:12.001Z |

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusStatisticsTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/job/CompactionJobStatusStatisticsTest.java
@@ -51,7 +51,7 @@ public class CompactionJobStatusStatisticsTest {
 
         // When / Then
         assertThat(CompactionJobStatus.computeStatisticsOfDelayBetweenFinishAndCommit(List.of(status1, status2)))
-                .get().hasToString("avg: 1.5s, min: 1s, max: 2s, std dev: 0.5s");
+                .get().hasToString("avg: 1.5s, min: 1s, 99%: 2s, 99.9%: 2s, max: 2s, std dev: 0.5s");
     }
 
     @Test
@@ -80,7 +80,7 @@ public class CompactionJobStatusStatisticsTest {
 
         // When / Then
         assertThat(CompactionJobStatus.computeStatisticsOfDelayBetweenCreationAndFilesAssignment(List.of(status1, status2)))
-                .get().hasToString("avg: 2.5s, min: 2s, max: 3s, std dev: 0.5s");
+                .get().hasToString("avg: 2.5s, min: 2s, 99%: 3s, 99.9%: 3s, max: 3s, std dev: 0.5s");
     }
 
     @Test

--- a/java/core/src/test/java/sleeper/core/util/DurationStatisticsTest.java
+++ b/java/core/src/test/java/sleeper/core/util/DurationStatisticsTest.java
@@ -18,6 +18,7 @@ package sleeper.core.util;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +32,7 @@ public class DurationStatisticsTest {
 
         // When / Then
         assertThat(DurationStatistics.fromIfAny(data))
-                .get().hasToString("avg: 10s, min: 10s, max: 10s, std dev: 0s");
+                .get().hasToString("avg: 10s, min: 10s, 99%: 10s, 99.9%: 10s, max: 10s, std dev: 0s");
     }
 
     @Test
@@ -46,7 +47,18 @@ public class DurationStatisticsTest {
 
         // When / Then
         assertThat(DurationStatistics.fromIfAny(data))
-                .get().hasToString("avg: 1m 0s, min: 58s, max: 1m 2s, std dev: 1.414s");
+                .get().hasToString("avg: 1m 0s, min: 58s, 99%: 1m 2s, 99.9%: 1m 2s, max: 1m 2s, std dev: 1.414s");
+    }
+
+    @Test
+    void shouldReportStatisticsForManyDurations() {
+        // Given
+        Stream<Duration> data = IntStream.rangeClosed(1, 7200)
+                .mapToObj(Duration::ofSeconds);
+
+        // When / Then
+        assertThat(DurationStatistics.fromIfAny(data))
+                .get().hasToString("avg: 1h 0.5s, min: 1s, 99%: 1h 58m 48s, 99.9%: 1h 59m 53s, max: 2h 0s, std dev: 34m 38.46s");
     }
 
     @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3347

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated DurationStatisticsTest, compaction job report test data

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.