### PR TITLE
Issue 3486 - Disable EksBulkImportST if log retention is set

### DIFF
--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
@@ -18,6 +18,7 @@ package sleeper.systemtest.dsl.instance;
 
 import sleeper.core.properties.deploy.DeployInstanceConfiguration;
 import sleeper.core.properties.instance.InstanceProperties;
+import sleeper.core.properties.instance.InstanceProperty;
 import sleeper.core.properties.local.LoadLocalProperties;
 import sleeper.core.properties.table.TableProperties;
 import sleeper.core.schema.Schema;
@@ -200,6 +201,10 @@ public class SystemTestParameters {
         properties.set(SYSTEM_TEST_REPO, buildSystemTestECRRepoName());
         properties.set(SYSTEM_TEST_CLUSTER_ENABLED, String.valueOf(isSystemTestClusterEnabled()));
         return properties;
+    }
+
+    public boolean isInstancePropertyOverridden(InstanceProperty property) {
+        return instancePropertiesOverrides.isSet(property);
     }
 
     private static Path findScriptsDir() {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3486

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated EksBulkImportST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added, removed, or updated any external dependencies used in the project, I have updated the
  [NOTICES](/NOTICES) file to reflect this.