### PR TITLE
Issue 3808 - Disable page indexing on Parquet reading in DataFusion

### DIFF
--- a/rust/compaction/src/datafusion.rs
+++ b/rust/compaction/src/datafusion.rs
@@ -438,6 +438,7 @@ fn create_session_cfg<T>(input_data: &CompactionInput, input_paths: &[T]) -> Ses
     // sure the target partitions as at least as big as number of input files.
     sf.options_mut().execution.target_partitions =
         std::cmp::max(sf.options().execution.target_partitions, input_paths.len());
+    sf.options_mut().execution.parquet.enable_page_index = false;
     sf.options_mut().execution.parquet.max_row_group_size = input_data.max_row_group_size;
     sf.options_mut().execution.parquet.data_pagesize_limit = input_data.max_page_size;
     sf.options_mut().execution.parquet.compression = Some(get_compression(&input_data.compression));


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3808

### Tests

- [X] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Sleeper functionality unchanged.

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
