### PR TITLE
Issue 3662 - Raise polling timeout waiting for state store committer logs

### DIFF
--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/statestore/SystemTestStateStore.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/statestore/SystemTestStateStore.java
@@ -27,6 +27,7 @@ import sleeper.systemtest.dsl.SystemTestDrivers;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import sleeper.systemtest.dsl.snapshot.SnapshotsDriver;
 import sleeper.systemtest.dsl.snapshot.WaitForSnapshot;
+import sleeper.systemtest.dsl.util.PollWithRetriesDriver;
 
 import java.time.Instant;
 import java.util.Map;
@@ -43,6 +44,7 @@ public class SystemTestStateStore {
     private final StateStoreCommitterDriver driver;
     private final StateStoreCommitterLogsDriver logsDriver;
     private final SnapshotsDriver snapshotsDriver;
+    private final PollWithRetriesDriver pollDriver;
 
     public SystemTestStateStore(SystemTestContext context) {
         this.context = context;
@@ -50,10 +52,11 @@ public class SystemTestStateStore {
         driver = adminDrivers.stateStoreCommitter(context);
         logsDriver = adminDrivers.stateStoreCommitterLogs(context);
         snapshotsDriver = adminDrivers.snapshots();
+        pollDriver = adminDrivers.pollWithRetries();
     }
 
     public SystemTestStateStoreFakeCommits fakeCommits() {
-        return new SystemTestStateStoreFakeCommits(context, driver, logsDriver);
+        return new SystemTestStateStoreFakeCommits(context, driver, logsDriver, pollDriver);
     }
 
     public double commitsPerSecondForTable() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/statestore/SystemTestStateStoreFakeCommits.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/statestore/SystemTestStateStoreFakeCommits.java
@@ -18,10 +18,11 @@ package sleeper.systemtest.dsl.statestore;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.StateStoreException;
-import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.util.PollWithRetriesDriver;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ public class SystemTestStateStoreFakeCommits {
 
     private final SystemTestInstanceContext instance;
     private final StateStoreCommitterDriver driver;
+    private final PollWithRetriesDriver pollDriver;
     private final WaitForStateStoreCommitLogs waiter;
     private final Map<String, Integer> waitForNumCommitsByTableId = new ConcurrentHashMap<>();
     private final Instant getRunsAfterTime;
@@ -41,8 +43,10 @@ public class SystemTestStateStoreFakeCommits {
     public SystemTestStateStoreFakeCommits(
             SystemTestContext context,
             StateStoreCommitterDriver driver,
-            StateStoreCommitterLogsDriver logsDriver) {
+            StateStoreCommitterLogsDriver logsDriver,
+            PollWithRetriesDriver pollDriver) {
         this.driver = driver;
+        this.pollDriver = pollDriver;
         instance = context.instance();
         waiter = new WaitForStateStoreCommitLogs(logsDriver);
         getRunsAfterTime = context.reporting().getRecordingStartTime();
@@ -77,8 +81,10 @@ public class SystemTestStateStoreFakeCommits {
         return this;
     }
 
-    public SystemTestStateStoreFakeCommits waitForCommitLogs(PollWithRetries poll) throws InterruptedException {
-        waiter.waitForCommitLogs(poll, waitForNumCommitsByTableId, getRunsAfterTime);
+    public SystemTestStateStoreFakeCommits waitForCommitLogs() throws InterruptedException {
+        waiter.waitForCommitLogs(
+                pollDriver.pollWithIntervalAndTimeout(Duration.ofSeconds(20), Duration.ofMinutes(5)),
+                waitForNumCommitsByTableId, getRunsAfterTime);
         return this;
     }
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/statestore/SystemTestStateStoreFakeCommitsTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/statestore/SystemTestStateStoreFakeCommitsTest.java
@@ -18,7 +18,6 @@ package sleeper.systemtest.dsl.statestore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.dsl.SleeperSystemTest;
 import sleeper.systemtest.dsl.testutil.InMemoryDslTest;
 import sleeper.systemtest.dsl.testutil.InMemorySystemTestDrivers;
@@ -47,7 +46,7 @@ public class SystemTestStateStoreFakeCommitsTest {
         // When
         sleeper.stateStore().fakeCommits()
                 .send(StateStoreCommitMessage.addPartitionFile("root", "file.parquet", 100))
-                .waitForCommitLogs(PollWithRetries.noRetries());
+                .waitForCommitLogs();
 
         // Then
         assertThat(printFiles(sleeper.partitioning().tree(), sleeper.tableFiles().all()))
@@ -63,7 +62,7 @@ public class SystemTestStateStoreFakeCommitsTest {
         sleeper.stateStore().fakeCommits()
                 .sendBatched(LongStream.rangeClosed(1, 1000)
                         .mapToObj(i -> StateStoreCommitMessage.addPartitionFile("root", "file-" + i + ".parquet", i)))
-                .waitForCommitLogs(PollWithRetries.noRetries());
+                .waitForCommitLogs();
 
         // Then
         assertThat(sleeper.tableFiles().references()).hasSize(1000);
@@ -78,7 +77,7 @@ public class SystemTestStateStoreFakeCommitsTest {
         committer.addFakeCommits(sleeper, 1);
 
         // When / Then
-        assertThatCode(() -> commitsDsl.waitForCommitLogs(PollWithRetries.noRetries()))
+        assertThatCode(() -> commitsDsl.waitForCommitLogs())
                 .doesNotThrowAnyException();
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterST.java
@@ -21,12 +21,10 @@ import org.junit.jupiter.api.Test;
 import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
 import sleeper.core.statestore.FileReferenceFactory;
-import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.dsl.SleeperSystemTest;
 import sleeper.systemtest.dsl.statestore.StateStoreCommitMessage;
 import sleeper.systemtest.suite.testutil.SystemTest;
 
-import java.time.Duration;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
@@ -55,7 +53,7 @@ public class StateStoreCommitterST {
                 .sendBatched(IntStream.rangeClosed(1, 1000)
                         .mapToObj(i -> fileFactory.rootFile("file-" + i + ".parquet", i))
                         .map(StateStoreCommitMessage::addFile))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(sleeper.tableFiles().recordsByFilename()).isEqualTo(

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterThroughputST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/StateStoreCommitterThroughputST.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.parallel.Execution;
 import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
 import sleeper.core.statestore.FileReferenceFactory;
-import sleeper.core.util.PollWithRetries;
 import sleeper.systemtest.dsl.SleeperSystemTest;
 import sleeper.systemtest.dsl.statestore.StateStoreCommitMessage;
 import sleeper.systemtest.suite.testutil.Slow;
@@ -65,7 +64,7 @@ public class StateStoreCommitterThroughputST {
                 .sendBatched(IntStream.rangeClosed(1, 1000)
                         .mapToObj(i -> fileFactory.rootFile(filename(i), i))
                         .map(StateStoreCommitMessage::addFile))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(sleeper.tableFiles().references()).hasSize(1000);
@@ -86,7 +85,7 @@ public class StateStoreCommitterThroughputST {
                 .sendBatched(IntStream.rangeClosed(1, 1000)
                         .mapToObj(i -> fileFactory.rootFile(filename(i), i))
                         .map(StateStoreCommitMessage::addFileWithJob))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(sleeper.tableFiles().references()).hasSize(1000);
@@ -108,7 +107,7 @@ public class StateStoreCommitterThroughputST {
                 .sendBatchedForEachTable(IntStream.rangeClosed(1, 1000)
                         .mapToObj(i -> fileFactory.rootFile(filename(i), i))
                         .map(StateStoreCommitMessage::addFile))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(sleeper.tableFiles().referencesByTable())
@@ -138,7 +137,7 @@ public class StateStoreCommitterThroughputST {
         sleeper.stateStore().fakeCommits()
                 .sendBatched(IntStream.rangeClosed(1, 1000)
                         .mapToObj(i -> factory -> factory.assignJobOnPartitionToFiles(jobId(i), "root", List.of(filename(i)))))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(printFiles(partitions, sleeper.tableFiles().all()))
@@ -175,7 +174,7 @@ public class StateStoreCommitterThroughputST {
                         .mapToObj(i -> factory -> factory.commitCompactionForPartitionOnTaskInRun(
                                 jobId(i), "root", List.of(filename(i), filename(i + 1000)),
                                 "test-task", jobRunId(i), summary(startTime(i), Duration.ofMinutes(1), i * 2, i * 2))))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(printFiles(partitions, sleeper.tableFiles().all()))
@@ -218,7 +217,7 @@ public class StateStoreCommitterThroughputST {
         sleeper.stateStore().fakeCommits()
                 .sendBatched(IntStream.rangeClosed(1, 1000)
                         .mapToObj(i -> factory -> factory.filesDeleted(List.of(filename(i), filename(i + 1000)))))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(printFiles(partitions, sleeper.tableFiles().all()))
@@ -252,7 +251,7 @@ public class StateStoreCommitterThroughputST {
                                         jobId(i), "root", List.of(filename(i), filename(i + 1000)),
                                         "test-task", jobRunId(i), summary(startTime(i), Duration.ofMinutes(1), i * 2, i * 2)),
                                 factory -> factory.filesDeleted(List.of(filename(i), filename(i + 1000))))))
-                .waitForCommitLogs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(20), Duration.ofMinutes(3)));
+                .waitForCommitLogs();
 
         // Then
         assertThat(sleeper.tableFiles().referencesByTable())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3662

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated SystemTestStateStoreFakeCommitsTest, StateStoreCommitterST, StateStoreCommitterThroughputST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.