### PR TITLE
Issue 3859 - Always load snapshot when no transactions have been read yet

### DIFF
--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -192,7 +192,7 @@ class TransactionLogHead<T> {
                     state.getClass().getSimpleName(), sleeperTable, nextSnapshotCheckTime);
             return startTime;
         }
-        long minTransactionNumberToLoadSnapshot = lastTransactionNumber + minTransactionsAheadToLoadSnapshot;
+        long minTransactionNumberToLoadSnapshot = minTransactionNumberToLoadSnapshot();
         Optional<TransactionLogSnapshot> snapshotOpt = snapshotLoader
                 .loadLatestSnapshotIfAtMinimumTransaction(minTransactionNumberToLoadSnapshot);
         Instant finishTime = stateUpdateClock.get();
@@ -209,6 +209,14 @@ class TransactionLogHead<T> {
                     LoggedDuration.withShortOutput(startTime, finishTime));
         });
         return finishTime;
+    }
+
+    private long minTransactionNumberToLoadSnapshot() {
+        if (lastTransactionNumber < 1) { // Always load snapshot when no transactions have been read yet
+            return 1;
+        } else {
+            return lastTransactionNumber + minTransactionsAheadToLoadSnapshot;
+        }
     }
 
     private void updateFromLog(Instant startTime) {

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -15,7 +15,6 @@
  */
 package sleeper.core.statestore.transactionlog;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -77,22 +76,6 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
             // Then
             assertThat(stateStore().getAllPartitions())
                     .containsExactlyInAnyOrderElementsOf(partitions.buildList());
-        }
-
-        @Test
-        @Disabled("TODO")
-        void shouldLoadSnapshotOnFirstQueryWhenEarlierThanMinTransactionsAhead() throws Exception {
-            // Given
-            FileReference file = fileFactory().rootFile(123);
-
-            // When
-            createSnapshotWithFreshStateAtTransactionNumber(1, stateStore -> {
-                stateStore.addFile(file);
-            });
-            StateStore stateStore = stateStore(builder -> builder.minTransactionsAheadToLoadSnapshot(5));
-
-            // Then
-            assertThat(stateStore.getFileReferences()).containsExactly(file);
         }
     }
 
@@ -174,6 +157,21 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
 
             // Then
             assertThat(stateStore.getAllPartitions()).containsExactlyElementsOf(snapshotPartitions);
+        }
+
+        @Test
+        void shouldIgnoreMinTransactionsAheadOnFirstQuery() throws Exception {
+            // Given
+            FileReference file = fileFactory().rootFile(123);
+            StateStore stateStore = stateStore(builder -> builder.minTransactionsAheadToLoadSnapshot(5));
+
+            // When
+            createSnapshotWithFreshStateAtTransactionNumber(1, store -> {
+                store.addFile(file);
+            });
+
+            // Then
+            assertThat(stateStore.getFileReferences()).containsExactly(file);
         }
     }
 

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreSnapshotsTest.java
@@ -15,6 +15,7 @@
  */
 package sleeper.core.statestore.transactionlog;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
     class FirstLoad {
 
         @Test
-        void shouldLoadFilesFromSnapshotWhenNotInLogOnFirstLoad() throws Exception {
+        void shouldLoadSnapshotOnFirstQueryForFiles() throws Exception {
             // Given
             FileReference file = fileFactory().rootFile(123);
 
@@ -64,7 +65,7 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
         }
 
         @Test
-        void shouldLoadPartitionsFromSnapshotWhenNotInLogOnFirstLoad() throws Exception {
+        void shouldLoadSnapshotOnFirstQueryForPartitions() throws Exception {
             // Given
             partitions.splitToNewChildren("root", "L", "R", "abc");
 
@@ -76,6 +77,22 @@ public class TransactionLogStateStoreSnapshotsTest extends InMemoryTransactionLo
             // Then
             assertThat(stateStore().getAllPartitions())
                     .containsExactlyInAnyOrderElementsOf(partitions.buildList());
+        }
+
+        @Test
+        @Disabled("TODO")
+        void shouldLoadSnapshotOnFirstQueryWhenEarlierThanMinTransactionsAhead() throws Exception {
+            // Given
+            FileReference file = fileFactory().rootFile(123);
+
+            // When
+            createSnapshotWithFreshStateAtTransactionNumber(1, stateStore -> {
+                stateStore.addFile(file);
+            });
+            StateStore stateStore = stateStore(builder -> builder.minTransactionsAheadToLoadSnapshot(5));
+
+            // Then
+            assertThat(stateStore.getFileReferences()).containsExactly(file);
         }
     }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3859

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated TransactionLogStateStoreSnapshotsTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
