### PR TITLE
Issue 3601 - Make nightly test instance IDs short enough

### DIFF
--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
@@ -33,7 +33,8 @@ import static sleeper.core.properties.validation.SleeperPropertyValueUtils.descr
 public interface SystemTestProperty extends InstanceProperty {
     int SYSTEM_TEST_ID_MAX_LEN = 13;
     SystemTestProperty SYSTEM_TEST_ID = Index.propertyBuilder("sleeper.systemtest.standalone.id")
-            .description("The id of the deployment, if deploying standalone.")
+            .description("The id of the deployment, if deploying standalone. This is also used as a base to generate " +
+                    "Sleeper instance IDs, so must be short enough to leave room to define multiple instances.")
             .validationPredicate(value -> value == null || value.length() <= SYSTEM_TEST_ID_MAX_LEN)
             .editable(false).build();
     SystemTestProperty SYSTEM_TEST_ACCOUNT = Index.propertyBuilder("sleeper.systemtest.standalone.account")

--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestProperty.java
@@ -31,9 +31,10 @@ import static sleeper.core.properties.validation.SleeperPropertyValueUtils.descr
 // Suppress as this class will always be referenced before impl class, so initialization behaviour will be deterministic
 @SuppressFBWarnings("IC_SUPERCLASS_USES_SUBCLASS_DURING_INITIALIZATION")
 public interface SystemTestProperty extends InstanceProperty {
+    int SYSTEM_TEST_ID_MAX_LEN = 13;
     SystemTestProperty SYSTEM_TEST_ID = Index.propertyBuilder("sleeper.systemtest.standalone.id")
             .description("The id of the deployment, if deploying standalone.")
-            .validationPredicate(value -> value == null || value.length() <= 12)
+            .validationPredicate(value -> value == null || value.length() <= SYSTEM_TEST_ID_MAX_LEN)
             .editable(false).build();
     SystemTestProperty SYSTEM_TEST_ACCOUNT = Index.propertyBuilder("sleeper.systemtest.standalone.account")
             .description("The AWS account when deploying standalone.")

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/testutil/LocalStackTestInstance.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/testutil/LocalStackTestInstance.java
@@ -47,8 +47,8 @@ public class LocalStackTestInstance {
             .build();
 
     public static final SystemTestInstanceConfiguration MAIN = usingSystemTestDefaults("main", LocalStackTestInstance::buildMainConfiguration);
-    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE = usingSystemTestDefaults("prdftbl", LocalStackTestInstance::buildPredefinedTableConfiguration);
-    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE_NO_NAME = usingSystemTestDefaults("prdftnn", LocalStackTestInstance::buildPredefinedTableConfigurationNoName);
+    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE = usingSystemTestDefaults("prdtbl", LocalStackTestInstance::buildPredefinedTableConfiguration);
+    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE_NO_NAME = usingSystemTestDefaults("prdtnn", LocalStackTestInstance::buildPredefinedTableConfigurationNoName);
 
     private static DeployInstanceConfiguration buildMainConfiguration() {
         return buildConfigurationWithTableProperties(properties -> properties.set(TABLE_NAME, "system-test"));

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
@@ -34,9 +34,9 @@ public class SystemTestInstanceConfiguration {
         deployConfig = builder.deployConfig;
         useSystemTestIngestSourceBucket = builder.useSystemTestIngestSourceBucket;
         disableTransactionLogSnapshots = builder.disableTransactionLogSnapshots;
-        // Combines with SystemTestParameters.shortTestId to create an instance ID within maximum length
-        if (shortName.length() > 7) {
-            throw new IllegalArgumentException("Instance shortName must not be longer than 7 characters");
+        // Combines with SystemTestParameters.shortTestId and a hyphen to create an instance ID within maximum length
+        if (shortName.length() > 6) {
+            throw new IllegalArgumentException("Instance shortName must not be longer than 6 characters");
         }
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
@@ -22,6 +22,7 @@ import sleeper.core.properties.instance.InstanceProperty;
 import sleeper.core.properties.local.LoadLocalProperties;
 import sleeper.core.properties.table.TableProperties;
 import sleeper.core.schema.Schema;
+import sleeper.systemtest.configuration.SystemTestProperty;
 import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
 
 import java.nio.file.Path;
@@ -40,6 +41,7 @@ import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_AC
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_CLUSTER_ENABLED;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_ECS_SECURITY_GROUPS;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_ID;
+import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_ID_MAX_LEN;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_JARS_BUCKET;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_LOG_RETENTION_DAYS;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_REGION;
@@ -79,8 +81,8 @@ public class SystemTestParameters {
         standalonePropertiesTemplate = Objects.requireNonNull(builder.standalonePropertiesTemplate, "standalonePropertiesTemplate must not be null");
         instancePropertiesOverrides = Objects.requireNonNull(builder.instancePropertiesOverrides, "instancePropertiesOverrides must not be null");
         // Combines with SystemTestInstanceConfiguration.shortName to create an instance ID within maximum length
-        if (shortTestId.length() > 13) {
-            throw new IllegalArgumentException("shortTestId is too long, must be at most 13 characters: " + shortTestId);
+        if (!SystemTestProperty.SYSTEM_TEST_ID.getValidationPredicate().test(shortTestId)) {
+            throw new IllegalArgumentException("shortTestId is not valid, must be at most " + SYSTEM_TEST_ID_MAX_LEN + " characters: " + shortTestId);
         }
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestParameters.java
@@ -80,7 +80,7 @@ public class SystemTestParameters {
         forceStateStoreClassname = builder.forceStateStoreClassname;
         standalonePropertiesTemplate = Objects.requireNonNull(builder.standalonePropertiesTemplate, "standalonePropertiesTemplate must not be null");
         instancePropertiesOverrides = Objects.requireNonNull(builder.instancePropertiesOverrides, "instancePropertiesOverrides must not be null");
-        // Combines with SystemTestInstanceConfiguration.shortName to create an instance ID within maximum length
+        // Combines with SystemTestInstanceConfiguration.shortName and a hyphen to create an instance ID within maximum length
         if (!SystemTestProperty.SYSTEM_TEST_ID.getValidationPredicate().test(shortTestId)) {
             throw new IllegalArgumentException("shortTestId is not valid, must be at most " + SYSTEM_TEST_ID_MAX_LEN + " characters: " + shortTestId);
         }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/gc/GarbageCollectionTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/gc/GarbageCollectionTest.java
@@ -35,14 +35,14 @@ import static sleeper.core.properties.table.TableProperty.COMPACTION_FILES_BATCH
 import static sleeper.core.properties.table.TableProperty.COMPACTION_STRATEGY_CLASS;
 import static sleeper.core.properties.table.TableProperty.GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.core.testutils.printers.FileReferencePrinter.printFiles;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.withDefaultProperties;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.MAIN;
 
 @InMemoryDslTest
 public class GarbageCollectionTest {
 
     @BeforeEach
     void setUp(SleeperSystemTest sleeper, AfterTestReports reporting, AfterTestPurgeQueues purgeQueues) {
-        sleeper.connectToInstance(withDefaultProperties("main"));
+        sleeper.connectToInstance(MAIN);
     }
 
     @Test

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/MultipleTablesTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/MultipleTablesTest.java
@@ -39,8 +39,8 @@ import static sleeper.systemtest.dsl.sourcedata.GenerateNumberedValue.addPrefix;
 import static sleeper.systemtest.dsl.sourcedata.GenerateNumberedValue.numberStringAndZeroPadTo;
 import static sleeper.systemtest.dsl.sourcedata.GenerateNumberedValueOverrides.overrideField;
 import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.DEFAULT_SCHEMA;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.MAIN;
 import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.ROW_KEY_FIELD_NAME;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.withDefaultProperties;
 import static sleeper.systemtest.dsl.testutil.SystemTestTableMetricsHelper.tableMetrics;
 
 @InMemoryDslTest
@@ -50,7 +50,7 @@ public class MultipleTablesTest {
 
     @BeforeEach
     void setUp(SleeperSystemTest sleeper) {
-        sleeper.connectToInstanceNoTables(withDefaultProperties("main"));
+        sleeper.connectToInstanceNoTables(MAIN);
     }
 
     @Test

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/SetupInstanceTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/SetupInstanceTest.java
@@ -27,13 +27,13 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.core.properties.instance.CommonProperty.RETAIN_INFRA_AFTER_DESTROY;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.withDefaultProperties;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.MAIN;
 
 @InMemoryDslTest
 public class SetupInstanceTest {
     @BeforeEach
     void setUp(SleeperSystemTest sleeper) {
-        sleeper.connectToInstance(withDefaultProperties("main"));
+        sleeper.connectToInstance(MAIN);
     }
 
     @Test

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/SleeperInstanceTablesTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/instance/SleeperInstanceTablesTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import sleeper.core.deploy.DeployInstanceConfiguration;
 import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
 import sleeper.core.properties.SleeperPropertiesInvalidException;
@@ -45,11 +44,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.properties.table.TableProperty.TABLE_NAME;
 import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.core.schema.SchemaTestHelper.schemaWithKey;
-import static sleeper.systemtest.dsl.instance.SystemTestInstanceConfiguration.usingSystemTestDefaults;
 import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.DEFAULT_SCHEMA;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.createDslInstanceProperties;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.createDslTableProperties;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.withDefaultProperties;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.MAIN;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.PREDEFINED_TABLE;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.PREDEFINED_TABLE_NO_NAME;
 
 @InMemoryDslTest
 public class SleeperInstanceTablesTest {
@@ -59,7 +57,7 @@ public class SleeperInstanceTablesTest {
     class DefineNamedTables {
         @BeforeEach
         void setUp(SleeperSystemTest sleeper) {
-            sleeper.connectToInstanceNoTables(withDefaultProperties("main"));
+            sleeper.connectToInstanceNoTables(MAIN);
         }
 
         @Test
@@ -114,7 +112,7 @@ public class SleeperInstanceTablesTest {
     class InspectAllTables {
         @BeforeEach
         void setUp(SleeperSystemTest sleeper) {
-            sleeper.connectToInstanceNoTables(withDefaultProperties("main"));
+            sleeper.connectToInstanceNoTables(MAIN);
         }
 
         @Test
@@ -183,7 +181,7 @@ public class SleeperInstanceTablesTest {
         @Test
         void shouldGenerateNameForTableDefinedInTest(SleeperSystemTest sleeper) {
             // Given
-            sleeper.connectToInstanceNoTables(withDefaultProperties("main"));
+            sleeper.connectToInstanceNoTables(MAIN);
 
             // When
             sleeper.tables().create("A", DEFAULT_SCHEMA);
@@ -197,12 +195,7 @@ public class SleeperInstanceTablesTest {
         @Test
         void shouldGenerateNameForPredefinedTable(SleeperSystemTest sleeper) {
             // When
-            sleeper.connectToInstance(usingSystemTestDefaults("prdftbl", () -> {
-                InstanceProperties instanceProperties = createDslInstanceProperties();
-                TableProperties tableProperties = createDslTableProperties(instanceProperties);
-                tableProperties.set(TABLE_NAME, "predefined-test-table");
-                return new DeployInstanceConfiguration(instanceProperties, tableProperties);
-            }));
+            sleeper.connectToInstance(PREDEFINED_TABLE);
 
             // Then
             assertThat(sleeper.tableProperties().get(TABLE_NAME))
@@ -212,16 +205,8 @@ public class SleeperInstanceTablesTest {
 
         @Test
         void shouldRefusePredefinedTableWithNoName(SleeperSystemTest sleeper) {
-            // Given
-            SystemTestInstanceConfiguration configuration = usingSystemTestDefaults("nonmtbl", () -> {
-                InstanceProperties instanceProperties = createDslInstanceProperties();
-                TableProperties tableProperties = createDslTableProperties(instanceProperties);
-                tableProperties.unset(TABLE_NAME);
-                return new DeployInstanceConfiguration(instanceProperties, tableProperties);
-            });
-
             // When / Then
-            assertThatThrownBy(() -> sleeper.connectToInstance(configuration))
+            assertThatThrownBy(() -> sleeper.connectToInstance(PREDEFINED_TABLE_NO_NAME))
                     .isInstanceOf(SleeperPropertiesInvalidException.class);
         }
     }
@@ -240,7 +225,7 @@ public class SleeperInstanceTablesTest {
         @Test
         void shouldFailToIngestWhenNoTableChosen(SleeperSystemTest sleeper) {
             // Given
-            sleeper.connectToInstanceNoTables(withDefaultProperties("main"));
+            sleeper.connectToInstanceNoTables(MAIN);
             var ingest = sleeper.ingest().direct(null);
 
             // When / Then

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/partitioning/PartitionSplittingTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/partitioning/PartitionSplittingTest.java
@@ -35,15 +35,15 @@ import static sleeper.core.testutils.printers.PartitionsPrinter.printPartitions;
 import static sleeper.systemtest.dsl.sourcedata.GenerateNumberedValue.addPrefix;
 import static sleeper.systemtest.dsl.sourcedata.GenerateNumberedValue.numberStringAndZeroPadTo;
 import static sleeper.systemtest.dsl.sourcedata.GenerateNumberedValueOverrides.overrideField;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.MAIN;
 import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.ROW_KEY_FIELD_NAME;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.withDefaultProperties;
 
 @InMemoryDslTest
 public class PartitionSplittingTest {
 
     @BeforeEach
     void setUp(SleeperSystemTest sleeper) {
-        sleeper.connectToInstance(withDefaultProperties("main"));
+        sleeper.connectToInstance(MAIN);
     }
 
     @Test

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/sourcedata/SystemTestSourceFilesTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/sourcedata/SystemTestSourceFilesTest.java
@@ -26,7 +26,7 @@ import sleeper.systemtest.dsl.testutil.InMemoryDslTest;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.withDefaultProperties;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.MAIN;
 
 @InMemoryDslTest
 public class SystemTestSourceFilesTest {
@@ -38,7 +38,7 @@ public class SystemTestSourceFilesTest {
                 "key", "some-id",
                 "timestamp", 1234L,
                 "value", "Some value"));
-        sleeper.connectToInstance(withDefaultProperties("main"));
+        sleeper.connectToInstance(MAIN);
 
         // When
         sleeper.sourceFiles().create("test.parquet", record);

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemoryTestInstance.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemoryTestInstance.java
@@ -51,6 +51,18 @@ public class InMemoryTestInstance {
             .valueFields(new Field(VALUE_FIELD_NAME, new StringType()))
             .build();
     public static final SystemTestInstanceConfiguration MAIN = withDefaultProperties("main");
+    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE = usingSystemTestDefaults("prdtbl", () -> {
+        InstanceProperties instanceProperties = createDslInstanceProperties();
+        TableProperties tableProperties = createDslTableProperties(instanceProperties);
+        tableProperties.set(TABLE_NAME, "predefined-test-table");
+        return new DeployInstanceConfiguration(instanceProperties, tableProperties);
+    });
+    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE_NO_NAME = usingSystemTestDefaults("nontbl", () -> {
+        InstanceProperties instanceProperties = createDslInstanceProperties();
+        TableProperties tableProperties = createDslTableProperties(instanceProperties);
+        tableProperties.unset(TABLE_NAME);
+        return new DeployInstanceConfiguration(instanceProperties, tableProperties);
+    });
 
     public static SystemTestInstanceConfiguration withDefaultProperties(String identifier) {
         return withInstanceProperties(identifier, properties -> {

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemoryTestInstance.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemoryTestInstance.java
@@ -25,8 +25,6 @@ import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.StringType;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceConfiguration;
 
-import java.util.function.Consumer;
-
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EMR_SERVERLESS_JOB_QUEUE_URL;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.INGEST_JOB_QUEUE_URL;
 import static sleeper.core.properties.instance.CommonProperty.FILE_SYSTEM;
@@ -50,6 +48,7 @@ public class InMemoryTestInstance {
             .sortKeyFields(new Field(SORT_KEY_FIELD_NAME, new LongType()))
             .valueFields(new Field(VALUE_FIELD_NAME, new StringType()))
             .build();
+
     public static final SystemTestInstanceConfiguration MAIN = withDefaultProperties("main");
     public static final SystemTestInstanceConfiguration PREDEFINED_TABLE = usingSystemTestDefaults("prdtbl", () -> {
         InstanceProperties instanceProperties = createDslInstanceProperties();
@@ -64,16 +63,9 @@ public class InMemoryTestInstance {
         return new DeployInstanceConfiguration(instanceProperties, tableProperties);
     });
 
-    public static SystemTestInstanceConfiguration withDefaultProperties(String identifier) {
-        return withInstanceProperties(identifier, properties -> {
-        });
-    }
-
-    public static SystemTestInstanceConfiguration withInstanceProperties(
-            String identifier, Consumer<InstanceProperties> config) {
+    private static SystemTestInstanceConfiguration withDefaultProperties(String identifier) {
         return usingSystemTestDefaults(identifier, () -> {
             InstanceProperties instanceProperties = createDslInstanceProperties();
-            config.accept(instanceProperties);
             return DeployInstanceConfiguration.builder()
                     .instanceProperties(instanceProperties)
                     .tableProperties(createDslTableProperties(instanceProperties))
@@ -81,7 +73,7 @@ public class InMemoryTestInstance {
         });
     }
 
-    public static InstanceProperties createDslInstanceProperties() {
+    private static InstanceProperties createDslInstanceProperties() {
         InstanceProperties instanceProperties = createTestInstanceProperties();
         instanceProperties.set(RETAIN_INFRA_AFTER_DESTROY, "false");
         instanceProperties.set(FILE_SYSTEM, "file://");
@@ -91,7 +83,7 @@ public class InMemoryTestInstance {
         return instanceProperties;
     }
 
-    public static TableProperties createDslTableProperties(InstanceProperties instanceProperties) {
+    private static TableProperties createDslTableProperties(InstanceProperties instanceProperties) {
         TableProperties tableProperties = createTestTableProperties(instanceProperties, DEFAULT_SCHEMA);
         tableProperties.unset(TABLE_ID);
         tableProperties.set(TABLE_NAME, "system-test");

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemoryTestInstance.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemoryTestInstance.java
@@ -56,7 +56,7 @@ public class InMemoryTestInstance {
         tableProperties.set(TABLE_NAME, "predefined-test-table");
         return new DeployInstanceConfiguration(instanceProperties, tableProperties);
     });
-    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE_NO_NAME = usingSystemTestDefaults("nontbl", () -> {
+    public static final SystemTestInstanceConfiguration PREDEFINED_TABLE_NO_NAME = usingSystemTestDefaults("prdtnn", () -> {
         InstanceProperties instanceProperties = createDslInstanceProperties();
         TableProperties tableProperties = createDslTableProperties(instanceProperties);
         tableProperties.unset(TABLE_NAME);

--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
@@ -75,14 +75,14 @@ public class SystemTestInstance {
 
     public static final SystemTestInstanceConfiguration MAIN = usingSystemTestDefaults("main", SystemTestInstance::createMainConfiguration);
     public static final SystemTestInstanceConfiguration INGEST_PERFORMANCE = usingSystemTestDefaults("ingest", SystemTestInstance::createIngestPerformanceConfiguration);
-    public static final SystemTestInstanceConfiguration COMPACTION_PERFORMANCE = usingSystemTestDefaults("compact", SystemTestInstance::createCompactionPerformanceConfiguration);
+    public static final SystemTestInstanceConfiguration COMPACTION_PERFORMANCE = usingSystemTestDefaults("cptprf", SystemTestInstance::createCompactionPerformanceConfiguration);
     public static final SystemTestInstanceConfiguration BULK_IMPORT_PERFORMANCE = usingSystemTestDefaults("emr", SystemTestInstance::createBulkImportPerformanceConfiguration);
     public static final SystemTestInstanceConfiguration BULK_IMPORT_EKS = usingSystemTestDefaults("bi-eks", SystemTestInstance::createBulkImportOnEksConfiguration);
-    public static final SystemTestInstanceConfiguration BULK_IMPORT_PERSISTENT_EMR = usingSystemTestDefaults("emr-pst", SystemTestInstance::createBulkImportOnPersistentEmrConfiguration);
-    public static final SystemTestInstanceConfiguration PARALLEL_COMPACTIONS = usingSystemTestDefaults("cpt-pll", SystemTestInstance::createCompactionInParallelConfiguration);
-    public static final SystemTestInstanceConfiguration COMPACTION_ON_EC2 = usingSystemTestDefaults("cpt-ec2", SystemTestInstance::createCompactionOnEC2Configuration);
-    public static final SystemTestInstanceConfiguration COMMITTER_THROUGHPUT = usingSystemTestDefaults("commitr", SystemTestInstance::createStateStoreCommitterThroughputConfiguration);
-    public static final SystemTestInstanceConfiguration REENABLE_OPTIONAL_STACKS = usingSystemTestDefaults("optstck", SystemTestInstance::createReenableOptionalStacksConfiguration);
+    public static final SystemTestInstanceConfiguration BULK_IMPORT_PERSISTENT_EMR = usingSystemTestDefaults("emrpst", SystemTestInstance::createBulkImportOnPersistentEmrConfiguration);
+    public static final SystemTestInstanceConfiguration PARALLEL_COMPACTIONS = usingSystemTestDefaults("cptpll", SystemTestInstance::createCompactionInParallelConfiguration);
+    public static final SystemTestInstanceConfiguration COMPACTION_ON_EC2 = usingSystemTestDefaults("cptec2", SystemTestInstance::createCompactionOnEC2Configuration);
+    public static final SystemTestInstanceConfiguration COMMITTER_THROUGHPUT = usingSystemTestDefaults("cmmitr", SystemTestInstance::createStateStoreCommitterThroughputConfiguration);
+    public static final SystemTestInstanceConfiguration REENABLE_OPTIONAL_STACKS = usingSystemTestDefaults("opstck", SystemTestInstance::createReenableOptionalStacksConfiguration);
     public static final SystemTestInstanceConfiguration INGEST_NO_SOURCE_BUCKET = noSourceBucket("no-src", SystemTestInstance::createNoSourceBucketConfiguration);
 
     private static final String MAIN_EMR_MASTER_TYPES = "m7i.xlarge,m6i.xlarge,m6a.xlarge,m5.xlarge,m5a.xlarge";


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3601

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.