### PR TITLE
Issue 3554 - Make compaction task file assignment wait optional

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -924,7 +924,7 @@ sleeper.compaction.task.wait.time.seconds=20
 # This prevents invalid compaction jobs from being run, particularly in the case where the compaction
 # job creator runs again before the input files are assigned. This causes compaction tasks to wait
 # idle while input files are assigned, and puts extra load on the state store.
-# If this is false, any created job will be executed, and will only be validated when committed tothe
+# If this is false, any created job will be executed, and will only be validated when committed to the
 # state store.
 sleeper.compaction.task.wait.for.input.file.assignment=false
 

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -922,8 +922,9 @@ sleeper.compaction.task.wait.time.seconds=20
 # before starting it. The compaction task will poll the state store for whether the input files have
 # been assigned to the job, and will only start once this has occurred.
 # This prevents invalid compaction jobs from being run, particularly in the case where the compaction
-# job creator runs again before the input files are assigned. This causes compaction tasks to wait
-# idle while input files are assigned, and puts extra load on the state store.
+# job creator runs again before the input files are assigned.
+# This also causes compaction tasks to wait idle while input files are assigned, and puts extra load
+# on the state store when there are many compaction tasks.
 # If this is false, any created job will be executed, and will only be validated when committed to the
 # state store.
 sleeper.compaction.task.wait.for.input.file.assignment=false

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -918,6 +918,16 @@ sleeper.compaction.job.failed.visibility.timeout.seconds=60
 # messages in the time defined by this property, it will try to wait for a message again.
 sleeper.compaction.task.wait.time.seconds=20
 
+# Set to true if compaction tasks should wait for input files to be assigned to a compaction job
+# before starting it. The compaction task will poll the state store for whether the input files have
+# been assigned to the job, and will only start once this has occurred.
+# This prevents invalid compaction jobs from being run, particularly in the case where the compaction
+# job creator runs again before the input files are assigned. This causes compaction tasks to wait
+# idle while input files are assigned, and puts extra load on the state store.
+# If this is false, any created job will be executed, and will only be validated when committed tothe
+# state store.
+sleeper.compaction.task.wait.for.input.file.assignment=false
+
 # The time in seconds for a compaction task to wait after receiving no compaction jobs before
 # attempting to receive a message again.
 # When a compaction task waits for compaction jobs to appear on the SQS queue, if the task receives no

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskAssignFilesTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskAssignFilesTest.java
@@ -19,8 +19,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import sleeper.compaction.job.CompactionJob;
+import sleeper.compaction.job.commit.CompactionJobCommitRequest;
 import sleeper.core.record.process.ProcessRunTime;
+import sleeper.core.record.process.RecordsProcessed;
+import sleeper.core.record.process.RecordsProcessedSummary;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,8 +33,10 @@ import java.util.Queue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.compaction.job.CompactionJobStatusTestData.failedCompactionRun;
 import static sleeper.compaction.job.CompactionJobStatusTestData.jobCreated;
+import static sleeper.compaction.job.CompactionJobStatusTestData.uncommittedCompactionRun;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT;
 import static sleeper.core.properties.table.TableProperty.STATESTORE_ASYNC_COMMITS_ENABLED;
+import static sleeper.core.record.process.RecordsProcessedSummaryTestHelper.summary;
 
 public class CompactionTaskAssignFilesTest extends CompactionTaskTestBase {
 
@@ -147,5 +153,33 @@ public class CompactionTaskAssignFilesTest extends CompactionTaskTestBase {
                                 Instant.parse("2024-10-28T11:53:00Z"),
                                 List.of("1 replace file reference requests failed to update the state store",
                                         "File not found: " + job.getInputFiles().get(0)))));
+    }
+
+    @Test
+    void shouldSendInvalidCommitToQueueWhenFileAssignmentCheckDisabledWithAsyncCommit() throws Exception {
+        // Given
+        instanceProperties.set(COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT, "false");
+        tableProperties.set(STATESTORE_ASYNC_COMMITS_ENABLED, "true");
+        CompactionJob job = createJob("test-job");
+        send(job);
+        stateStore.clearFileData();
+
+        // When
+        runTaskCheckingFiles(
+                waitForFileAssignment(timePassesAMinuteAtATimeFrom(Instant.parse("2024-10-28T11:45:00Z"))).withAttempts(10),
+                processJobs(jobSucceeds(new RecordsProcessed(10L, 5L))),
+                timePassesAMinuteAtATimeFrom(Instant.parse("2024-10-28T11:50:00Z")));
+
+        // Then
+        RecordsProcessedSummary expectedSummary = summary(
+                Instant.parse("2024-10-28T11:51:00Z"), Duration.ofMinutes(1), 10, 5);
+        assertThat(failedJobs).isEmpty();
+        assertThat(jobsOnQueue).isEmpty();
+        assertThat(foundWaitsForFileAssignment).isEmpty();
+        assertThat(jobStore.getAllJobs(DEFAULT_TABLE_ID)).containsExactly(
+                jobCreated(job, DEFAULT_CREATED_TIME,
+                        uncommittedCompactionRun(DEFAULT_TASK_ID, expectedSummary)));
+        assertThat(commitRequestsOnQueue).containsExactly(
+                new CompactionJobCommitRequest(job, DEFAULT_TASK_ID, "test-job-run-1", expectedSummary));
     }
 }

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskAssignFilesTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskAssignFilesTest.java
@@ -15,6 +15,7 @@
  */
 package sleeper.compaction.task;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import sleeper.compaction.job.CompactionJob;
@@ -28,8 +29,15 @@ import java.util.Queue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.compaction.job.CompactionJobStatusTestData.failedCompactionRun;
 import static sleeper.compaction.job.CompactionJobStatusTestData.jobCreated;
+import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT;
+import static sleeper.core.properties.table.TableProperty.STATESTORE_ASYNC_COMMITS_ENABLED;
 
 public class CompactionTaskAssignFilesTest extends CompactionTaskTestBase {
+
+    @BeforeEach
+    void setUp() {
+        instanceProperties.set(COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT, "true");
+    }
 
     @Test
     void shouldRetryOnceWaitingForFilesToBeAssignedToJob() throws Exception {
@@ -110,5 +118,34 @@ public class CompactionTaskAssignFilesTest extends CompactionTaskTestBase {
                 jobCreated(job, DEFAULT_CREATED_TIME,
                         failedCompactionRun(DEFAULT_TASK_ID, new ProcessRunTime(waitForFilesTime, failTime), List.of(
                                 "File reference not found in partition root, filename " + job.getInputFiles().get(0)))));
+    }
+
+    @Test
+    void shouldFailAtEndWhenFileAssignmentCheckDisabledWithDirectCommit() throws Exception {
+        // Given
+        instanceProperties.set(COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT, "false");
+        tableProperties.set(STATESTORE_ASYNC_COMMITS_ENABLED, "false");
+        CompactionJob job = createJob("test-job");
+        send(job);
+        stateStore.clearFileData();
+
+        // When
+        runTaskCheckingFiles(
+                waitForFileAssignment(timePassesAMinuteAtATimeFrom(Instant.parse("2024-10-28T11:45:00Z"))).withAttempts(10),
+                processJobs(jobSucceeds()),
+                timePassesAMinuteAtATimeFrom(Instant.parse("2024-10-28T11:50:00Z")));
+
+        // Then
+        assertThat(failedJobs).containsExactly(job);
+        assertThat(jobsOnQueue).isEmpty();
+        assertThat(foundWaitsForFileAssignment).isEmpty();
+        assertThat(jobStore.getAllJobs(DEFAULT_TABLE_ID)).containsExactly(
+                jobCreated(job, DEFAULT_CREATED_TIME,
+                        failedCompactionRun(DEFAULT_TASK_ID,
+                                Instant.parse("2024-10-28T11:51:00Z"),
+                                Instant.parse("2024-10-28T11:52:00Z"),
+                                Instant.parse("2024-10-28T11:53:00Z"),
+                                List.of("1 replace file reference requests failed to update the state store",
+                                        "File not found: " + job.getInputFiles().get(0)))));
     }
 }

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTestBase.java
@@ -125,7 +125,11 @@ public class CompactionTaskTestBase {
     }
 
     protected void runTaskCheckingFiles(StateStoreWaitForFiles fileAssignmentCheck, CompactionRunner compactor) throws Exception {
-        runTask(pollQueue(), fileAssignmentCheck, compactor, timePassesAMinuteAtATime(), DEFAULT_TASK_ID, jobRunIdsInSequence());
+        runTaskCheckingFiles(fileAssignmentCheck, compactor, timePassesAMinuteAtATime());
+    }
+
+    protected void runTaskCheckingFiles(StateStoreWaitForFiles fileAssignmentCheck, CompactionRunner compactor, Supplier<Instant> timeSupplier) throws Exception {
+        runTask(pollQueue(), fileAssignmentCheck, compactor, timeSupplier, DEFAULT_TASK_ID, jobRunIdsInSequence());
     }
 
     protected void runTask(
@@ -327,7 +331,11 @@ public class CompactionTaskTestBase {
     }
 
     private Supplier<Instant> timePassesAMinuteAtATime() {
-        return Stream.iterate(Instant.parse("2024-09-04T09:50:00Z"),
+        return timePassesAMinuteAtATimeFrom(Instant.parse("2024-09-04T09:50:00Z"));
+    }
+
+    protected Supplier<Instant> timePassesAMinuteAtATimeFrom(Instant firstTime) {
+        return Stream.iterate(firstTime,
                 time -> time.plus(Duration.ofMinutes(1)))
                 .iterator()::next;
     }

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -81,8 +81,9 @@ public interface CompactionProperty {
                     "job before starting it. The compaction task will poll the state store for whether the input " +
                     "files have been assigned to the job, and will only start once this has occurred.\n" +
                     "This prevents invalid compaction jobs from being run, particularly in the case where the " +
-                    "compaction job creator runs again before the input files are assigned. This causes compaction " +
-                    "tasks to wait idle while input files are assigned, and puts extra load on the state store.\n" +
+                    "compaction job creator runs again before the input files are assigned.\n" +
+                    "This also causes compaction tasks to wait idle while input files are assigned, and puts extra " +
+                    "load on the state store when there are many compaction tasks.\n" +
                     "If this is false, any created job will be executed, and will only be validated when committed " +
                     "to the state store.")
             .defaultValue("false")

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -76,6 +76,18 @@ public interface CompactionProperty {
             .defaultValue("20")
             .validationPredicate(val -> SleeperPropertyValueUtils.isNonNegativeIntLtEqValue(val, 20))
             .propertyGroup(InstancePropertyGroup.COMPACTION).build();
+    UserDefinedInstanceProperty COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT = Index.propertyBuilder("sleeper.compaction.task.wait.for.input.file.assignment")
+            .description("Set to true if compaction tasks should wait for input files to be assigned to a compaction " +
+                    "job before starting it. The compaction task will poll the state store for whether the input " +
+                    "files have been assigned to the job, and will only start once this has occurred.\n" +
+                    "This prevents invalid compaction jobs from being run, particularly in the case where the " +
+                    "compaction job creator runs again before the input files are assigned. This causes compaction " +
+                    "tasks to wait idle while input files are assigned, and puts extra load on the state store.\n" +
+                    "If this is false, any created job will be executed, and will only be validated when committed to" +
+                    "the state store.")
+            .defaultValue("false")
+            .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)
+            .propertyGroup(InstancePropertyGroup.COMPACTION).build();
     UserDefinedInstanceProperty COMPACTION_TASK_DELAY_BEFORE_RETRY_IN_SECONDS = Index.propertyBuilder("sleeper.compaction.task.delay.before.retry.seconds")
             .description("The time in seconds for a compaction task to wait after receiving no compaction jobs " +
                     "before attempting to receive a message again.\n" +

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -83,8 +83,8 @@ public interface CompactionProperty {
                     "This prevents invalid compaction jobs from being run, particularly in the case where the " +
                     "compaction job creator runs again before the input files are assigned. This causes compaction " +
                     "tasks to wait idle while input files are assigned, and puts extra load on the state store.\n" +
-                    "If this is false, any created job will be executed, and will only be validated when committed to" +
-                    "the state store.")
+                    "If this is false, any created job will be executed, and will only be validated when committed " +
+                    "to the state store.")
             .defaultValue("false")
             .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)
             .propertyGroup(InstancePropertyGroup.COMPACTION).build();

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -946,8 +946,9 @@ sleeper.compaction.task.wait.time.seconds=20
 # before starting it. The compaction task will poll the state store for whether the input files have
 # been assigned to the job, and will only start once this has occurred.
 # This prevents invalid compaction jobs from being run, particularly in the case where the compaction
-# job creator runs again before the input files are assigned. This causes compaction tasks to wait
-# idle while input files are assigned, and puts extra load on the state store.
+# job creator runs again before the input files are assigned.
+# This also causes compaction tasks to wait idle while input files are assigned, and puts extra load
+# on the state store when there are many compaction tasks.
 # If this is false, any created job will be executed, and will only be validated when committed to the
 # state store.
 sleeper.compaction.task.wait.for.input.file.assignment=false

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -942,6 +942,16 @@ sleeper.compaction.job.failed.visibility.timeout.seconds=60
 # messages in the time defined by this property, it will try to wait for a message again.
 sleeper.compaction.task.wait.time.seconds=20
 
+# Set to true if compaction tasks should wait for input files to be assigned to a compaction job
+# before starting it. The compaction task will poll the state store for whether the input files have
+# been assigned to the job, and will only start once this has occurred.
+# This prevents invalid compaction jobs from being run, particularly in the case where the compaction
+# job creator runs again before the input files are assigned. This causes compaction tasks to wait
+# idle while input files are assigned, and puts extra load on the state store.
+# If this is false, any created job will be executed, and will only be validated when committed tothe
+# state store.
+sleeper.compaction.task.wait.for.input.file.assignment=false
+
 # The time in seconds for a compaction task to wait after receiving no compaction jobs before
 # attempting to receive a message again.
 # When a compaction task waits for compaction jobs to appear on the SQS queue, if the task receives no

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -948,7 +948,7 @@ sleeper.compaction.task.wait.time.seconds=20
 # This prevents invalid compaction jobs from being run, particularly in the case where the compaction
 # job creator runs again before the input files are assigned. This causes compaction tasks to wait
 # idle while input files are assigned, and puts extra load on the state store.
-# If this is false, any created job will be executed, and will only be validated when committed tothe
+# If this is false, any created job will be executed, and will only be validated when committed to the
 # state store.
 sleeper.compaction.task.wait.for.input.file.assignment=false
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3554

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated CompactionTaskAssignFilesTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.