### PR TITLE
Issue 3528 - Remove upper limit on committer throughput assertions

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterThroughputST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterThroughputST.java
@@ -282,17 +282,17 @@ public class StateStoreCommitterThroughputST {
 
     private static Consumer<Double> expectedCommitsPerSecondForTransactionLogOnly() {
         return commitsPerSecond -> assertThat(commitsPerSecond)
-                .isBetween(50.0, 200.0);
+                .isGreaterThan(50.0);
     }
 
     private static Consumer<Double> expectedCommitsPerSecondForTransactionLogAndStatusStore() {
         return commitsPerSecond -> assertThat(commitsPerSecond)
-                .isBetween(35.0, 80.0);
+                .isGreaterThan(35.0);
     }
 
     private static Consumer<Double> expectedCommitsPerSecondForTransactionLogAcrossTables() {
         return commitsPerSecond -> assertThat(commitsPerSecond)
-                .isBetween(20.0, 200.0);
+                .isGreaterThan(20.0);
     }
 
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3528

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated StateStoreCommitterThroughputST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.