### PR TITLE
Issue 3855 - Raise timeout waiting for bulk import in performance test

### DIFF
--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrBulkImportPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EmrBulkImportPerformanceST.java
@@ -63,7 +63,7 @@ public class EmrBulkImportPerformanceST {
                 .sendAllGeneratedFilesAsOneJob(BULK_IMPORT_EMR_JOB_QUEUE_URL)
                 .sendAllGeneratedFilesAsOneJob(BULK_IMPORT_EMR_JOB_QUEUE_URL)
                 .sendAllGeneratedFilesAsOneJob(BULK_IMPORT_EMR_JOB_QUEUE_URL)
-                .waitForBulkImportJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofMinutes(20)));
+                .waitForBulkImportJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofMinutes(30)));
 
         assertThat(sleeper.tableFiles().references())
                 .hasSize(2560)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3855

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by system tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
