### PR TITLE
Issue 3884 - Disable nightly DynamoDB system tests

### DIFF
--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -48,14 +48,10 @@ else
   MAIN_SUITE_NAME=custom
   MAIN_SUITE_PARAMS=("$@")
 fi
-SECONDARY_SUITE_NAME=dynamo-state-store
-SECONDARY_SUITE_PARAMS=(-Dsleeper.system.test.force.statestore.classname=sleeper.statestore.dynamodb.DynamoDBStateStore "$@")
 
 echo "DEPLOY_ID=$DEPLOY_ID"
 echo "MAIN_SUITE_NAME=$MAIN_SUITE_NAME"
 echo "MAIN_SUITE_PARAMS=(${MAIN_SUITE_PARAMS[*]})"
-echo "SECONDARY_SUITE_NAME=$SECONDARY_SUITE_NAME"
-echo "SECONDARY_SUITE_PARAMS=(${SECONDARY_SUITE_PARAMS[*]})"
 
 source "$SCRIPTS_DIR/functions/timeUtils.sh"
 source "$SCRIPTS_DIR/functions/systemTestUtils.sh"
@@ -112,7 +108,6 @@ runMavenSystemTests() {
 }
 
 runMavenSystemTests "${DEPLOY_ID}mvn${START_TIME_SHORT}" $MAIN_SUITE_NAME "${MAIN_SUITE_PARAMS[@]}"
-runMavenSystemTests "${DEPLOY_ID}dyn${START_TIME_SHORT}" $SECONDARY_SUITE_NAME "${SECONDARY_SUITE_PARAMS[@]}"
 
 echo "[$(time_str)] Uploading test output"
 java -cp "${SYSTEM_TEST_JAR}" \


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3884

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Just script change

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
