### PR TITLE
Issue 3529 - Increase timeout for data generation in ParallelCompactionsST

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
@@ -72,7 +72,7 @@ public class ParallelCompactionsST {
                     properties.setNumber(NUMBER_OF_RECORDS_PER_INGEST, 1_000_000);
                 }).runDataGenerationTasks(
                         PollWithRetries.intervalAndPollingTimeout(
-                                Duration.ofSeconds(10), Duration.ofMinutes(5)))
+                                Duration.ofSeconds(10), Duration.ofMinutes(10)))
                 .waitForTotalFileReferences(81920);
 
         // When we run compaction


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3529

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated ParallelCompactionsST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.