### PR TITLE
Issue 3776 - Configure memory overhead when scaling compaction EC2 instances

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1023,11 +1023,18 @@ sleeper.compaction.task.x86.cpu=1024
 # options.
 sleeper.compaction.task.x86.memory=4096
 
-# 
+# Used when scaling EC2 instances to support an expected number of compaction tasks. This is the
+# amount of memory in MB that we expect ECS to reserve on an EC2 instance before making memory
+# available for compaction tasks.
+# If this is unset, it will be computed as a percentage of the memory on the EC2 instead, see
+# `sleeper.compaction.task.scaling.overhead.percentage`.
 # sleeper.compaction.task.scaling.overhead.fixed=
 
-# 
-sleeper.compaction.task.scaling.overhead.percentage=90
+# Used when scaling EC2 instances to support an expected number of compaction tasks. This is the
+# percentage of memory in an EC2 instance that we expect ECS to reserve before making memory available
+# for compaction tasks.
+# Defaults to 10%, so we expect 90% of the memory on an EC2 instance to be used for compaction tasks.
+sleeper.compaction.task.scaling.overhead.percentage=10
 
 # What launch type should compaction containers use? Valid options: FARGATE, EC2.
 sleeper.compaction.ecs.launch.type=FARGATE

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1023,6 +1023,12 @@ sleeper.compaction.task.x86.cpu=1024
 # options.
 sleeper.compaction.task.x86.memory=4096
 
+# 
+# sleeper.compaction.task.scaling.overhead.fixed=
+
+# 
+sleeper.compaction.task.scaling.overhead.percentage=90
+
 # What launch type should compaction containers use? Valid options: FARGATE, EC2.
 sleeper.compaction.ecs.launch.type=FARGATE
 

--- a/java/common/common-task/src/test/java/sleeper/task/common/RunCompactionTasksTest.java
+++ b/java/common/common-task/src/test/java/sleeper/task/common/RunCompactionTasksTest.java
@@ -16,6 +16,7 @@
 package sleeper.task.common;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.COMPAC
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_EC2_TYPE;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_ECS_LAUNCHTYPE;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_CPU_ARCHITECTURE;
+import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_FIXED_OVERHEAD;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_X86_CPU;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_X86_MEMORY;
 import static sleeper.core.properties.instance.CompactionProperty.MAXIMUM_CONCURRENT_COMPACTION_TASKS;
@@ -310,6 +312,27 @@ public class RunCompactionTasksTest {
             // Then
             assertThat(scaleToHostsRequests).containsExactly(2);
             assertThat(launchTasksRequests).containsExactly(6);
+        }
+
+        @Test
+        @Disabled
+        void shouldScaleToSetScalingLimitBasedOnPropertySet() {
+            //Given
+
+            instanceProperties.set(COMPACTION_EC2_TYPE, "test-type");
+            instanceTypes.put("test-type", new InstanceType(4, 4096));
+            instanceProperties.set(COMPACTION_TASK_CPU_ARCHITECTURE, "X86_64");
+            instanceProperties.setNumber(COMPACTION_TASK_X86_CPU, 1024);
+            instanceProperties.setNumber(COMPACTION_TASK_X86_MEMORY, 1024);
+            instanceProperties.setNumber(COMPACTION_TASK_FIXED_OVERHEAD, 512);
+
+            // When
+            runTasks(jobsOnQueue(6), noExistingTasks());
+
+            // Then
+            assertThat(scaleToHostsRequests).containsExactly(2);
+            //assertThat(launchTasksRequests).containsExactly(6);
+
         }
 
         @Test

--- a/java/core/src/main/java/sleeper/core/properties/SleeperPropertyValues.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperPropertyValues.java
@@ -82,6 +82,22 @@ public interface SleeperPropertyValues<T extends SleeperProperty> {
     }
 
     /**
+     * Retrieves the value of a nullable long integer property. Please call the getter relevant to the type of the
+     * property, see other methods on this class.
+     *
+     * @param  property the property
+     * @return          the value of the property
+     */
+    default Long getNullableLong(T property) {
+        String val = get(property);
+        if (val != null) {
+            return Long.parseLong(val);
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Retrieves the value of a double precision floating point property. Please call the getter relevant to the type of
      * the property, see other methods on this class.
      *

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -204,6 +204,17 @@ public interface CompactionProperty {
             .defaultValue("4096")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCdkDeployWhenChanged(true).build();
+    UserDefinedInstanceProperty COMPACTION_TASK_FIXED_OVERHEAD = Index.propertyBuilder("sleeper.compaction.task.scaling.overhead.fixed")
+            .description("")
+            .validationPredicate(SleeperPropertyValueUtils::isNonNegativeIntegerOrNull)
+            .propertyGroup(InstancePropertyGroup.COMPACTION)
+            .runCdkDeployWhenChanged(true).build();
+    UserDefinedInstanceProperty COMPACTION_TASK_PERCENTAGE_OVERHEAD = Index.propertyBuilder("sleeper.compaction.task.scaling.overhead.percentage")
+            .description("")
+            .defaultValue("90")
+            .validationPredicate(val -> SleeperPropertyValueUtils.isNonNegativeIntLtEqValue(val, 95))
+            .propertyGroup(InstancePropertyGroup.COMPACTION)
+            .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_ECS_LAUNCHTYPE = Index.propertyBuilder("sleeper.compaction.ecs.launch.type")
             .description("What launch type should compaction containers use? Valid options: FARGATE, EC2.")
             .defaultValue("FARGATE")

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -211,7 +211,7 @@ public interface CompactionProperty {
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_PERCENTAGE_OVERHEAD = Index.propertyBuilder("sleeper.compaction.task.scaling.overhead.percentage")
             .description("")
-            .defaultValue("90")
+            .defaultValue("10")
             .validationPredicate(val -> SleeperPropertyValueUtils.isNonNegativeIntLtEqValue(val, 95))
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCdkDeployWhenChanged(true).build();

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -205,14 +205,22 @@ public interface CompactionProperty {
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_FIXED_OVERHEAD = Index.propertyBuilder("sleeper.compaction.task.scaling.overhead.fixed")
-            .description("")
+            .description("Used when scaling EC2 instances to support an expected number of compaction tasks. " +
+                    "This is the amount of memory in MB that we expect ECS to reserve on an EC2 instance before " +
+                    "making memory available for compaction tasks.\n" +
+                    "If this is unset, it will be computed as a percentage of the memory on the EC2 instead, see " +
+                    "`sleeper.compaction.task.scaling.overhead.percentage`.")
             .validationPredicate(SleeperPropertyValueUtils::isNonNegativeIntegerOrNull)
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TASK_PERCENTAGE_OVERHEAD = Index.propertyBuilder("sleeper.compaction.task.scaling.overhead.percentage")
-            .description("")
+            .description("Used when scaling EC2 instances to support an expected number of compaction tasks. " +
+                    "This is the percentage of memory in an EC2 instance that we expect ECS to reserve before " +
+                    "making memory available for compaction tasks.\n" +
+                    "Defaults to 10%, so we expect 90% of the memory on an EC2 instance to be used for compaction " +
+                    "tasks.")
             .defaultValue("10")
-            .validationPredicate(val -> SleeperPropertyValueUtils.isNonNegativeIntLtEqValue(val, 95))
+            .validationPredicate(val -> SleeperPropertyValueUtils.isNonNegativeIntLtEqValue(val, 99))
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_ECS_LAUNCHTYPE = Index.propertyBuilder("sleeper.compaction.ecs.launch.type")

--- a/java/core/src/main/java/sleeper/core/properties/validation/SleeperPropertyValueUtils.java
+++ b/java/core/src/main/java/sleeper/core/properties/validation/SleeperPropertyValueUtils.java
@@ -99,6 +99,16 @@ public class SleeperPropertyValueUtils {
     }
 
     /**
+     * Checks if a property value is an integer greater than or equal to 0 or unset.
+     *
+     * @param  integer the value
+     * @return         true if the value meets the requirement
+     */
+    public static boolean isNonNegativeIntegerOrNull(String integer) {
+        return (integer == null) || (isNonNegativeInteger(integer));
+    }
+
+    /**
      * Checks if a property value is an integer.
      *
      * @param  integer the value

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1047,6 +1047,12 @@ sleeper.compaction.task.x86.cpu=1024
 # options.
 sleeper.compaction.task.x86.memory=4096
 
+# 
+# sleeper.compaction.task.scaling.overhead.fixed=
+
+# 
+sleeper.compaction.task.scaling.overhead.percentage=90
+
 # What launch type should compaction containers use? Valid options: FARGATE, EC2.
 sleeper.compaction.ecs.launch.type=FARGATE
 

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1047,11 +1047,18 @@ sleeper.compaction.task.x86.cpu=1024
 # options.
 sleeper.compaction.task.x86.memory=4096
 
-# 
+# Used when scaling EC2 instances to support an expected number of compaction tasks. This is the
+# amount of memory in MB that we expect ECS to reserve on an EC2 instance before making memory
+# available for compaction tasks.
+# If this is unset, it will be computed as a percentage of the memory on the EC2 instead, see
+# `sleeper.compaction.task.scaling.overhead.percentage`.
 # sleeper.compaction.task.scaling.overhead.fixed=
 
-# 
-sleeper.compaction.task.scaling.overhead.percentage=90
+# Used when scaling EC2 instances to support an expected number of compaction tasks. This is the
+# percentage of memory in an EC2 instance that we expect ECS to reserve before making memory available
+# for compaction tasks.
+# Defaults to 10%, so we expect 90% of the memory on an EC2 instance to be used for compaction tasks.
+sleeper.compaction.task.scaling.overhead.percentage=10
 
 # What launch type should compaction containers use? Valid options: FARGATE, EC2.
 sleeper.compaction.ecs.launch.type=FARGATE


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3776

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated RunCompactionTasksTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
