### PR TITLE
Issue 3571 - Avoid conflicting nightly test names

### DIFF
--- a/java/cdk-environment/src/main/java/sleeper/environment/cdk/buildec2/BuildEC2Parameters.java
+++ b/java/cdk-environment/src/main/java/sleeper/environment/cdk/buildec2/BuildEC2Parameters.java
@@ -59,9 +59,9 @@ public class BuildEC2Parameters {
         nightlyTestEnabled = context.get(NIGHTLY_TEST_RUN_ENABLED);
         if (nightlyTestEnabled) {
             nightlyTestDeployId = context.get(NIGHTLY_TEST_DEPLOY_ID)
-                    .orElseThrow(() -> new IllegalArgumentException("Nightly test deploy ID must be set (up to 2 characters)"));
+                    .orElseThrow(() -> new IllegalArgumentException("nightlyTestDeployId must be set (up to 2 characters)"));
             if (nightlyTestDeployId.length() > 2) {
-                throw new IllegalArgumentException("Nightly test deploy ID must be at most 2 characters long");
+                throw new IllegalArgumentException("nightlyTestDeployId must be at most 2 characters long");
             }
             testHour = "" + context.get(NIGHTLY_TEST_RUN_HOUR_UTC);
             testBucket = context.get(NIGHTLY_TEST_BUCKET)

--- a/java/cdk-environment/src/main/java/sleeper/environment/cdk/config/AppParameters.java
+++ b/java/cdk-environment/src/main/java/sleeper/environment/cdk/config/AppParameters.java
@@ -39,6 +39,7 @@ public class AppParameters {
     public static final StringListParameter AUTO_SHUTDOWN_EXISTING_EC2_IDS = StringListParameter.key("autoShutdownExistingEc2Ids");
     public static final IntParameter AUTO_SHUTDOWN_HOUR_UTC = IntParameter.keyAndDefault("autoShutdownHourUtc", 19);
     public static final BooleanParameter NIGHTLY_TEST_RUN_ENABLED = BooleanParameter.keyAndDefault("nightlyTestsEnabled", false);
+    public static final OptionalStringParameter NIGHTLY_TEST_DEPLOY_ID = OptionalStringParameter.key("nightlyTestDeployId");
     public static final IntParameter NIGHTLY_TEST_RUN_HOUR_UTC = IntParameter.keyAndDefault("nightlyTestHourUtc", 3);
     public static final OptionalStringParameter NIGHTLY_TEST_BUCKET = OptionalStringParameter.key("nightlyTestBucket");
     public static final StringListParameter NIGHTLY_TEST_SUBNETS = StringListParameter.key("subnetIds");

--- a/java/cdk-environment/src/main/resources/nightlyTestSettings.json
+++ b/java/cdk-environment/src/main/resources/nightlyTestSettings.json
@@ -1,4 +1,5 @@
 {
+  "deployId": "${deployId}",
   "vpc": "${vpc}",
   "subnets": "${subnets}",
   "resultsBucket": "${testBucket}",

--- a/java/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/BuildEC2ParametersTest.java
+++ b/java/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/BuildEC2ParametersTest.java
@@ -126,7 +126,7 @@ public class BuildEC2ParametersTest {
 
         assertThatThrownBy(() -> BuildEC2Parameters.from(context))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nightly test deploy ID must be at most 2 characters long");
+                .hasMessage("nightlyTestDeployId must be at most 2 characters long");
     }
 
     @Test
@@ -140,6 +140,6 @@ public class BuildEC2ParametersTest {
 
         assertThatThrownBy(() -> BuildEC2Parameters.from(context))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nightly test deploy ID must be set (up to 2 characters)");
+                .hasMessage("nightlyTestDeployId must be set (up to 2 characters)");
     }
 }

--- a/java/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/BuildEC2ParametersTest.java
+++ b/java/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/BuildEC2ParametersTest.java
@@ -20,10 +20,12 @@ import org.junit.jupiter.api.Test;
 import sleeper.environment.cdk.config.AppContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.environment.cdk.buildec2.BuildEC2Image.LOGIN_USER;
 import static sleeper.environment.cdk.buildec2.BuildEC2Parameters.BRANCH;
 import static sleeper.environment.cdk.buildec2.BuildEC2Parameters.FORK;
 import static sleeper.environment.cdk.buildec2.BuildEC2Parameters.REPOSITORY;
+import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_DEPLOY_ID;
 import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_RUN_ENABLED;
 import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_SUBNETS;
 import static sleeper.environment.cdk.config.AppParameters.VPC_ID;
@@ -73,17 +75,20 @@ public class BuildEC2ParametersTest {
         assertThat(BuildEC2Parameters.builder()
                 .context(AppContext.of(
                         NIGHTLY_TEST_RUN_ENABLED.value(true),
+                        NIGHTLY_TEST_DEPLOY_ID.value("mt"),
                         VPC_ID.value("my-vpc"),
                         NIGHTLY_TEST_SUBNETS.value("subnet-1,subnet-2"),
                         FORK.value("my-fork"),
                         REPOSITORY.value("my-repo")))
                 .testBucket("nightly-test-results")
                 .build().fillUserDataTemplate("{" +
+                        "\"deployId\": \"${deployId}\"," +
                         "\"vpc\":\"${vpc}\"," +
                         "\"subnets\":\"${subnets}\"," +
                         "\"resultsBucket\":\"${testBucket}\"," +
                         "\"repoPath\":\"${fork}/${repository}\"}"))
                 .isEqualTo("{" +
+                        "\"deployId\": \"mt\"," +
                         "\"vpc\":\"my-vpc\"," +
                         "\"subnets\":\"subnet-1,subnet-2\"," +
                         "\"resultsBucket\":\"nightly-test-results\"," +
@@ -96,15 +101,45 @@ public class BuildEC2ParametersTest {
                 .context(AppContext.empty())
                 .testBucket(null)
                 .build().fillUserDataTemplate("{" +
+                        "\"deployId\": \"${deployId}\"," +
                         "\"vpc\":\"${vpc}\"," +
                         "\"subnets\":\"${subnets}\"," +
                         "\"resultsBucket\":\"${testBucket}\"," +
                         "\"repoPath\":\"${fork}/${repository}\"}"))
                 .isEqualTo("{" +
+                        "\"deployId\": \"${deployId}\"," +
                         "\"vpc\":\"${vpc}\"," +
                         "\"subnets\":\"${subnets}\"," +
                         "\"resultsBucket\":\"${testBucket}\"," +
                         "\"repoPath\":\"gchq/sleeper\"}");
     }
 
+    @Test
+    void shouldRefuseTooLongNightlyTestDeployId() {
+        AppContext context = AppContext.of(
+                NIGHTLY_TEST_RUN_ENABLED.value(true),
+                NIGHTLY_TEST_DEPLOY_ID.value("abc"),
+                VPC_ID.value("my-vpc"),
+                NIGHTLY_TEST_SUBNETS.value("subnet-1,subnet-2"),
+                FORK.value("my-fork"),
+                REPOSITORY.value("my-repo"));
+
+        assertThatThrownBy(() -> BuildEC2Parameters.from(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nightly test deploy ID must be at most 2 characters long");
+    }
+
+    @Test
+    void shouldRefuseNoNightlyTestDeployId() {
+        AppContext context = AppContext.of(
+                NIGHTLY_TEST_RUN_ENABLED.value(true),
+                VPC_ID.value("my-vpc"),
+                NIGHTLY_TEST_SUBNETS.value("subnet-1,subnet-2"),
+                FORK.value("my-fork"),
+                REPOSITORY.value("my-repo"));
+
+        assertThatThrownBy(() -> BuildEC2Parameters.from(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nightly test deploy ID must be set (up to 2 characters)");
+    }
 }

--- a/java/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/LoadUserDataUtilTest.java
+++ b/java/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/LoadUserDataUtilTest.java
@@ -25,6 +25,7 @@ import static sleeper.environment.cdk.buildec2.BuildEC2Parameters.BRANCH;
 import static sleeper.environment.cdk.buildec2.BuildEC2Parameters.FORK;
 import static sleeper.environment.cdk.buildec2.BuildEC2Parameters.REPOSITORY;
 import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_BUCKET;
+import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_DEPLOY_ID;
 import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_RUN_ENABLED;
 import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_RUN_HOUR_UTC;
 import static sleeper.environment.cdk.config.AppParameters.NIGHTLY_TEST_SUBNETS;
@@ -55,6 +56,7 @@ class LoadUserDataUtilTest {
                 FORK.value("a-fork"),
                 BRANCH.value("feature/something"),
                 NIGHTLY_TEST_RUN_ENABLED.value(true),
+                NIGHTLY_TEST_DEPLOY_ID.value("mt"),
                 VPC_ID.value("my-vpc"),
                 NIGHTLY_TEST_SUBNETS.value("subnet-1", "subnet-2"),
                 NIGHTLY_TEST_BUCKET.value("my-bucket")))))
@@ -70,11 +72,13 @@ class LoadUserDataUtilTest {
     void shouldLoadNightlyTestSettings() {
         assertThat(LoadUserDataUtil.nightlyTestSettingsJson(BuildEC2Parameters.from(AppContext.of(
                 NIGHTLY_TEST_RUN_ENABLED.value(true),
+                NIGHTLY_TEST_DEPLOY_ID.value("mt"),
                 VPC_ID.value("my-vpc"),
                 NIGHTLY_TEST_SUBNETS.value("subnet-1", "subnet-2"),
                 NIGHTLY_TEST_BUCKET.value("my-bucket"),
                 FORK.value("my-fork"),
                 REPOSITORY.value("my-repo")))))
+                .contains("\"deployId\": \"mt\"")
                 .contains("\"vpc\": \"my-vpc\"")
                 .contains("\"subnets\": \"subnet-1,subnet-2\"")
                 .contains("\"repoPath\": \"my-fork/my-repo\"")
@@ -85,6 +89,7 @@ class LoadUserDataUtilTest {
     void shouldLoadCrontab() {
         assertThat(LoadUserDataUtil.crontab(BuildEC2Parameters.from(AppContext.of(
                 NIGHTLY_TEST_RUN_ENABLED.value(true),
+                NIGHTLY_TEST_DEPLOY_ID.value("mt"),
                 NIGHTLY_TEST_RUN_HOUR_UTC.value(3),
                 LOGIN_USER.value("my-user"),
                 VPC_ID.value("my-vpc"),

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
@@ -34,6 +34,7 @@ public class SystemTestInstanceConfiguration {
         deployConfig = builder.deployConfig;
         useSystemTestIngestSourceBucket = builder.useSystemTestIngestSourceBucket;
         disableTransactionLogSnapshots = builder.disableTransactionLogSnapshots;
+        // Combines with SystemTestParameters.shortTestId to create an instance ID within maximum length
         if (shortName.length() > 7) {
             throw new IllegalArgumentException("Instance shortName must not be longer than 7 characters");
         }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
@@ -78,6 +78,7 @@ public class SystemTestParameters {
         forceStateStoreClassname = builder.forceStateStoreClassname;
         standalonePropertiesTemplate = Objects.requireNonNull(builder.standalonePropertiesTemplate, "standalonePropertiesTemplate must not be null");
         instancePropertiesOverrides = Objects.requireNonNull(builder.instancePropertiesOverrides, "instancePropertiesOverrides must not be null");
+        // Combines with SystemTestInstanceConfiguration.shortName to create an instance ID within maximum length
         if (shortTestId.length() > 13) {
             throw new IllegalArgumentException("shortTestId is too long, must be at most 13 characters: " + shortTestId);
         }

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
@@ -78,6 +78,9 @@ public class SystemTestParameters {
         forceStateStoreClassname = builder.forceStateStoreClassname;
         standalonePropertiesTemplate = Objects.requireNonNull(builder.standalonePropertiesTemplate, "standalonePropertiesTemplate must not be null");
         instancePropertiesOverrides = Objects.requireNonNull(builder.instancePropertiesOverrides, "instancePropertiesOverrides must not be null");
+        if (shortTestId.length() > 13) {
+            throw new IllegalArgumentException("shortTestId is too long, must be at most 13 characters: " + shortTestId);
+        }
     }
 
     public static Builder builder() {

--- a/scripts/cli/builder/Dockerfile
+++ b/scripts/cli/builder/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     python3-venv \
     zip \
     jq \
+    uuid-runtime \
     sudo \
     gcc g++ cmake make \
     pkg-config libssl-dev \

--- a/scripts/test/nightly/README.md
+++ b/scripts/test/nightly/README.md
@@ -29,7 +29,7 @@ cp /sleeper-builder/sleeper/scripts/test/nightly/nightlyTestSettings.json /sleep
 vim nightlyTestSettings.json
 ```
 
-You'll need to set a VPC, subnets, results S3 bucket and a path to your fork in GitHub.
+You'll need to set a deployment ID, a VPC, subnets, a results S3 bucket and a path to your fork in GitHub.
 
 #### Automatic merge to main
 

--- a/scripts/test/nightly/README.md
+++ b/scripts/test/nightly/README.md
@@ -29,7 +29,8 @@ cp /sleeper-builder/sleeper/scripts/test/nightly/nightlyTestSettings.json /sleep
 vim nightlyTestSettings.json
 ```
 
-You'll need to set a deployment ID, a VPC, subnets, a results S3 bucket and a path to your fork in GitHub.
+You'll need to set a deployment ID, a VPC, subnets, a results S3 bucket and a path to your fork in GitHub. The
+deployment ID is at most 2 characters, to avoid S3 naming conflicts between your deployment and any others.
 
 #### Automatic merge to main
 

--- a/scripts/test/nightly/nightlyTestSettings.json
+++ b/scripts/test/nightly/nightlyTestSettings.json
@@ -1,4 +1,5 @@
 {
+  "deployId": "my deployment ID (up to 2 characters to distinguish these tests from others running simultaneously)",
   "vpc": "my VPC ID",
   "subnets": "comma separated list of my subnet IDs",
   "resultsBucket": "S3 bucket name",

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -59,7 +59,10 @@ source "$SCRIPTS_DIR/functions/timeUtils.sh"
 source "$SCRIPTS_DIR/functions/systemTestUtils.sh"
 START_TIMESTAMP=$(record_time)
 START_TIME=$(recorded_time_str "$START_TIMESTAMP" "%Y%m%d-%H%M%S")
-START_TIME_SHORT=$(recorded_time_str "$START_TIMESTAMP" "%m%d%H%M")
+START_DAY=$(recorded_time_str "$START_TIMESTAMP" "%m%d")
+# Use randomness to avoid naming conflicts between test runs
+DAY_RUN_ID=$(uuidgen -r | head -c 4)
+TEST_RUN_ID="$START_DAY$DAY_RUN_ID"
 OUTPUT_DIR="/tmp/sleeper/${MAIN_SUITE_NAME}Tests/$START_TIME"
 
 mkdir -p "$OUTPUT_DIR"
@@ -109,8 +112,8 @@ runMavenSystemTests() {
     echo -n "$TEST_EXIT_CODE $SHORT_ID" > "$OUTPUT_DIR/$TEST_NAME.status"
 }
 
-runMavenSystemTests "mvn-$START_TIME_SHORT" $MAIN_SUITE_NAME "${MAIN_SUITE_PARAMS[@]}"
-runMavenSystemTests "dyn-$START_TIME_SHORT" $SECONDARY_SUITE_NAME "${SECONDARY_SUITE_PARAMS[@]}"
+runMavenSystemTests "mvn-$TEST_RUN_ID" $MAIN_SUITE_NAME "${MAIN_SUITE_PARAMS[@]}"
+runMavenSystemTests "dyn-$TEST_RUN_ID" $SECONDARY_SUITE_NAME "${SECONDARY_SUITE_PARAMS[@]}"
 
 echo "[$(time_str)] Uploading test output"
 java -cp "${SYSTEM_TEST_JAR}" \

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -62,7 +62,7 @@ START_TIME=$(recorded_time_str "$START_TIMESTAMP" "%Y%m%d-%H%M%S")
 START_DAY=$(recorded_time_str "$START_TIMESTAMP" "%m%d")
 # Use randomness to avoid naming conflicts between test runs
 DAY_RUN_ID=$(uuidgen -r | head -c 4)
-TEST_RUN_ID="$START_DAY$DAY_RUN_ID"
+TEST_RUN_ID="$START_DAY-$DAY_RUN_ID"
 OUTPUT_DIR="/tmp/sleeper/${MAIN_SUITE_NAME}Tests/$START_TIME"
 
 mkdir -p "$OUTPUT_DIR"

--- a/scripts/test/nightly/updateAndRunTests.sh
+++ b/scripts/test/nightly/updateAndRunTests.sh
@@ -28,6 +28,7 @@ fi
 SETTINGS_FILE=$1
 TEST_TYPE=$2
 
+DEPLOY_ID=$(jq ".deployId" "$SETTINGS_FILE" --raw-output)
 VPC=$(jq ".vpc" "$SETTINGS_FILE" --raw-output)
 SUBNETS=$(jq ".subnets" "$SETTINGS_FILE" --raw-output)
 RESULTS_BUCKET=$(jq ".resultsBucket" "$SETTINGS_FILE" --raw-output)
@@ -41,7 +42,7 @@ git fetch
 git switch --discard-changes -C develop origin/develop
 
 set +e
-./runTests.sh "$VPC" "$SUBNETS" "$RESULTS_BUCKET" "$TEST_TYPE"
+./runTests.sh "$DEPLOY_ID" "$VPC" "$SUBNETS" "$RESULTS_BUCKET" "$TEST_TYPE"
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3571

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Tested bash code manually
    - Updated BuildEC2ParametersTest, LoadUserDataUtilTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.