### PR TITLE
Issue 3524 - Temporarily disable dependency check plugin

### DIFF
--- a/.github/workflows/dependency-check.yaml
+++ b/.github/workflows/dependency-check.yaml
@@ -31,21 +31,25 @@ jobs:
       - name: Resolve dependencies
         run: mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -Dmaven.repo.local=${{ runner.temp }}/.m2/repository
         working-directory: ./java
-      - name: Update CVEs database
-        run: mvn --batch-mode dependency-check:update-only -Dmaven.repo.local=${{ runner.temp }}/.m2/repository
-        working-directory: ./java
-      - name: Build with Maven
-        run: mvn --batch-mode verify dependency-check:aggregate -Pquick -DskipRust -Dmaven.repo.local=${{ runner.temp }}/.m2/repository
-        working-directory: ./java
-      - name: Cache Maven dependencies & CVEs database
-        uses: actions/cache/save@v3
-        if: ${{ always() }}
-        with:
-          path: ${{ runner.temp }}/.m2/repository
-          key: ${{ steps.restore-cache.outputs.cache-primary-key }}
-      - name: Upload dependency check report
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: Dependency check report
-          path: java/target/dependency-check-report.html
+      - name: Explain disabled workflow
+        run: |
+          echo "Temporarily disabled checks as the NVD API is producing an unexpected value causing the plugin to fail."
+          echo "See the following issue: https://github.com/gchq/sleeper/issues/3525"
+      # - name: Update CVEs database
+      #   run: mvn --batch-mode dependency-check:update-only -Dmaven.repo.local=${{ runner.temp }}/.m2/repository
+      #   working-directory: ./java
+      # - name: Build with Maven
+      #   run: mvn --batch-mode verify dependency-check:aggregate -Pquick -DskipRust -Dmaven.repo.local=${{ runner.temp }}/.m2/repository
+      #   working-directory: ./java
+      # - name: Cache Maven dependencies & CVEs database
+      #   uses: actions/cache/save@v3
+      #   if: ${{ always() }}
+      #   with:
+      #     path: ${{ runner.temp }}/.m2/repository
+      #     key: ${{ steps.restore-cache.outputs.cache-primary-key }}
+      # - name: Upload dependency check report
+      #   if: ${{ always() }}
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: Dependency check report
+      #     path: java/target/dependency-check-report.html


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3524

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Workflow ran against PR

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.