### PR TITLE
Issue 3619 - Stop returning compactions for non-existent table to the queue

### DIFF
--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/task/CompactionTask.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/task/CompactionTask.java
@@ -177,6 +177,7 @@ public class CompactionTask {
                     throw e;
                 } catch (TableNotFoundException e) {
                     LOGGER.warn("Found compaction job for non-existent table, ignoring: {}", job);
+                    message.deleteFromQueue();
                 } catch (Exception e) {
                     LOGGER.error("Failed processing compaction job, putting job back on queue", e);
                     numConsecutiveFailures++;

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/task/CompactionTaskTest.java
@@ -73,14 +73,16 @@ public class CompactionTaskTest extends CompactionTaskTestBase {
     void shouldDiscardJobsForNonExistentTable() throws Exception {
         // Given
         TableProperties table = createTestTableProperties(instanceProperties, schema);
-        jobsOnQueue.add(createJobNotInStateStore("job1", table));
-        jobsOnQueue.add(createJobNotInStateStore("job2", table));
+        CompactionJob job1 = createJobNotInStateStore("job1", table);
+        CompactionJob job2 = createJobNotInStateStore("job2", table);
+        jobsOnQueue.add(job1);
+        jobsOnQueue.add(job2);
 
         // When
         runTask(processNoJobs());
 
         // Then
-        assertThat(consumedJobs).isEmpty();
+        assertThat(consumedJobs).containsExactly(job1, job2);
         assertThat(jobsReturnedToQueue).isEmpty();
         assertThat(jobsOnQueue).isEmpty();
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3619

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated CompactionTaskTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.