### PR TITLE
Issue 3202 - Make optional stacks redeployable except EKS

### DIFF
--- a/example/basic/instance.properties
+++ b/example/basic/instance.properties
@@ -23,7 +23,7 @@ sleeper.retain.infra.after.destroy=true
 # PersistentEmrBulkImportStack, EksBulkImportStack, EmrStudioStack, QueryStack, WebSocketQueryStack,
 # AthenaStack, KeepLambdaWarmStack, CompactionStack, GarbageCollectorStack, PartitionSplittingStack,
 # DashboardStack, TableMetricsStack]
-sleeper.optional.stacks=CompactionStack,GarbageCollectorStack,IngestStack,IngestBatcherStack,PartitionSplittingStack,QueryStack,AthenaStack,EmrServerlessBulkImportStack,EmrStudioStack,DashboardStack,TableMetricsStack
+sleeper.optional.stacks=IngestStack,IngestBatcherStack,EmrServerlessBulkImportStack,EmrStudioStack,QueryStack,AthenaStack,CompactionStack,GarbageCollectorStack,PartitionSplittingStack,DashboardStack,TableMetricsStack
 
 # The AWS account number. This is the AWS account that the instance will be deployed to.
 sleeper.account=1234567890

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -28,7 +28,7 @@ sleeper.retain.infra.after.destroy=true
 # PersistentEmrBulkImportStack, EksBulkImportStack, EmrStudioStack, QueryStack, WebSocketQueryStack,
 # AthenaStack, KeepLambdaWarmStack, CompactionStack, GarbageCollectorStack, PartitionSplittingStack,
 # DashboardStack, TableMetricsStack]
-sleeper.optional.stacks=CompactionStack,GarbageCollectorStack,IngestStack,IngestBatcherStack,PartitionSplittingStack,QueryStack,AthenaStack,EmrServerlessBulkImportStack,EmrStudioStack,DashboardStack,TableMetricsStack
+sleeper.optional.stacks=IngestStack,IngestBatcherStack,EmrServerlessBulkImportStack,EmrStudioStack,QueryStack,AthenaStack,CompactionStack,GarbageCollectorStack,PartitionSplittingStack,DashboardStack,TableMetricsStack
 
 # The AWS account number. This is the AWS account that the instance will be deployed to.
 sleeper.account=1234567890

--- a/java/cdk/src/main/java/sleeper/cdk/SleeperCdkApp.java
+++ b/java/cdk/src/main/java/sleeper/cdk/SleeperCdkApp.java
@@ -42,6 +42,7 @@ import sleeper.cdk.stack.IngestStatusStoreResources;
 import sleeper.cdk.stack.IngestStatusStoreStack;
 import sleeper.cdk.stack.InstanceRolesStack;
 import sleeper.cdk.stack.KeepLambdaWarmStack;
+import sleeper.cdk.stack.LoggingStack;
 import sleeper.cdk.stack.ManagedPoliciesStack;
 import sleeper.cdk.stack.PartitionSplittingStack;
 import sleeper.cdk.stack.PropertiesStack;
@@ -117,8 +118,11 @@ public class SleeperCdkApp extends Stack {
                 .collect(toUnmodifiableSet());
 
         List<IMetric> errorMetrics = new ArrayList<>();
+
+        LoggingStack loggingStack = new LoggingStack(this, "Logging", instanceProperties);
+
         // Stack for Checking VPC configuration
-        new VpcStack(this, "Vpc", instanceProperties, jars);
+        new VpcStack(this, "Vpc", instanceProperties, jars, loggingStack);
 
         // Topic stack
         TopicStack topicStack = new TopicStack(this, "Topic", instanceProperties);
@@ -140,11 +144,11 @@ public class SleeperCdkApp extends Stack {
         TableIndexStack tableIndexStack = new TableIndexStack(this, "TableIndex", instanceProperties, policiesStack);
         StateStoreCommitterStack stateStoreCommitterStack = new StateStoreCommitterStack(this, "StateStoreCommitter",
                 instanceProperties, jars,
-                configBucketStack, tableIndexStack,
+                loggingStack, configBucketStack, tableIndexStack,
                 stateStoreStacks, ingestStatusStore, compactionStatusStore,
                 policiesStack, topicStack.getTopic(), errorMetrics);
         coreStacks = new CoreStacks(
-                configBucketStack, tableIndexStack, policiesStack, stateStoreStacks, dataStack,
+                loggingStack, configBucketStack, tableIndexStack, policiesStack, stateStoreStacks, dataStack,
                 stateStoreCommitterStack, ingestStatusStore, compactionStatusStore);
 
         new TransactionLogSnapshotStack(this, "TransactionLogSnapshot",

--- a/java/cdk/src/main/java/sleeper/cdk/SleeperCdkApp.java
+++ b/java/cdk/src/main/java/sleeper/cdk/SleeperCdkApp.java
@@ -129,7 +129,7 @@ public class SleeperCdkApp extends Stack {
 
         // Stacks for tables
         ManagedPoliciesStack policiesStack = new ManagedPoliciesStack(this, "Policies", instanceProperties);
-        TableDataStack dataStack = new TableDataStack(this, "TableData", instanceProperties, policiesStack, jars);
+        TableDataStack dataStack = new TableDataStack(this, "TableData", instanceProperties, loggingStack, policiesStack, jars);
         TransactionLogStateStoreStack transactionLogStateStoreStack = new TransactionLogStateStoreStack(
                 this, "TransactionLogStateStore", instanceProperties, dataStack);
         StateStoreStacks stateStoreStacks = new StateStoreStacks(
@@ -140,7 +140,7 @@ public class SleeperCdkApp extends Stack {
                 instanceProperties, policiesStack).getResources();
         CompactionStatusStoreResources compactionStatusStore = new CompactionStatusStoreStack(this, "CompactionStatusStore",
                 instanceProperties, policiesStack).getResources();
-        ConfigBucketStack configBucketStack = new ConfigBucketStack(this, "Configuration", instanceProperties, policiesStack, jars);
+        ConfigBucketStack configBucketStack = new ConfigBucketStack(this, "Configuration", instanceProperties, loggingStack, policiesStack, jars);
         TableIndexStack tableIndexStack = new TableIndexStack(this, "TableIndex", instanceProperties, policiesStack);
         StateStoreCommitterStack stateStoreCommitterStack = new StateStoreCommitterStack(this, "StateStoreCommitter",
                 instanceProperties, jars,

--- a/java/cdk/src/main/java/sleeper/cdk/stack/AthenaStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/AthenaStack.java
@@ -77,7 +77,7 @@ public class AthenaStack extends NestedStack {
                 .removalPolicy(RemovalPolicy.DESTROY)
                 .build();
 
-        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, customResourcesJar, spillBucket);
+        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, customResourcesJar, spillBucket, bucketName);
 
         IKey spillMasterKey = createSpillMasterKey(this, instanceProperties);
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/AthenaStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/AthenaStack.java
@@ -77,7 +77,7 @@ public class AthenaStack extends NestedStack {
                 .removalPolicy(RemovalPolicy.DESTROY)
                 .build();
 
-        AutoDeleteS3Objects.autoDeleteForBucket(this, customResourcesJar, instanceProperties, spillBucket);
+        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, customResourcesJar, spillBucket);
 
         IKey spillMasterKey = createSpillMasterKey(this, instanceProperties);
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/CompactionStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/CompactionStack.java
@@ -396,8 +396,8 @@ public class CompactionStack extends NestedStack {
             FargateTaskDefinition fargateTaskDefinition = compactionFargateTaskDefinition();
             String fargateTaskDefinitionFamily = fargateTaskDefinition.getFamily();
             instanceProperties.set(COMPACTION_TASK_FARGATE_DEFINITION_FAMILY, fargateTaskDefinitionFamily);
-            ContainerDefinitionOptions fargateContainerDefinitionOptions = createFargateContainerDefinition(containerImage,
-                    environmentVariables, instanceProperties);
+            ContainerDefinitionOptions fargateContainerDefinitionOptions = createFargateContainerDefinition(
+                    coreStacks, containerImage, environmentVariables, instanceProperties);
             fargateTaskDefinition.addContainer(ContainerConstants.COMPACTION_CONTAINER_NAME,
                     fargateContainerDefinitionOptions);
             grantPermissions.accept(fargateTaskDefinition);
@@ -405,8 +405,8 @@ public class CompactionStack extends NestedStack {
             Ec2TaskDefinition ec2TaskDefinition = compactionEC2TaskDefinition();
             String ec2TaskDefinitionFamily = ec2TaskDefinition.getFamily();
             instanceProperties.set(COMPACTION_TASK_EC2_DEFINITION_FAMILY, ec2TaskDefinitionFamily);
-            ContainerDefinitionOptions ec2ContainerDefinitionOptions = createEC2ContainerDefinition(containerImage,
-                    environmentVariables, instanceProperties);
+            ContainerDefinitionOptions ec2ContainerDefinitionOptions = createEC2ContainerDefinition(
+                    coreStacks, containerImage, environmentVariables, instanceProperties);
             ec2TaskDefinition.addContainer(ContainerConstants.COMPACTION_CONTAINER_NAME, ec2ContainerDefinitionOptions);
             grantPermissions.accept(ec2TaskDefinition);
             addEC2CapacityProvider(cluster, vpc, coreStacks, taskCreatorJar);
@@ -551,7 +551,7 @@ public class CompactionStack extends NestedStack {
     }
 
     private ContainerDefinitionOptions createFargateContainerDefinition(
-            ContainerImage image, Map<String, String> environment, InstanceProperties instanceProperties) {
+            CoreStacks coreStacks, ContainerImage image, Map<String, String> environment, InstanceProperties instanceProperties) {
         String architecture = instanceProperties.get(COMPACTION_TASK_CPU_ARCHITECTURE).toUpperCase(Locale.ROOT);
         CompactionTaskRequirements requirements = CompactionTaskRequirements.getArchRequirements(architecture, instanceProperties);
         return ContainerDefinitionOptions.builder()
@@ -559,12 +559,12 @@ public class CompactionStack extends NestedStack {
                 .environment(environment)
                 .cpu(requirements.getCpu())
                 .memoryLimitMiB(requirements.getMemoryLimitMiB())
-                .logging(Utils.createECSContainerLogDriver(this, instanceProperties, "FargateCompactionTasks"))
+                .logging(Utils.createECSContainerLogDriver(coreStacks, "FargateCompactionTasks"))
                 .build();
     }
 
     private ContainerDefinitionOptions createEC2ContainerDefinition(
-            ContainerImage image, Map<String, String> environment, InstanceProperties instanceProperties) {
+            CoreStacks coreStacks, ContainerImage image, Map<String, String> environment, InstanceProperties instanceProperties) {
         String architecture = instanceProperties.get(COMPACTION_TASK_CPU_ARCHITECTURE).toUpperCase(Locale.ROOT);
         CompactionTaskRequirements requirements = CompactionTaskRequirements.getArchRequirements(architecture, instanceProperties);
         return ContainerDefinitionOptions.builder()
@@ -575,7 +575,7 @@ public class CompactionStack extends NestedStack {
                 // container allocation failing when we need almost entire resources
                 // of machine
                 .memoryLimitMiB((int) (requirements.getMemoryLimitMiB() * 0.95))
-                .logging(Utils.createECSContainerLogDriver(this, instanceProperties, "EC2CompactionTasks"))
+                .logging(Utils.createECSContainerLogDriver(coreStacks, "EC2CompactionTasks"))
                 .build();
     }
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/ConfigBucketStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/ConfigBucketStack.java
@@ -40,7 +40,8 @@ public class ConfigBucketStack extends NestedStack {
     private final IBucket configBucket;
 
     public ConfigBucketStack(
-            Construct scope, String id, InstanceProperties instanceProperties, ManagedPoliciesStack policiesStack, BuiltJars jars) {
+            Construct scope, String id, InstanceProperties instanceProperties,
+            LoggingStack loggingStack, ManagedPoliciesStack policiesStack, BuiltJars jars) {
         super(scope, id);
 
         configBucket = Bucket.Builder.create(this, "ConfigBucket")
@@ -54,7 +55,7 @@ public class ConfigBucketStack extends NestedStack {
 
         instanceProperties.set(CONFIG_BUCKET, configBucket.getBucketName());
 
-        AutoDeleteS3Objects.autoDeleteForBucket(this, jars, instanceProperties, configBucket);
+        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, loggingStack, jars, configBucket);
 
         configBucket.grantRead(policiesStack.getDirectIngestPolicyForGrants());
         configBucket.grantRead(policiesStack.getIngestByQueuePolicyForGrants());

--- a/java/cdk/src/main/java/sleeper/cdk/stack/ConfigBucketStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/ConfigBucketStack.java
@@ -43,10 +43,10 @@ public class ConfigBucketStack extends NestedStack {
             Construct scope, String id, InstanceProperties instanceProperties,
             LoggingStack loggingStack, ManagedPoliciesStack policiesStack, BuiltJars jars) {
         super(scope, id);
-
+        String bucketName = String.join("-", "sleeper",
+                Utils.cleanInstanceId(instanceProperties), "config");
         configBucket = Bucket.Builder.create(this, "ConfigBucket")
-                .bucketName(String.join("-", "sleeper",
-                        Utils.cleanInstanceId(instanceProperties), "config"))
+                .bucketName(bucketName)
                 .versioned(false)
                 .encryption(BucketEncryption.S3_MANAGED)
                 .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
@@ -55,7 +55,7 @@ public class ConfigBucketStack extends NestedStack {
 
         instanceProperties.set(CONFIG_BUCKET, configBucket.getBucketName());
 
-        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, loggingStack, jars, configBucket);
+        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, loggingStack, jars, configBucket, bucketName);
 
         configBucket.grantRead(policiesStack.getDirectIngestPolicyForGrants());
         configBucket.grantRead(policiesStack.getIngestByQueuePolicyForGrants());

--- a/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
@@ -60,6 +60,10 @@ public class CoreStacks {
         return loggingStack.getLogGroupByFunctionName(functionName);
     }
 
+    public ILogGroup getLogGroupByECSLogDriverId(String id) {
+        return loggingStack.getLogGroupByECSLogDriverId(id);
+    }
+
     public void grantReadInstanceConfig(IGrantable grantee) {
         configBucketStack.grantRead(grantee);
     }

--- a/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
@@ -60,6 +60,10 @@ public class CoreStacks {
         return loggingStack.getLogGroupByFunctionName(functionName);
     }
 
+    public ILogGroup getProviderLogGroupByFunctionName(String functionName) {
+        return loggingStack.getProviderLogGroupByFunctionName(functionName);
+    }
+
     public ILogGroup getLogGroupByECSLogDriverId(String id) {
         return loggingStack.getLogGroupByECSLogDriverId(id);
     }

--- a/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
@@ -68,6 +68,10 @@ public class CoreStacks {
         return loggingStack.getLogGroupByECSLogDriverId(id);
     }
 
+    public ILogGroup getLogGroupByStateMachineId(String id) {
+        return loggingStack.getLogGroupByStateMachineId(id);
+    }
+
     public void grantReadInstanceConfig(IGrantable grantee) {
         configBucketStack.grantRead(grantee);
     }

--- a/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/CoreStacks.java
@@ -21,6 +21,7 @@ import software.amazon.awscdk.services.iam.IGrantable;
 import software.amazon.awscdk.services.iam.IRole;
 import software.amazon.awscdk.services.iam.ManagedPolicy;
 import software.amazon.awscdk.services.lambda.IFunction;
+import software.amazon.awscdk.services.logs.ILogGroup;
 import software.amazon.awscdk.services.sqs.IQueue;
 
 import javax.annotation.Nullable;
@@ -29,6 +30,7 @@ import java.util.Objects;
 
 public class CoreStacks {
 
+    private final LoggingStack loggingStack;
     private final ConfigBucketStack configBucketStack;
     private final TableIndexStack tableIndexStack;
     private final ManagedPoliciesStack policiesStack;
@@ -38,11 +40,12 @@ public class CoreStacks {
     private final IngestStatusStoreResources ingestStatusStore;
     private final CompactionStatusStoreResources compactionStatusStore;
 
-    public CoreStacks(ConfigBucketStack configBucketStack, TableIndexStack tableIndexStack,
+    public CoreStacks(LoggingStack loggingStack, ConfigBucketStack configBucketStack, TableIndexStack tableIndexStack,
             ManagedPoliciesStack policiesStack, StateStoreStacks stateStoreStacks, TableDataStack dataStack,
             StateStoreCommitterStack stateStoreCommitterStack,
             IngestStatusStoreResources ingestStatusStore,
             CompactionStatusStoreResources compactionStatusStore) {
+        this.loggingStack = loggingStack;
         this.configBucketStack = configBucketStack;
         this.tableIndexStack = tableIndexStack;
         this.policiesStack = policiesStack;
@@ -51,6 +54,10 @@ public class CoreStacks {
         this.stateStoreCommitterStack = stateStoreCommitterStack;
         this.ingestStatusStore = ingestStatusStore;
         this.compactionStatusStore = compactionStatusStore;
+    }
+
+    public ILogGroup getLogGroupByFunctionName(String functionName) {
+        return loggingStack.getLogGroupByFunctionName(functionName);
     }
 
     public void grantReadInstanceConfig(IGrantable grantee) {

--- a/java/cdk/src/main/java/sleeper/cdk/stack/IngestStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/IngestStack.java
@@ -58,7 +58,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static sleeper.cdk.util.Utils.createAlarmForDlq;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.cdk.util.Utils.shouldDeployPaused;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.INGEST_CLOUDWATCH_RULE;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.INGEST_CLUSTER;
@@ -257,7 +256,7 @@ public class IngestStack extends NestedStack {
                 .handler("sleeper.ingest.starter.RunIngestTasksLambda::eventHandler")
                 .environment(Utils.createDefaultEnvironment(instanceProperties))
                 .reservedConcurrentExecutions(1)
-                .logGroup(createLambdaLogGroup(this, "IngestTasksCreatorLogGroup", functionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(functionName)));
 
         // Grant this function permission to read from the S3 bucket
         coreStacks.grantReadInstanceConfig(handler);

--- a/java/cdk/src/main/java/sleeper/cdk/stack/IngestStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/IngestStack.java
@@ -213,7 +213,7 @@ public class IngestStack extends NestedStack {
 
         ContainerDefinitionOptions containerDefinitionOptions = ContainerDefinitionOptions.builder()
                 .image(containerImage)
-                .logging(Utils.createECSContainerLogDriver(this, instanceProperties, "IngestTasks"))
+                .logging(Utils.createECSContainerLogDriver(coreStacks, "IngestTasks"))
                 .environment(Utils.createDefaultEnvironment(instanceProperties))
                 .build();
         taskDefinition.addContainer("IngestContainer", containerDefinitionOptions);

--- a/java/cdk/src/main/java/sleeper/cdk/stack/KeepLambdaWarmStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/KeepLambdaWarmStack.java
@@ -37,7 +37,6 @@ import sleeper.core.properties.instance.InstanceProperties;
 
 import java.util.Collections;
 
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.cdk.util.Utils.shouldDeployPaused;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.QUERY_WARM_LAMBDA_CLOUDWATCH_RULE;
 import static sleeper.core.properties.instance.CommonProperty.ID;
@@ -76,7 +75,7 @@ public class KeepLambdaWarmStack extends NestedStack {
                 .handler("sleeper.query.lambda.WarmQueryExecutorLambda::handleRequest")
                 .environment(Utils.createDefaultEnvironment(instanceProperties))
                 .reservedConcurrentExecutions(1)
-                .logGroup(createLambdaLogGroup(this, id + "LogGroup", functionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(functionName)));
 
         // Cloudwatch rule to trigger this lambda
         Rule rule = Rule.Builder

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -62,7 +62,7 @@ public class LoggingStack extends NestedStack {
         createLogGroup("bulk-import-NonPersistentEMR-start");
         createLogGroup("bulk-import-PersistentEMR-start");
         createLogGroup("bulk-import-eks-starter");
-        createLogGroup("EksBulkImportStateMachine");
+        createStateMachineLogGroup("EksBulkImportStateMachine");
         createLogGroup("bulk-import-autodelete");
         createLogGroup("bulk-import-autodelete-provider");
         createLogGroup("IngestTasks");
@@ -105,7 +105,7 @@ public class LoggingStack extends NestedStack {
     }
 
     public ILogGroup getLogGroupByStateMachineId(String id) {
-        return getLogGroupByNameWithPrefixes(addNamePrefixes(id));
+        return getLogGroupByNameWithPrefixes(addStateMachineNamePrefixes(id));
     }
 
     private ILogGroup getLogGroupByNameWithPrefixes(String nameWithPrefixes) {
@@ -113,11 +113,22 @@ public class LoggingStack extends NestedStack {
     }
 
     private void createLogGroup(String shortName) {
-        String nameWithPrefixes = addNamePrefixes(shortName);
+        createLogGroup(shortName, addNamePrefixes(shortName));
+    }
+
+    private void createStateMachineLogGroup(String shortName) {
+        createLogGroup(shortName, addStateMachineNamePrefixes(shortName));
+    }
+
+    private void createLogGroup(String shortName, String nameWithPrefixes) {
         logGroupByName.put(nameWithPrefixes, LogGroup.Builder.create(this, shortName)
                 .logGroupName(nameWithPrefixes)
                 .retention(Utils.getRetentionDays(instanceProperties.getInt(LOG_RETENTION_IN_DAYS)))
                 .build());
+    }
+
+    private String addStateMachineNamePrefixes(String shortName) {
+        return "/aws/vendedlogs/states/" + addNamePrefixes(shortName);
     }
 
     private String addNamePrefixes(String shortName) {

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -38,23 +38,36 @@ public class LoggingStack extends NestedStack {
         super(scope, id);
         this.instanceProperties = instanceProperties;
 
-        // For core stacks, accessed directly by getter
+        // Accessed directly by getter on this class
         createLogGroup("vpc-check");
         createLogGroup("statestore-committer");
 
-        // For non-core stacks, accessed via CoreStacks getters
+        // Accessed via CoreStacks getters
         createLogGroup("state-snapshot-creation-trigger");
         createLogGroup("state-snapshot-creation");
         createLogGroup("state-transaction-deletion-trigger");
         createLogGroup("state-transaction-deletion");
         createLogGroup("metrics-trigger");
         createLogGroup("metrics-publisher");
+        createLogGroup("bulk-import-EMRServerless-start");
+        createLogGroup("bulk-import-NonPersistentEMR-start");
+        createLogGroup("bulk-import-PersistentEMR-start");
+        createLogGroup("bulk-import-eks-starter");
+        createLogGroup("IngestTasks");
+        createLogGroup("FargateCompactionTasks");
+        createLogGroup("EC2CompactionTasks");
+        createLogGroup("garbage-collector-trigger");
+        createLogGroup("garbage-collector");
         createLogGroup("Simple-athena-handler");
         createLogGroup("IteratorApplying-athena-handler");
     }
 
     public ILogGroup getLogGroupByFunctionName(String functionName) {
         return getLogGroupByNameWithPrefixes(functionName);
+    }
+
+    public ILogGroup getLogGroupByECSLogDriverId(String id) {
+        return getLogGroupByNameWithPrefixes(addNamePrefixes(id));
     }
 
     private ILogGroup getLogGroupByNameWithPrefixes(String nameWithPrefixes) {

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -62,6 +62,7 @@ public class LoggingStack extends NestedStack {
         createLogGroup("bulk-import-NonPersistentEMR-start");
         createLogGroup("bulk-import-PersistentEMR-start");
         createLogGroup("bulk-import-eks-starter");
+        createLogGroup("EksBulkImportStateMachine");
         createLogGroup("bulk-import-autodelete");
         createLogGroup("bulk-import-autodelete-provider");
         createLogGroup("IngestTasks");
@@ -100,6 +101,10 @@ public class LoggingStack extends NestedStack {
     }
 
     public ILogGroup getLogGroupByECSLogDriverId(String id) {
+        return getLogGroupByNameWithPrefixes(addNamePrefixes(id));
+    }
+
+    public ILogGroup getLogGroupByStateMachineId(String id) {
         return getLogGroupByNameWithPrefixes(addNamePrefixes(id));
     }
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -120,7 +120,7 @@ public class LoggingStack extends NestedStack {
                 .build());
     }
 
-    private String addNamePrefixes(String id) {
-        return String.join("-", "sleeper", Utils.cleanInstanceId(instanceProperties), id);
+    private String addNamePrefixes(String shortName) {
+        return String.join("-", "sleeper", Utils.cleanInstanceId(instanceProperties), shortName);
     }
 }

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -40,11 +40,20 @@ public class LoggingStack extends NestedStack {
 
         // Accessed directly by getter on this class
         createLogGroup("vpc-check");
+        createLogGroup("vpc-check-provider");
+        createLogGroup("config-autodelete");
+        createLogGroup("config-autodelete-provider");
+        createLogGroup("table-data-autodelete");
+        createLogGroup("table-data-autodelete-provider");
         createLogGroup("statestore-committer");
 
         // Accessed via CoreStacks getters
+        createLogGroup("properties-writer");
+        createLogGroup("properties-writer-provider");
         createLogGroup("state-snapshot-creation-trigger");
         createLogGroup("state-snapshot-creation");
+        createLogGroup("state-snapshot-deletion-trigger");
+        createLogGroup("state-snapshot-deletion");
         createLogGroup("state-transaction-deletion-trigger");
         createLogGroup("state-transaction-deletion");
         createLogGroup("metrics-trigger");
@@ -53,17 +62,41 @@ public class LoggingStack extends NestedStack {
         createLogGroup("bulk-import-NonPersistentEMR-start");
         createLogGroup("bulk-import-PersistentEMR-start");
         createLogGroup("bulk-import-eks-starter");
+        createLogGroup("bulk-import-autodelete");
+        createLogGroup("bulk-import-autodelete-provider");
         createLogGroup("IngestTasks");
+        createLogGroup("ingest-create-tasks");
+        createLogGroup("ingest-batcher-submit-files");
+        createLogGroup("ingest-batcher-create-jobs");
+        createLogGroup("partition-splitting-trigger");
+        createLogGroup("partition-splitting-find-to-split");
+        createLogGroup("partition-splitting-handler");
         createLogGroup("FargateCompactionTasks");
         createLogGroup("EC2CompactionTasks");
+        createLogGroup("compaction-job-creation-trigger");
+        createLogGroup("compaction-job-creation-handler");
+        createLogGroup("compaction-tasks-creator");
+        createLogGroup("compaction-custom-termination");
         createLogGroup("garbage-collector-trigger");
         createLogGroup("garbage-collector");
+        createLogGroup("query-executor");
+        createLogGroup("query-leaf-partition");
+        createLogGroup("query-websocket-handler");
+        createLogGroup("query-results-autodelete");
+        createLogGroup("query-results-autodelete-provider");
+        createLogGroup("query-keep-warm");
         createLogGroup("Simple-athena-handler");
         createLogGroup("IteratorApplying-athena-handler");
+        createLogGroup("spill-bucket-autodelete");
+        createLogGroup("spill-bucket-autodelete-provider");
     }
 
     public ILogGroup getLogGroupByFunctionName(String functionName) {
         return getLogGroupByNameWithPrefixes(functionName);
+    }
+
+    public ILogGroup getProviderLogGroupByFunctionName(String functionName) {
+        return getLogGroupByNameWithPrefixes(functionName + "-provider");
     }
 
     public ILogGroup getLogGroupByECSLogDriverId(String id) {

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -25,6 +25,7 @@ import sleeper.core.properties.instance.InstanceProperties;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static sleeper.core.properties.instance.CommonProperty.LOG_RETENTION_IN_DAYS;
 
@@ -36,8 +37,18 @@ public class LoggingStack extends NestedStack {
     public LoggingStack(Construct scope, String id, InstanceProperties instanceProperties) {
         super(scope, id);
         this.instanceProperties = instanceProperties;
+
+        // For core stacks, accessed directly by getter
         createLogGroup("vpc-check");
         createLogGroup("statestore-committer");
+
+        // For non-core stacks, accessed via CoreStacks getters
+        createLogGroup("state-snapshot-creation-trigger");
+        createLogGroup("state-snapshot-creation");
+        createLogGroup("state-transaction-deletion-trigger");
+        createLogGroup("state-transaction-deletion");
+        createLogGroup("metrics-trigger");
+        createLogGroup("metrics-publisher");
         createLogGroup("Simple-athena-handler");
         createLogGroup("IteratorApplying-athena-handler");
     }
@@ -47,7 +58,7 @@ public class LoggingStack extends NestedStack {
     }
 
     private ILogGroup getLogGroupByNameWithPrefixes(String nameWithPrefixes) {
-        return logGroupByName.get(nameWithPrefixes);
+        return Objects.requireNonNull(logGroupByName.get(nameWithPrefixes), "No log group found: " + nameWithPrefixes);
     }
 
     private void createLogGroup(String logGroupName) {

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -112,9 +112,9 @@ public class LoggingStack extends NestedStack {
         return Objects.requireNonNull(logGroupByName.get(nameWithPrefixes), "No log group found: " + nameWithPrefixes);
     }
 
-    private void createLogGroup(String logGroupName) {
-        String nameWithPrefixes = addNamePrefixes(logGroupName);
-        logGroupByName.put(nameWithPrefixes, LogGroup.Builder.create(this, logGroupName)
+    private void createLogGroup(String shortName) {
+        String nameWithPrefixes = addNamePrefixes(shortName);
+        logGroupByName.put(nameWithPrefixes, LogGroup.Builder.create(this, shortName)
                 .logGroupName(addNamePrefixes(nameWithPrefixes))
                 .retention(Utils.getRetentionDays(instanceProperties.getInt(LOG_RETENTION_IN_DAYS)))
                 .build());

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -115,7 +115,7 @@ public class LoggingStack extends NestedStack {
     private void createLogGroup(String shortName) {
         String nameWithPrefixes = addNamePrefixes(shortName);
         logGroupByName.put(nameWithPrefixes, LogGroup.Builder.create(this, shortName)
-                .logGroupName(addNamePrefixes(nameWithPrefixes))
+                .logGroupName(nameWithPrefixes)
                 .retention(Utils.getRetentionDays(instanceProperties.getInt(LOG_RETENTION_IN_DAYS)))
                 .build());
     }

--- a/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/LoggingStack.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.cdk.stack;
+
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.services.logs.ILogGroup;
+import software.amazon.awscdk.services.logs.LogGroup;
+import software.constructs.Construct;
+
+import sleeper.cdk.util.Utils;
+import sleeper.core.properties.instance.InstanceProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static sleeper.core.properties.instance.CommonProperty.LOG_RETENTION_IN_DAYS;
+
+public class LoggingStack extends NestedStack {
+
+    private final Map<String, ILogGroup> logGroupByName = new HashMap<>();
+    private final InstanceProperties instanceProperties;
+
+    public LoggingStack(Construct scope, String id, InstanceProperties instanceProperties) {
+        super(scope, id);
+        this.instanceProperties = instanceProperties;
+        createLogGroup("vpc-check");
+        createLogGroup("statestore-committer");
+        createLogGroup("Simple-athena-handler");
+        createLogGroup("IteratorApplying-athena-handler");
+    }
+
+    public ILogGroup getLogGroupByFunctionName(String functionName) {
+        return getLogGroupByNameWithPrefixes(functionName);
+    }
+
+    private ILogGroup getLogGroupByNameWithPrefixes(String nameWithPrefixes) {
+        return logGroupByName.get(nameWithPrefixes);
+    }
+
+    private void createLogGroup(String logGroupName) {
+        String nameWithPrefixes = addNamePrefixes(logGroupName);
+        logGroupByName.put(nameWithPrefixes, LogGroup.Builder.create(this, logGroupName)
+                .logGroupName(addNamePrefixes(nameWithPrefixes))
+                .retention(Utils.getRetentionDays(instanceProperties.getInt(LOG_RETENTION_IN_DAYS)))
+                .build());
+    }
+
+    private String addNamePrefixes(String id) {
+        return String.join("-", "sleeper", Utils.cleanInstanceId(instanceProperties), id);
+    }
+}

--- a/java/cdk/src/main/java/sleeper/cdk/stack/PropertiesStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/PropertiesStack.java
@@ -32,8 +32,6 @@ import sleeper.core.properties.instance.InstanceProperties;
 
 import java.util.HashMap;
 
-import static sleeper.cdk.util.Utils.createCustomResourceProviderLogGroup;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.core.properties.instance.CommonProperty.JARS_BUCKET;
 
 /**
@@ -61,14 +59,14 @@ public class PropertiesStack extends NestedStack {
                 .memorySize(2048)
                 .environment(Utils.createDefaultEnvironment(instanceProperties))
                 .description("Lambda for writing instance properties to S3 upon initialisation and teardown")
-                .logGroup(createLambdaLogGroup(this, "PropertiesWriterLambdaLogGroup", functionName, instanceProperties))
+                .logGroup(coreStacks.getLogGroupByFunctionName(functionName))
                 .runtime(Runtime.JAVA_11));
 
         coreStacks.grantWriteInstanceConfig(propertiesWriterLambda);
 
         Provider propertiesWriterProvider = Provider.Builder.create(this, "PropertiesWriterProvider")
                 .onEventHandler(propertiesWriterLambda)
-                .logGroup(createCustomResourceProviderLogGroup(this, "PropertiesWriterProviderLogGroup", functionName, instanceProperties))
+                .logGroup(coreStacks.getProviderLogGroupByFunctionName(functionName))
                 .build();
 
         CustomResource.Builder.create(this, "InstanceProperties")

--- a/java/cdk/src/main/java/sleeper/cdk/stack/QueryStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/QueryStack.java
@@ -349,10 +349,11 @@ public class QueryStack extends NestedStack {
      */
     private IBucket setupResultsBucket(InstanceProperties instanceProperties, CoreStacks coreStacks, LambdaCode customResourcesJar) {
         RemovalPolicy removalPolicy = removalPolicy(instanceProperties);
+        String bucketName = String.join("-", "sleeper",
+                Utils.cleanInstanceId(instanceProperties), "query-results");
         Bucket resultsBucket = Bucket.Builder
                 .create(this, "QueryResultsBucket")
-                .bucketName(String.join("-", "sleeper",
-                        Utils.cleanInstanceId(instanceProperties), "query-results"))
+                .bucketName(bucketName)
                 .versioned(false)
                 .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
                 .encryption(BucketEncryption.S3_MANAGED)
@@ -363,7 +364,7 @@ public class QueryStack extends NestedStack {
         instanceProperties.set(CdkDefinedInstanceProperty.QUERY_RESULTS_BUCKET, resultsBucket.getBucketName());
 
         if (removalPolicy == RemovalPolicy.DESTROY) {
-            AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, customResourcesJar, resultsBucket);
+            AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, customResourcesJar, resultsBucket, bucketName);
         }
 
         return resultsBucket;

--- a/java/cdk/src/main/java/sleeper/cdk/stack/TableDataStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/TableDataStack.java
@@ -44,10 +44,11 @@ public class TableDataStack extends NestedStack {
 
         RemovalPolicy removalPolicy = removalPolicy(instanceProperties);
 
+        String bucketName = String.join("-", "sleeper",
+                Utils.cleanInstanceId(instanceProperties), "table-data");
         dataBucket = Bucket.Builder
                 .create(this, "TableDataBucket")
-                .bucketName(String.join("-", "sleeper",
-                        Utils.cleanInstanceId(instanceProperties), "table-data"))
+                .bucketName(bucketName)
                 .versioned(false)
                 .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
                 .encryption(BucketEncryption.S3_MANAGED)
@@ -55,7 +56,7 @@ public class TableDataStack extends NestedStack {
                 .build();
 
         if (removalPolicy == RemovalPolicy.DESTROY) {
-            AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, loggingStack, jars, dataBucket);
+            AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, loggingStack, jars, dataBucket, bucketName);
         }
 
         instanceProperties.set(DATA_BUCKET, dataBucket.getBucketName());

--- a/java/cdk/src/main/java/sleeper/cdk/stack/TableDataStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/TableDataStack.java
@@ -38,7 +38,8 @@ public class TableDataStack extends NestedStack {
     private final IBucket dataBucket;
 
     public TableDataStack(
-            Construct scope, String id, InstanceProperties instanceProperties, ManagedPoliciesStack policiesStack, BuiltJars jars) {
+            Construct scope, String id, InstanceProperties instanceProperties,
+            LoggingStack loggingStack, ManagedPoliciesStack policiesStack, BuiltJars jars) {
         super(scope, id);
 
         RemovalPolicy removalPolicy = removalPolicy(instanceProperties);
@@ -54,7 +55,7 @@ public class TableDataStack extends NestedStack {
                 .build();
 
         if (removalPolicy == RemovalPolicy.DESTROY) {
-            AutoDeleteS3Objects.autoDeleteForBucket(this, jars, instanceProperties, dataBucket);
+            AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, loggingStack, jars, dataBucket);
         }
 
         instanceProperties.set(DATA_BUCKET, dataBucket.getBucketName());

--- a/java/cdk/src/main/java/sleeper/cdk/stack/TableMetricsStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/TableMetricsStack.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static sleeper.cdk.util.Utils.createAlarmForDlq;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.cdk.util.Utils.shouldDeployPaused;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.TABLE_METRICS_DLQ_ARN;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.TABLE_METRICS_DLQ_URL;
@@ -80,7 +79,7 @@ public class TableMetricsStack extends NestedStack {
                 .reservedConcurrentExecutions(1)
                 .memorySize(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_MEMORY_IN_MB))
                 .timeout(Duration.seconds(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_TIMEOUT_IN_SECONDS)))
-                .logGroup(createLambdaLogGroup(this, "MetricsTriggerLogGroup", triggerFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(triggerFunctionName)));
         IFunction tableMetricsPublisher = metricsJar.buildFunction(this, "MetricsPublisher", builder -> builder
                 .functionName(publishFunctionName)
                 .description("Generates metrics for a Sleeper table based on info in its state store, and publishes them to CloudWatch")
@@ -90,7 +89,7 @@ public class TableMetricsStack extends NestedStack {
                 .reservedConcurrentExecutions(instanceProperties.getInt(METRICS_LAMBDA_CONCURRENCY_RESERVED))
                 .memorySize(1024)
                 .timeout(Duration.minutes(1))
-                .logGroup(createLambdaLogGroup(this, "MetricsPublisherLogGroup", publishFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(publishFunctionName)));
 
         instanceProperties.set(TABLE_METRICS_LAMBDA_FUNCTION, tableMetricsTrigger.getFunctionName());
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/TransactionLogSnapshotStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/TransactionLogSnapshotStack.java
@@ -41,7 +41,6 @@ import sleeper.core.properties.instance.InstanceProperties;
 import java.util.List;
 
 import static sleeper.cdk.util.Utils.createAlarmForDlq;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.cdk.util.Utils.shouldDeployPaused;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_SNAPSHOT_CREATION_DLQ_ARN;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_SNAPSHOT_CREATION_DLQ_URL;
@@ -164,7 +163,7 @@ public class TransactionLogSnapshotStack extends NestedStack {
                 .reservedConcurrentExecutions(1)
                 .memorySize(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_MEMORY_IN_MB))
                 .timeout(Duration.seconds(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_TIMEOUT_IN_SECONDS)))
-                .logGroup(createLambdaLogGroup(this, "TransactionLogSnapshotDeletionTriggerLogGroup", triggerFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(triggerFunctionName)));
         IFunction snapshotDeletionLambda = statestoreJar.buildFunction(this, "TransactionLogSnapshotDeletion", builder -> builder
                 .functionName(deletionFunctionName)
                 .description("Deletes old transaction log snapshots for tables")
@@ -174,7 +173,7 @@ public class TransactionLogSnapshotStack extends NestedStack {
                 .reservedConcurrentExecutions(instanceProperties.getInt(TRANSACTION_LOG_SNAPSHOT_DELETION_LAMBDA_CONCURRENCY_RESERVED))
                 .memorySize(1024)
                 .timeout(Duration.minutes(1))
-                .logGroup(createLambdaLogGroup(this, "TransactionLogSnapshotDeletionLogGroup", deletionFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(deletionFunctionName)));
 
         Rule rule = Rule.Builder.create(this, "TransactionLogSnapshotDeletionSchedule")
                 .ruleName(SleeperScheduleRule.TRANSACTION_LOG_SNAPSHOT_DELETION.buildRuleName(instanceProperties))

--- a/java/cdk/src/main/java/sleeper/cdk/stack/TransactionLogSnapshotStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/TransactionLogSnapshotStack.java
@@ -94,7 +94,7 @@ public class TransactionLogSnapshotStack extends NestedStack {
                 .reservedConcurrentExecutions(1)
                 .memorySize(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_MEMORY_IN_MB))
                 .timeout(Duration.seconds(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_TIMEOUT_IN_SECONDS)))
-                .logGroup(createLambdaLogGroup(this, "TransactionLogSnapshotCreationTriggerLogGroup", triggerFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(triggerFunctionName)));
         IFunction snapshotCreationLambda = statestoreJar.buildFunction(this, "TransactionLogSnapshotCreation", builder -> builder
                 .functionName(creationFunctionName)
                 .description("Creates transaction log snapshots for tables")
@@ -104,7 +104,7 @@ public class TransactionLogSnapshotStack extends NestedStack {
                 .reservedConcurrentExecutions(instanceProperties.getInt(TRANSACTION_LOG_SNAPSHOT_CREATION_LAMBDA_CONCURRENCY_RESERVED))
                 .memorySize(1024)
                 .timeout(Duration.minutes(1))
-                .logGroup(createLambdaLogGroup(this, "TransactionLogSnapshotCreationLogGroup", creationFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(creationFunctionName)));
 
         Rule rule = Rule.Builder.create(this, "TransactionLogSnapshotCreationSchedule")
                 .ruleName(SleeperScheduleRule.TRANSACTION_LOG_SNAPSHOT_CREATION.buildRuleName(instanceProperties))

--- a/java/cdk/src/main/java/sleeper/cdk/stack/TransactionLogTransactionStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/TransactionLogTransactionStack.java
@@ -41,7 +41,6 @@ import sleeper.core.properties.instance.InstanceProperties;
 import java.util.List;
 
 import static sleeper.cdk.util.Utils.createAlarmForDlq;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.cdk.util.Utils.shouldDeployPaused;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_TRANSACTION_DELETION_DLQ_ARN;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.TRANSACTION_LOG_TRANSACTION_DELETION_DLQ_URL;
@@ -84,7 +83,7 @@ public class TransactionLogTransactionStack extends NestedStack {
                 .reservedConcurrentExecutions(1)
                 .memorySize(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_MEMORY_IN_MB))
                 .timeout(Duration.seconds(instanceProperties.getInt(TABLE_BATCHING_LAMBDAS_TIMEOUT_IN_SECONDS)))
-                .logGroup(createLambdaLogGroup(this, "TransactionLogTransactionDeletionTriggerLogGroup", triggerFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(triggerFunctionName)));
         IFunction transactionDeletionLambda = statestoreJar.buildFunction(this, "TransactionLogTransactionDeletion", builder -> builder
                 .functionName(deletionFunctionName)
                 .description("Deletes old transaction log transactions for tables")
@@ -94,7 +93,7 @@ public class TransactionLogTransactionStack extends NestedStack {
                 .reservedConcurrentExecutions(instanceProperties.getInt(TRANSACTION_LOG_TRANSACTION_DELETION_LAMBDA_CONCURRENCY_RESERVED))
                 .memorySize(1024)
                 .timeout(Duration.minutes(1))
-                .logGroup(createLambdaLogGroup(this, "TransactionLogTransactionDeletionLogGroup", deletionFunctionName, instanceProperties)));
+                .logGroup(coreStacks.getLogGroupByFunctionName(deletionFunctionName)));
 
         Rule rule = Rule.Builder.create(this, "TransactionLogTransactionDeletionSchedule")
                 .ruleName(SleeperScheduleRule.TRANSACTION_LOG_TRANSACTION_DELETION.buildRuleName(instanceProperties))

--- a/java/cdk/src/main/java/sleeper/cdk/stack/VpcStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/VpcStack.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static sleeper.cdk.util.Utils.createCustomResourceProviderLogGroup;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.core.properties.instance.CommonProperty.REGION;
 import static sleeper.core.properties.instance.CommonProperty.VPC_ENDPOINT_CHECK;
 import static sleeper.core.properties.instance.CommonProperty.VPC_ID;
@@ -50,7 +49,7 @@ import static sleeper.core.properties.instance.CommonProperty.VPC_ID;
 public class VpcStack extends NestedStack {
     private static final Logger LOGGER = LoggerFactory.getLogger(VpcStack.class);
 
-    public VpcStack(Construct scope, String id, InstanceProperties instanceProperties, BuiltJars jars) {
+    public VpcStack(Construct scope, String id, InstanceProperties instanceProperties, BuiltJars jars, LoggingStack logging) {
         super(scope, id);
 
         if (!instanceProperties.getBoolean(VPC_ENDPOINT_CHECK)) {
@@ -71,7 +70,7 @@ public class VpcStack extends NestedStack {
                 .handler("sleeper.cdk.custom.VpcCheckLambda::handleEvent")
                 .memorySize(2048)
                 .description("Lambda for checking the VPC has an associated S3 endpoint")
-                .logGroup(createLambdaLogGroup(this, "VpcCheckLambdaLogGroup", functionName, instanceProperties))
+                .logGroup(logging.getLogGroupByFunctionName(functionName))
                 .runtime(Runtime.JAVA_11));
 
         vpcCheckLambda.addToRolePolicy(new PolicyStatement(new PolicyStatementProps.Builder()

--- a/java/cdk/src/main/java/sleeper/cdk/stack/VpcStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/VpcStack.java
@@ -41,7 +41,6 @@ import sleeper.core.properties.instance.InstanceProperties;
 import java.util.HashMap;
 import java.util.Map;
 
-import static sleeper.cdk.util.Utils.createCustomResourceProviderLogGroup;
 import static sleeper.core.properties.instance.CommonProperty.REGION;
 import static sleeper.core.properties.instance.CommonProperty.VPC_ENDPOINT_CHECK;
 import static sleeper.core.properties.instance.CommonProperty.VPC_ID;
@@ -83,7 +82,7 @@ public class VpcStack extends NestedStack {
         Provider provider = new Provider(this, "VpcCustomResourceProvider",
                 ProviderProps.builder()
                         .onEventHandler(vpcCheckLambda)
-                        .logGroup(createCustomResourceProviderLogGroup(this, "VpcCustomResourceProviderLogGroup", functionName, instanceProperties))
+                        .logGroup(logging.getProviderLogGroupByFunctionName(functionName))
                         .build());
 
         // Custom resource to check whether VPC is valid

--- a/java/cdk/src/main/java/sleeper/cdk/stack/WebSocketQueryStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/WebSocketQueryStack.java
@@ -48,8 +48,6 @@ import sleeper.core.properties.instance.InstanceProperties;
 import java.util.Collections;
 import java.util.Map;
 
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
-
 public final class WebSocketQueryStack extends NestedStack {
 
     private CfnApi webSocketApi;
@@ -86,7 +84,7 @@ public final class WebSocketQueryStack extends NestedStack {
                 .handler("sleeper.query.lambda.WebSocketQueryProcessorLambda::handleRequest")
                 .environment(env)
                 .memorySize(256)
-                .logGroup(createLambdaLogGroup(this, "WebSocketApiHandlerLogGroup", functionName, instanceProperties))
+                .logGroup(coreStacks.getLogGroupByFunctionName(functionName))
                 .timeout(Duration.seconds(29))
                 .runtime(software.amazon.awscdk.services.lambda.Runtime.JAVA_11));
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/BulkImportBucketStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/BulkImportBucketStack.java
@@ -36,9 +36,10 @@ public class BulkImportBucketStack extends NestedStack {
 
     public BulkImportBucketStack(Construct scope, String id, InstanceProperties instanceProperties, CoreStacks coreStacks, BuiltJars jars) {
         super(scope, id);
+        String bucketName = String.join("-", "sleeper",
+                Utils.cleanInstanceId(instanceProperties), "bulk-import");
         importBucket = Bucket.Builder.create(this, "BulkImportBucket")
-                .bucketName(String.join("-", "sleeper",
-                        Utils.cleanInstanceId(instanceProperties), "bulk-import"))
+                .bucketName(bucketName)
                 .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
                 .versioned(false)
                 .removalPolicy(RemovalPolicy.DESTROY)
@@ -46,7 +47,7 @@ public class BulkImportBucketStack extends NestedStack {
                 .build();
         importBucket.grantWrite(coreStacks.getIngestByQueuePolicyForGrants());
         instanceProperties.set(BULK_IMPORT_BUCKET, importBucket.getBucketName());
-        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, jars, importBucket);
+        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, jars, importBucket, bucketName);
     }
 
     public IBucket getImportBucket() {

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/BulkImportBucketStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/BulkImportBucketStack.java
@@ -46,7 +46,7 @@ public class BulkImportBucketStack extends NestedStack {
                 .build();
         importBucket.grantWrite(coreStacks.getIngestByQueuePolicyForGrants());
         instanceProperties.set(BULK_IMPORT_BUCKET, importBucket.getBucketName());
-        AutoDeleteS3Objects.autoDeleteForBucket(this, jars, instanceProperties, importBucket);
+        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, coreStacks, jars, importBucket);
     }
 
     public IBucket getImportBucket() {

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/CommonEmrBulkImportHelper.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/CommonEmrBulkImportHelper.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static sleeper.cdk.util.Utils.createAlarmForDlq;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.core.properties.instance.CommonProperty.JARS_BUCKET;
 
 public class CommonEmrBulkImportHelper {
@@ -128,7 +127,6 @@ public class CommonEmrBulkImportHelper {
                 .runtime(software.amazon.awscdk.services.lambda.Runtime.JAVA_11)
                 .handler("sleeper.bulkimport.starter.BulkImportStarterLambda")
                 .logGroup(coreStacks.getLogGroupByFunctionName(functionName))
-                .logGroup(createLambdaLogGroup(scope, "BulkImport" + platform + "JobStarterLogGroup", functionName, instanceProperties))
                 .events(Lists.newArrayList(SqsEventSource.Builder.create(jobQueue).batchSize(1).build())));
 
         coreStacks.grantValidateBulkImport(function.getRole());

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/CommonEmrBulkImportHelper.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/CommonEmrBulkImportHelper.java
@@ -127,6 +127,7 @@ public class CommonEmrBulkImportHelper {
                 .environment(env)
                 .runtime(software.amazon.awscdk.services.lambda.Runtime.JAVA_11)
                 .handler("sleeper.bulkimport.starter.BulkImportStarterLambda")
+                .logGroup(coreStacks.getLogGroupByFunctionName(functionName))
                 .logGroup(createLambdaLogGroup(scope, "BulkImport" + platform + "JobStarterLogGroup", functionName, instanceProperties))
                 .events(Lists.newArrayList(SqsEventSource.Builder.create(jobQueue).batchSize(1).build())));
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
@@ -77,7 +77,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import static sleeper.cdk.util.Utils.createAlarmForDlq;
-import static sleeper.cdk.util.Utils.createLambdaLogGroup;
 import static sleeper.cdk.util.Utils.createStateMachineLogOptions;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_JOB_QUEUE_ARN;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_JOB_QUEUE_URL;
@@ -146,7 +145,7 @@ public final class EksBulkImportStack extends NestedStack {
                 .environment(env)
                 .runtime(software.amazon.awscdk.services.lambda.Runtime.JAVA_11)
                 .handler("sleeper.bulkimport.starter.BulkImportStarterLambda")
-                .logGroup(createLambdaLogGroup(this, "BulkImportEKSJobStarterLogGroup", functionName, instanceProperties))
+                .logGroup(coreStacks.getLogGroupByFunctionName(functionName))
                 .events(Lists.newArrayList(SqsEventSource.Builder.create(bulkImportJobQueue).batchSize(1).build())));
         configureJobStarterFunction(bulkImportJobStarter);
 

--- a/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
@@ -197,7 +197,7 @@ public final class EksBulkImportStack extends NestedStack {
                 .forEach(sa -> sa.getNode().addDependency(namespace));
         coreStacks.grantIngest(sparkServiceAccount.getRole());
 
-        StateMachine stateMachine = createStateMachine(bulkImportCluster, instanceProperties, errorsTopic);
+        StateMachine stateMachine = createStateMachine(bulkImportCluster, instanceProperties, coreStacks, errorsTopic);
         instanceProperties.set(CdkDefinedInstanceProperty.BULK_IMPORT_EKS_STATE_MACHINE_ARN, stateMachine.getStateMachineArn());
 
         bulkImportCluster.getAwsAuth().addRoleMapping(stateMachine.getRole(), AwsAuthMapping.builder()
@@ -222,7 +222,7 @@ public final class EksBulkImportStack extends NestedStack {
                 .build());
     }
 
-    private StateMachine createStateMachine(Cluster cluster, InstanceProperties instanceProperties, Topic errorsTopic) {
+    private StateMachine createStateMachine(Cluster cluster, InstanceProperties instanceProperties, CoreStacks coreStacks, Topic errorsTopic) {
         String imageName = instanceProperties.get(ACCOUNT) +
                 ".dkr.ecr." +
                 instanceProperties.get(REGION) +
@@ -267,7 +267,7 @@ public final class EksBulkImportStack extends NestedStack {
                                                                 .stateJson(deleteJobState).build()))
                                         .otherwise(createErrorMessage.next(publishError).next(Fail.Builder
                                                 .create(this, "FailedJobState").cause("Spark job failed").build())))))
-                .logs(createStateMachineLogOptions(this, "EksBulkImportStateMachineLogs", instanceProperties))
+                .logs(createStateMachineLogOptions(coreStacks, "EksBulkImportStateMachine"))
                 .build();
     }
 

--- a/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
+++ b/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
@@ -185,7 +185,7 @@ public class Utils {
                 .build();
     }
 
-    private static RetentionDays getRetentionDays(int numberOfDays) {
+    public static RetentionDays getRetentionDays(int numberOfDays) {
         switch (numberOfDays) {
             case -1:
                 return RetentionDays.INFINITE;

--- a/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
+++ b/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
@@ -154,22 +154,6 @@ public class Utils {
                 .build();
     }
 
-    public static LogGroup createLambdaLogGroup(
-            Construct scope, String id, String functionName, InstanceProperties instanceProperties) {
-        return LogGroup.Builder.create(scope, id)
-                .logGroupName(functionName)
-                .retention(getRetentionDays(instanceProperties.getInt(LOG_RETENTION_IN_DAYS)))
-                .build();
-    }
-
-    public static LogGroup createCustomResourceProviderLogGroup(
-            Construct scope, String id, String functionName, InstanceProperties instanceProperties) {
-        return LogGroup.Builder.create(scope, id)
-                .logGroupName(functionName + "-provider")
-                .retention(getRetentionDays(instanceProperties.getInt(LOG_RETENTION_IN_DAYS)))
-                .build();
-    }
-
     public static LogDriver createECSContainerLogDriver(CoreStacks coreStacks, String id) {
         ILogGroup logGroup = coreStacks.getLogGroupByECSLogDriverId(id);
         return LogDriver.awsLogs(AwsLogDriverProps.builder()

--- a/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
+++ b/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
@@ -65,7 +65,6 @@ import java.util.stream.Stream;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.VERSION;
 import static sleeper.core.properties.instance.CommonProperty.ID;
-import static sleeper.core.properties.instance.CommonProperty.LOG_RETENTION_IN_DAYS;
 import static sleeper.core.properties.instance.CommonProperty.RETAIN_INFRA_AFTER_DESTROY;
 import static sleeper.core.properties.instance.CommonProperty.STACK_TAG_NAME;
 import static sleeper.core.properties.instance.DashboardProperty.DASHBOARD_TIME_WINDOW_MINUTES;
@@ -162,13 +161,9 @@ public class Utils {
                 .build());
     }
 
-    public static LogOptions createStateMachineLogOptions(Construct scope, String id, InstanceProperties instanceProperties) {
-        String logGroupName = String.join("-", "sleeper", cleanInstanceId(instanceProperties), id);
+    public static LogOptions createStateMachineLogOptions(CoreStacks coreStacks, String id) {
         return LogOptions.builder()
-                .destination(LogGroup.Builder.create(scope, id)
-                        .logGroupName(logGroupName)
-                        .retention(getRetentionDays(instanceProperties.getInt(LOG_RETENTION_IN_DAYS)))
-                        .build())
+                .destination(coreStacks.getLogGroupByStateMachineId(id))
                 .level(LogLevel.ALL)
                 .includeExecutionData(true)
                 .build();

--- a/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
+++ b/java/cdk/src/main/java/sleeper/cdk/util/Utils.java
@@ -33,7 +33,6 @@ import software.amazon.awscdk.services.iam.ManagedPolicy;
 import software.amazon.awscdk.services.iam.PolicyStatement;
 import software.amazon.awscdk.services.lambda.IFunction;
 import software.amazon.awscdk.services.logs.ILogGroup;
-import software.amazon.awscdk.services.logs.LogGroup;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.Topic;
 import software.amazon.awscdk.services.sqs.Queue;
@@ -132,25 +131,6 @@ public class Utils {
     public static String cleanInstanceId(String instanceId) {
         return instanceId.toLowerCase(Locale.ROOT)
                 .replace(".", "-");
-    }
-
-    /**
-     * Configures a log group with the specified number of days. Valid values are taken from
-     * <a href=
-     * "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html">here</a>.
-     * A value of -1 represents an infinite number of days.
-     *
-     * @param  scope        the scope for the new construct
-     * @param  id           the ID for the new construct
-     * @param  logGroupName the name for the log group
-     * @param  numberOfDays number of days you want to retain the logs
-     * @return              The RetentionDays equivalent
-     */
-    public static LogGroup createLogGroupWithRetentionDays(Construct scope, String id, String logGroupName, int numberOfDays) {
-        return LogGroup.Builder.create(scope, id)
-                .logGroupName(logGroupName)
-                .retention(getRetentionDays(numberOfDays))
-                .build();
     }
 
     public static LogDriver createECSContainerLogDriver(CoreStacks coreStacks, String id) {

--- a/java/core/src/main/java/sleeper/core/properties/validation/OptionalStack.java
+++ b/java/core/src/main/java/sleeper/core/properties/validation/OptionalStack.java
@@ -18,8 +18,8 @@ package sleeper.core.properties.validation;
 import org.apache.commons.lang3.EnumUtils;
 
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * Valid values for optional deployment stacks. Determines which components of Sleeper will be deployed.
@@ -93,6 +93,11 @@ public enum OptionalStack {
             PartitionSplittingStack,
             QueryStack);
 
+    public static final List<OptionalStack> DEFAULT_STACKS = List.of(
+            IngestStack, IngestBatcherStack, EmrServerlessBulkImportStack, EmrStudioStack,
+            QueryStack, AthenaStack, CompactionStack, GarbageCollectorStack, PartitionSplittingStack,
+            DashboardStack, TableMetricsStack);
+
     /**
      * Checks if the value is a valid optional deployment stack.
      *
@@ -104,10 +109,24 @@ public enum OptionalStack {
                 .allMatch(item -> EnumUtils.isValidEnumIgnoreCase(OptionalStack.class, item));
     }
 
+    /**
+     * Returns the default value for the property to set optional stacks for an instance. This value is a
+     * comma-separated string.
+     *
+     * @return the default value
+     */
     public static String getDefaultValue() {
-        return Stream.of(CompactionStack, GarbageCollectorStack, IngestStack, IngestBatcherStack, PartitionSplittingStack,
-                QueryStack, AthenaStack, EmrServerlessBulkImportStack, EmrStudioStack, DashboardStack, TableMetricsStack)
-                .map(a -> a.toString())
-                .collect(Collectors.joining(","));
+        return DEFAULT_STACKS.stream()
+                .map(OptionalStack::toString)
+                .collect(joining(","));
+    }
+
+    /**
+     * Returns a list of all optional stacks.
+     *
+     * @return all optional stacks
+     */
+    public static List<OptionalStack> all() {
+        return List.of(values());
     }
 }

--- a/java/core/src/test/java/sleeper/core/properties/validation/OptionalStackTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/validation/OptionalStackTest.java
@@ -39,9 +39,9 @@ public class OptionalStackTest {
     void shouldGenerateListOfDefaultValueForOptionalStack() {
         InstanceProperties properties = new InstanceProperties();
         assertThat(properties.get(OPTIONAL_STACKS))
-                .isEqualTo("CompactionStack,GarbageCollectorStack,IngestStack,IngestBatcherStack," +
-                        "PartitionSplittingStack,QueryStack,AthenaStack,EmrServerlessBulkImportStack," +
-                        "EmrStudioStack,DashboardStack,TableMetricsStack");
+                .isEqualTo("IngestStack,IngestBatcherStack,EmrServerlessBulkImportStack,EmrStudioStack," +
+                        "QueryStack,AthenaStack,CompactionStack,GarbageCollectorStack,PartitionSplittingStack," +
+                        "DashboardStack,TableMetricsStack");
     }
 
     @Test

--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestBucketStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestBucketStack.java
@@ -73,7 +73,7 @@ public class SystemTestBucketStack extends NestedStack {
                 .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
                 .removalPolicy(RemovalPolicy.DESTROY)
                 .build();
-        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, jars, bucket,
+        AutoDeleteS3Objects.autoDeleteForBucket(this, instanceProperties, jars, bucket, bucketName,
                 functionName -> LogGroup.Builder.create(this, id + "-AutoDeleteLambdaLogGroup")
                         .logGroupName(functionName)
                         .retention(Utils.getRetentionDays(properties.getInt(SYSTEM_TEST_LOG_RETENTION_DAYS)))

--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
@@ -34,6 +34,7 @@ import software.amazon.awscdk.services.ecs.LogDriver;
 import software.amazon.awscdk.services.iam.Effect;
 import software.amazon.awscdk.services.iam.IRole;
 import software.amazon.awscdk.services.iam.PolicyStatement;
+import software.amazon.awscdk.services.logs.LogGroup;
 import software.amazon.awscdk.services.s3.Bucket;
 import software.constructs.Construct;
 
@@ -122,7 +123,10 @@ public class SystemTestClusterStack extends NestedStack {
                 .image(containerImage)
                 .logging(LogDriver.awsLogs(AwsLogDriverProps.builder()
                         .streamPrefix(logGroupName)
-                        .logGroup(Utils.createLogGroupWithRetentionDays(this, "SystemTestTasks", logGroupName, properties.getInt(SYSTEM_TEST_LOG_RETENTION_DAYS)))
+                        .logGroup(LogGroup.Builder.create(this, "SystemTestTasks")
+                                .logGroupName(logGroupName)
+                                .retention(Utils.getRetentionDays(properties.getInt(SYSTEM_TEST_LOG_RETENTION_DAYS)))
+                                .build())
                         .build()))
                 .environment(Utils.createDefaultEnvironment(instanceProperties))
                 .build();

--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
@@ -51,20 +51,14 @@ import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
 
 import java.util.List;
 
-import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.core.properties.instance.CommonProperty.ID;
 import static sleeper.core.properties.instance.CommonProperty.JARS_BUCKET;
 import static sleeper.core.properties.instance.CommonProperty.VPC_ID;
-import static sleeper.core.properties.instance.LoggingLevelsProperty.LOGGING_LEVEL;
-import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_BUCKET_NAME;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_CLUSTER_NAME;
-import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_ID;
-import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_JARS_BUCKET;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_LOG_RETENTION_DAYS;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_REPO;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_TASK_CPU;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_TASK_MEMORY;
-import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_VPC_ID;
 import static sleeper.systemtest.configuration.SystemTestProperty.WRITE_DATA_TASK_DEFINITION_FAMILY;
 
 public class SystemTestClusterStack extends NestedStack {
@@ -72,13 +66,7 @@ public class SystemTestClusterStack extends NestedStack {
     public SystemTestClusterStack(
             Construct scope, String id, SystemTestStandaloneProperties properties, SystemTestBucketStack bucketStack) {
         super(scope, id);
-        InstanceProperties instanceProperties = new InstanceProperties();
-        instanceProperties.set(ID, properties.get(SYSTEM_TEST_ID));
-        instanceProperties.set(VPC_ID, properties.get(SYSTEM_TEST_VPC_ID));
-        instanceProperties.set(JARS_BUCKET, properties.get(SYSTEM_TEST_JARS_BUCKET));
-        instanceProperties.set(CONFIG_BUCKET, properties.get(SYSTEM_TEST_BUCKET_NAME));
-        instanceProperties.set(LOGGING_LEVEL, "debug");
-        createSystemTestCluster(properties, properties, instanceProperties, bucketStack);
+        createSystemTestCluster(properties, properties, properties.toInstancePropertiesForCdkUtils(), bucketStack);
         Tags.of(this).add("DeploymentStack", id);
     }
 

--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestStandaloneProperties.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestStandaloneProperties.java
@@ -34,14 +34,21 @@ import java.util.Locale;
 import java.util.Properties;
 
 import static sleeper.core.properties.PropertiesUtils.loadProperties;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
+import static sleeper.core.properties.instance.CommonProperty.ID;
+import static sleeper.core.properties.instance.CommonProperty.JARS_BUCKET;
 import static sleeper.core.properties.instance.CommonProperty.LOG_RETENTION_IN_DAYS;
+import static sleeper.core.properties.instance.CommonProperty.VPC_ID;
 import static sleeper.core.properties.instance.LoggingLevelsProperty.APACHE_LOGGING_LEVEL;
 import static sleeper.core.properties.instance.LoggingLevelsProperty.AWS_LOGGING_LEVEL;
 import static sleeper.core.properties.instance.LoggingLevelsProperty.LOGGING_LEVEL;
 import static sleeper.core.properties.instance.LoggingLevelsProperty.PARQUET_LOGGING_LEVEL;
 import static sleeper.core.properties.instance.LoggingLevelsProperty.ROOT_LOGGING_LEVEL;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_BUCKET_NAME;
+import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_ID;
+import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_JARS_BUCKET;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_LOG_RETENTION_DAYS;
+import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_VPC_ID;
 
 public class SystemTestStandaloneProperties
         extends SleeperProperties<SystemTestProperty>
@@ -107,6 +114,10 @@ public class SystemTestStandaloneProperties
 
     public InstanceProperties toInstancePropertiesForCdkUtils() {
         InstanceProperties instanceProperties = new InstanceProperties();
+        instanceProperties.set(ID, get(SYSTEM_TEST_ID));
+        instanceProperties.set(VPC_ID, get(SYSTEM_TEST_VPC_ID));
+        instanceProperties.set(JARS_BUCKET, get(SYSTEM_TEST_JARS_BUCKET));
+        instanceProperties.set(CONFIG_BUCKET, get(SYSTEM_TEST_BUCKET_NAME));
         instanceProperties.set(LOG_RETENTION_IN_DAYS, get(SYSTEM_TEST_LOG_RETENTION_DAYS));
         instanceProperties.set(LOGGING_LEVEL, "DEBUG");
         instanceProperties.set(ROOT_LOGGING_LEVEL, "INFO");

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -43,6 +43,7 @@ import sleeper.systemtest.dsl.sourcedata.SystemTestSourceFiles;
 import sleeper.systemtest.dsl.statestore.SystemTestStateStore;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 import java.util.stream.LongStream;
 
@@ -175,7 +176,7 @@ public class SleeperSystemTest {
         new SystemTestOptionalStacks(context.instance()).addOptionalStack(stack);
     }
 
-    public void enableOptionalStacks(OptionalStack... stacks) {
+    public void enableOptionalStacks(Collection<OptionalStack> stacks) {
         new SystemTestOptionalStacks(context.instance()).addOptionalStacks(stacks);
     }
 
@@ -183,7 +184,7 @@ public class SleeperSystemTest {
         new SystemTestOptionalStacks(context.instance()).removeOptionalStack(stack);
     }
 
-    public void disableOptionalStacks(OptionalStack... stacks) {
+    public void disableOptionalStacks(Collection<OptionalStack> stacks) {
         new SystemTestOptionalStacks(context.instance()).removeOptionalStacks(stacks);
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/SleeperSystemTest.java
@@ -175,8 +175,16 @@ public class SleeperSystemTest {
         new SystemTestOptionalStacks(context.instance()).addOptionalStack(stack);
     }
 
+    public void enableOptionalStacks(OptionalStack... stacks) {
+        new SystemTestOptionalStacks(context.instance()).addOptionalStacks(stacks);
+    }
+
     public void disableOptionalStack(OptionalStack stack) {
         new SystemTestOptionalStacks(context.instance()).removeOptionalStack(stack);
+    }
+
+    public void disableOptionalStacks(OptionalStack... stacks) {
+        new SystemTestOptionalStacks(context.instance()).removeOptionalStacks(stacks);
     }
 
     public SystemTestStateStore stateStore() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
@@ -25,6 +25,7 @@ import sleeper.core.properties.validation.OptionalStack;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -55,6 +56,18 @@ public class SystemTestOptionalStacks {
     public void removeOptionalStack(OptionalStack stack) {
         LOGGER.info("Removing optional stack: {}", stack);
         updateOptionalStacks(stacks -> stacks.remove(stack));
+    }
+
+    public void addOptionalStacks(OptionalStack... stacks) {
+        List<OptionalStack> stacksList = List.of(stacks);
+        LOGGER.info("Adding optional stacks: {}", stacksList);
+        updateOptionalStacks(stacksSet -> stacksSet.addAll(stacksList));
+    }
+
+    public void removeOptionalStacks(OptionalStack... stacks) {
+        List<OptionalStack> stacksList = List.of(stacks);
+        LOGGER.info("Removing optional stacks: {}", stacksList);
+        updateOptionalStacks(stacksSet -> stacksSet.removeAll(stacksList));
     }
 
     private OptionalStack stack(Class<?> stackClass) {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestOptionalStacks.java
@@ -24,8 +24,8 @@ import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.validation.OptionalStack;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -58,16 +58,14 @@ public class SystemTestOptionalStacks {
         updateOptionalStacks(stacks -> stacks.remove(stack));
     }
 
-    public void addOptionalStacks(OptionalStack... stacks) {
-        List<OptionalStack> stacksList = List.of(stacks);
-        LOGGER.info("Adding optional stacks: {}", stacksList);
-        updateOptionalStacks(stacksSet -> stacksSet.addAll(stacksList));
+    public void addOptionalStacks(Collection<OptionalStack> stacks) {
+        LOGGER.info("Adding optional stacks: {}", stacks);
+        updateOptionalStacks(stacksSet -> stacksSet.addAll(stacks));
     }
 
-    public void removeOptionalStacks(OptionalStack... stacks) {
-        List<OptionalStack> stacksList = List.of(stacks);
-        LOGGER.info("Removing optional stacks: {}", stacksList);
-        updateOptionalStacks(stacksSet -> stacksSet.removeAll(stacksList));
+    public void removeOptionalStacks(Collection<OptionalStack> stacks) {
+        LOGGER.info("Removing optional stacks: {}", stacks);
+        updateOptionalStacks(stacksSet -> stacksSet.removeAll(stacks));
     }
 
     private OptionalStack stack(Class<?> stackClass) {

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
@@ -73,6 +73,7 @@ public class SystemTestInstance {
     public static final SystemTestInstanceConfiguration INGEST_PERFORMANCE = usingSystemTestDefaults("ingest", SystemTestInstance::buildIngestPerformanceConfiguration);
     public static final SystemTestInstanceConfiguration COMPACTION_PERFORMANCE = usingSystemTestDefaults("compact", SystemTestInstance::buildCompactionPerformanceConfiguration);
     public static final SystemTestInstanceConfiguration BULK_IMPORT_PERFORMANCE = usingSystemTestDefaults("emr", SystemTestInstance::buildBulkImportPerformanceConfiguration);
+    public static final SystemTestInstanceConfiguration REENABLE_OPTIONAL_STACKS = usingSystemTestDefaults("optstck", SystemTestInstance::buildMainConfiguration);
     public static final SystemTestInstanceConfiguration INGEST_NO_SOURCE_BUCKET = noSourceBucket("no-src", SystemTestInstance::buildMainConfiguration);
     public static final SystemTestInstanceConfiguration PARALLEL_COMPACTIONS = usingSystemTestDefaults("cpt-pll", SystemTestInstance::buildCompactionInParallelConfiguration);
     public static final SystemTestInstanceConfiguration COMPACTION_ON_EC2 = usingSystemTestDefaults("cpt-ec2", SystemTestInstance::buildCompactionOnEC2Configuration);

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/RedeployOptionalStacksST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/RedeployOptionalStacksST.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2024 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.suite;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import sleeper.core.properties.validation.OptionalStack;
+import sleeper.systemtest.dsl.SleeperSystemTest;
+import sleeper.systemtest.suite.testutil.Slow;
+import sleeper.systemtest.suite.testutil.SystemTest;
+
+import static sleeper.systemtest.suite.fixtures.SystemTestInstance.REENABLE_OPTIONAL_STACKS;
+
+@SystemTest
+// Slow because it needs to do many CDK deployments
+@Slow
+public class RedeployOptionalStacksST {
+
+    @BeforeEach
+    void setUp(SleeperSystemTest sleeper) {
+        sleeper.connectToInstance(REENABLE_OPTIONAL_STACKS);
+    }
+
+    @AfterEach
+    void tearDown(SleeperSystemTest sleeper) {
+        sleeper.disableOptionalStacks(OptionalStack.values());
+    }
+
+    @Test
+    void shouldDisableAndReenableAllOptionalStacks(SleeperSystemTest sleeper) {
+        sleeper.enableOptionalStacks(OptionalStack.values());
+        sleeper.disableOptionalStacks(OptionalStack.values());
+        sleeper.enableOptionalStacks(OptionalStack.values());
+    }
+
+}

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/RedeployOptionalStacksST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/RedeployOptionalStacksST.java
@@ -36,8 +36,9 @@ public class RedeployOptionalStacksST {
 
     private static final Set<OptionalStack> REDEPLOYABLE_STACKS = new LinkedHashSet<>(OptionalStack.all());
     static {
-        // We're currently unable to configure log groups related to an EKS cluster,
-        // so it fails to redeploy because those log groups already exist.
+        // We're currently unable to configure some of the log groups related to an EKS cluster, so it fails to redeploy
+        // because those log groups are retained and already exist. Here's the issue for this problem:
+        // https://github.com/gchq/sleeper/issues/3480 (Can't redeploy EKS bulk import optional stack)
         REDEPLOYABLE_STACKS.remove(OptionalStack.EksBulkImportStack);
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/RedeployOptionalStacksST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/RedeployOptionalStacksST.java
@@ -24,12 +24,22 @@ import sleeper.systemtest.dsl.SleeperSystemTest;
 import sleeper.systemtest.suite.testutil.Slow;
 import sleeper.systemtest.suite.testutil.SystemTest;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.REENABLE_OPTIONAL_STACKS;
 
 @SystemTest
 // Slow because it needs to do many CDK deployments
 @Slow
 public class RedeployOptionalStacksST {
+
+    private static final Set<OptionalStack> REDEPLOYABLE_STACKS = new LinkedHashSet<>(OptionalStack.all());
+    static {
+        // We're currently unable to configure log groups related to an EKS cluster,
+        // so it fails to redeploy because those log groups already exist.
+        REDEPLOYABLE_STACKS.remove(OptionalStack.EksBulkImportStack);
+    }
 
     @BeforeEach
     void setUp(SleeperSystemTest sleeper) {
@@ -38,14 +48,14 @@ public class RedeployOptionalStacksST {
 
     @AfterEach
     void tearDown(SleeperSystemTest sleeper) {
-        sleeper.disableOptionalStacks(OptionalStack.values());
+        sleeper.disableOptionalStacks(OptionalStack.all());
     }
 
     @Test
     void shouldDisableAndReenableAllOptionalStacks(SleeperSystemTest sleeper) {
-        sleeper.enableOptionalStacks(OptionalStack.values());
-        sleeper.disableOptionalStacks(OptionalStack.values());
-        sleeper.enableOptionalStacks(OptionalStack.values());
+        sleeper.enableOptionalStacks(REDEPLOYABLE_STACKS);
+        sleeper.disableOptionalStacks(OptionalStack.all());
+        sleeper.enableOptionalStacks(REDEPLOYABLE_STACKS);
     }
 
 }

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -82,7 +82,7 @@ sleeper.retain.infra.after.destroy=true
 # PersistentEmrBulkImportStack, EksBulkImportStack, EmrStudioStack, QueryStack, WebSocketQueryStack,
 # AthenaStack, KeepLambdaWarmStack, CompactionStack, GarbageCollectorStack, PartitionSplittingStack,
 # DashboardStack, TableMetricsStack]
-sleeper.optional.stacks=CompactionStack,GarbageCollectorStack,IngestStack,IngestBatcherStack,PartitionSplittingStack,QueryStack,AthenaStack,EmrServerlessBulkImportStack,EmrStudioStack,DashboardStack,TableMetricsStack
+sleeper.optional.stacks=IngestStack,IngestBatcherStack,EmrServerlessBulkImportStack,EmrStudioStack,QueryStack,AthenaStack,CompactionStack,GarbageCollectorStack,PartitionSplittingStack,DashboardStack,TableMetricsStack
 
 # Whether to check that the VPC that the instance is deployed to has an S3 endpoint. If there is no S3
 # endpoint then the NAT costs can be very significant.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3202

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - RedeployOptionalStacksST
    - Tested in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.