### PR TITLE
Issue 3790: Adjustment of Compaction Instance Property to a Table Property

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -898,10 +898,6 @@ sleeper.compaction.repo=<insert-unique-sleeper-id>/compaction-job-execution
 # batch size for a lambda as an SQS FIFO event source. This can be a maximum of 10.
 sleeper.compaction.job.creation.batch.size=1
 
-# The maximum number of compaction jobs that are to be created as part of single invocation. If this
-# limit is exceeded, the selection of jobs is randomised.
-sleeper.compaction.job.creation.limit=100000
-
 # The visibility timeout for the queue of compaction jobs.
 sleeper.compaction.queue.visibility.timeout.seconds=900
 
@@ -1098,6 +1094,10 @@ sleeper.default.table.compaction.job.send.timeout.seconds=90
 # will be sent if all input files have been successfully assigned to the jobs, otherwise the batch
 # will be retried after a delay.
 sleeper.default.table.compaction.job.send.retry.delay.seconds=30
+
+# The default limit on the number of compactation jobs that can be created within a single
+# invocation.Exceeding this limit, results in the selection being randomised.
+sleeper.default.table.compaction.job.creation.limit=100000
 
 # Used by the SizeRatioCompactionStrategy to decide if a group of files should be compacted.
 # If the file sizes are s_1, ..., s_n then the files are compacted if s_1 + ... + s_{n-1} >= ratio *

--- a/example/full/table.properties
+++ b/example/full/table.properties
@@ -111,6 +111,10 @@ sleeper.table.compaction.strategy.class=sleeper.compaction.core.job.creation.str
 # the output file.
 sleeper.table.compaction.files.batch.size=12
 
+# The number of compaction jobs that are to be created as a limit during a single invocation. If this
+# limit is exceeded, the selection of jobs is randomised.
+sleeper.table.compaction.job.creation.limit=100000
+
 # The number of compaction jobs to send in a single batch.
 # When compaction jobs are created, there is no limit on how many jobs can be created at once. A batch
 # is a group of compaction jobs that will have their creation updates applied at the same time. For

--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/job/creation/CreateCompactionJobs.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/job/creation/CreateCompactionJobs.java
@@ -25,9 +25,9 @@ import sleeper.compaction.core.job.creation.strategy.CompactionStrategy;
 import sleeper.compaction.core.job.creation.strategy.CompactionStrategyIndex;
 import sleeper.compaction.core.job.dispatch.CompactionJobDispatchRequest;
 import sleeper.core.partition.Partition;
-import sleeper.core.properties.instance.CompactionProperty;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.table.TableProperties;
+import sleeper.core.properties.table.TableProperty;
 import sleeper.core.statestore.FileReference;
 import sleeper.core.statestore.SplitFileReferences;
 import sleeper.core.statestore.StateStore;
@@ -158,7 +158,7 @@ public class CreateCompactionJobs {
         }
 
         Instant limitJobsStartTime = Instant.now();
-        int creationLimit = instanceProperties.getInt(CompactionProperty.COMPACTION_JOB_CREATION_LIMIT);
+        int creationLimit = tableProperties.getInt(TableProperty.COMPACTION_JOB_CREATION_LIMIT);
         if (compactionJobs.size() > creationLimit) {
             compactionJobs = reduceCompactionJobsDownToCreationLimit(compactionJobs, creationLimit);
         }

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/job/creation/CreateCompactionJobsTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/job/creation/CreateCompactionJobsTest.java
@@ -55,8 +55,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.compaction.core.job.CompactionJobStatusTestData.jobCreated;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.DATA_BUCKET;
-import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_JOB_CREATION_LIMIT;
 import static sleeper.core.properties.table.TableProperty.COMPACTION_FILES_BATCH_SIZE;
+import static sleeper.core.properties.table.TableProperty.COMPACTION_JOB_CREATION_LIMIT;
 import static sleeper.core.properties.table.TableProperty.COMPACTION_JOB_ID_ASSIGNMENT_COMMIT_ASYNC;
 import static sleeper.core.properties.table.TableProperty.COMPACTION_JOB_SEND_BATCH_SIZE;
 import static sleeper.core.properties.table.TableProperty.COMPACTION_STRATEGY_CLASS;
@@ -224,7 +224,7 @@ public class CreateCompactionJobsTest {
 
             tableProperties.set(COMPACTION_STRATEGY_CLASS, BasicCompactionStrategy.class.getName());
             tableProperties.set(COMPACTION_FILES_BATCH_SIZE, "3");
-            instanceProperties.set(COMPACTION_JOB_CREATION_LIMIT, "2");
+            tableProperties.set(COMPACTION_JOB_CREATION_LIMIT, "2");
             stateStore.initialise(new PartitionsBuilder(schema)
                     .rootFirst("root")
                     .splitToNewChildren("root", "L", "R", "bbb")

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -43,13 +43,6 @@ public interface CompactionProperty {
             .validationPredicate(SleeperPropertyValueUtils::isPositiveIntegerLtEq10)
             .propertyGroup(InstancePropertyGroup.COMPACTION).build();
 
-    UserDefinedInstanceProperty COMPACTION_JOB_CREATION_LIMIT = Index.propertyBuilder("sleeper.compaction.job.creation.limit")
-            .description("The maximum number of compaction jobs that are to be created as part of single invocation. " +
-                    "If this limit is exceeded, the selection of jobs is randomised.")
-            .defaultValue("100000")
-            .validationPredicate(SleeperPropertyValueUtils::isNonNegativeInteger)
-            .propertyGroup(InstancePropertyGroup.COMPACTION).build();
-
     UserDefinedInstanceProperty COMPACTION_QUEUE_VISIBILITY_TIMEOUT_IN_SECONDS = Index.propertyBuilder("sleeper.compaction.queue.visibility.timeout.seconds")
             .description("The visibility timeout for the queue of compaction jobs.")
             .defaultValue("900")
@@ -314,6 +307,12 @@ public interface CompactionProperty {
                     "The batch will be sent if all input files have been successfully assigned to the jobs, otherwise " +
                     "the batch will be retried after a delay.")
             .defaultValue("30")
+            .validationPredicate(SleeperPropertyValueUtils::isNonNegativeInteger)
+            .propertyGroup(InstancePropertyGroup.COMPACTION).build();
+    UserDefinedInstanceProperty DEFAULT_COMPACTION_JOB_CREATION_LIMIT = Index.propertyBuilder("sleeper.default.table.compaction.job.creation.limit")
+            .description("The default limit on the number of compactation jobs that can be created within a single invocation." +
+                    "Exceeding this limit, results in the selection being randomised.")
+            .defaultValue("100000")
             .validationPredicate(SleeperPropertyValueUtils::isNonNegativeInteger)
             .propertyGroup(InstancePropertyGroup.COMPACTION).build();
     UserDefinedInstanceProperty DEFAULT_SIZERATIO_COMPACTION_STRATEGY_RATIO = Index.propertyBuilder("sleeper.default.table.compaction.strategy.sizeratio.ratio")

--- a/java/core/src/main/java/sleeper/core/properties/table/TableProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/table/TableProperty.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static sleeper.core.properties.instance.CompactionProperty.DEFAULT_COMPACTION_FILES_BATCH_SIZE;
+import static sleeper.core.properties.instance.CompactionProperty.DEFAULT_COMPACTION_JOB_CREATION_LIMIT;
 import static sleeper.core.properties.instance.CompactionProperty.DEFAULT_COMPACTION_JOB_SEND_BATCH_SIZE;
 import static sleeper.core.properties.instance.CompactionProperty.DEFAULT_COMPACTION_JOB_SEND_RETRY_DELAY_SECS;
 import static sleeper.core.properties.instance.CompactionProperty.DEFAULT_COMPACTION_JOB_SEND_TIMEOUT_SECS;
@@ -246,6 +247,12 @@ public interface TableProperty extends SleeperProperty, TablePropertyComputeValu
                     "Also note that this many files may need to be open simultaneously. The value of " +
                     "'sleeper.fs.s3a.max-connections' must be at least the value of this plus one. The extra one is " +
                     "for the output file.")
+            .propertyGroup(TablePropertyGroup.COMPACTION)
+            .build();
+    TableProperty COMPACTION_JOB_CREATION_LIMIT = Index.propertyBuilder("sleeper.table.compaction.job.creation.limit")
+            .defaultProperty(DEFAULT_COMPACTION_JOB_CREATION_LIMIT)
+            .description("The number of compaction jobs that are to be created as a limit during a single invocation. " +
+                    "If this limit is exceeded, the selection of jobs is randomised.")
             .propertyGroup(TablePropertyGroup.COMPACTION)
             .build();
     TableProperty COMPACTION_JOB_SEND_BATCH_SIZE = Index.propertyBuilder("sleeper.table.compaction.job.send.batch.size")

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -922,10 +922,6 @@ sleeper.default.gc.delay.minutes=15
 # batch size for a lambda as an SQS FIFO event source. This can be a maximum of 10.
 sleeper.compaction.job.creation.batch.size=1
 
-# The maximum number of compaction jobs that are to be created as part of single invocation. If this
-# limit is exceeded, the selection of jobs is randomised.
-sleeper.compaction.job.creation.limit=100000
-
 # The visibility timeout for the queue of compaction jobs.
 sleeper.compaction.queue.visibility.timeout.seconds=900
 
@@ -1122,6 +1118,10 @@ sleeper.default.table.compaction.job.send.timeout.seconds=90
 # will be sent if all input files have been successfully assigned to the jobs, otherwise the batch
 # will be retried after a delay.
 sleeper.default.table.compaction.job.send.retry.delay.seconds=30
+
+# The default limit on the number of compactation jobs that can be created within a single
+# invocation.Exceeding this limit, results in the selection being randomised.
+sleeper.default.table.compaction.job.creation.limit=100000
 
 # Used by the SizeRatioCompactionStrategy to decide if a group of files should be compacted.
 # If the file sizes are s_1, ..., s_n then the files are compacted if s_1 + ... + s_{n-1} >= ratio *


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3790

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Execution of existing unit tests suites (primarily CompactionJobLimitationsForInvocation.shouldCreateJobsLimitedDownToCreationLimitWhenTheCompactionJobsExceedTheValue as direct calls property)

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
