### PR TITLE
Issue 3550 - Allow no writers in deployAll system test

### DIFF
--- a/java/common/common-task/src/main/java/sleeper/task/common/RunECSTasks.java
+++ b/java/common/common-task/src/main/java/sleeper/task/common/RunECSTasks.java
@@ -96,7 +96,7 @@ public class RunECSTasks {
         LOGGER.info("Creating {} tasks", numberOfTasksToCreate);
         try {
             int remainingTasks = numberOfTasksToCreate;
-            while (true) {
+            while (remainingTasks > 0) {
 
                 try {
                     remainingTasks = retryTaskUntilCapacityAvailable(remainingTasks);

--- a/java/common/common-task/src/test/java/sleeper/task/common/RunECSTasksIT.java
+++ b/java/common/common-task/src/test/java/sleeper/task/common/RunECSTasksIT.java
@@ -148,6 +148,15 @@ class RunECSTasksIT {
                     .extracting(RunTaskResponse::tasks, RunTaskResponse::failures)
                     .containsExactly(tuple(List.of(), List.of()));
         }
+
+        @Test
+        void shouldRunNoTasks() {
+            runTasksOrThrow(runTasks -> runTasks
+                    .runTaskRequest(request -> request.cluster("test-cluster"))
+                    .numberOfTasksToCreate(0));
+
+            verify(0, anyRequest());
+        }
     }
 
     @Nested

--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
@@ -109,13 +109,13 @@ public interface SystemTestProperty extends InstanceProperty {
             .build();
     SystemTestProperty NUMBER_OF_WRITERS = Index.propertyBuilder("sleeper.systemtest.writers")
             .description("The number of containers that write random data")
-            .defaultValue("1").validationPredicate(SleeperPropertyValueUtils::isPositiveInteger).build();
+            .defaultValue("1").validationPredicate(SleeperPropertyValueUtils::isNonNegativeInteger).build();
     SystemTestProperty NUMBER_OF_INGESTS_PER_WRITER = Index.propertyBuilder("sleeper.systemtest.ingests.per.writer")
             .description("The number of ingests to run for each writer")
-            .defaultValue("1").validationPredicate(SleeperPropertyValueUtils::isPositiveInteger).build();
+            .defaultValue("1").validationPredicate(SleeperPropertyValueUtils::isNonNegativeInteger).build();
     SystemTestProperty NUMBER_OF_RECORDS_PER_INGEST = Index.propertyBuilder("sleeper.systemtest.records.per.ingest")
             .description("The number of random records that each ingest should write")
-            .defaultValue("100").validationPredicate(SleeperPropertyValueUtils::isPositiveInteger).build();
+            .defaultValue("100").validationPredicate(SleeperPropertyValueUtils::isNonNegativeInteger).build();
     SystemTestProperty MIN_RANDOM_INT = Index.propertyBuilder("sleeper.systemtest.random.int.min")
             .description("The minimum value of integers generated randomly during random record generation")
             .defaultValue("0").validationPredicate(SleeperPropertyValueUtils::isInteger).build();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3550

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated RunECSTasksIT
    - Tested in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.