### PR TITLE
Issue 3913 - Set queue visibility timeout for transaction deletion lambda

### DIFF
--- a/java/cdk/src/main/java/sleeper/cdk/stack/core/TransactionLogTransactionStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/core/TransactionLogTransactionStack.java
@@ -54,7 +54,7 @@ import static sleeper.core.properties.instance.TableStateProperty.TRANSACTION_DE
 import static sleeper.core.properties.instance.TableStateProperty.TRANSACTION_DELETION_LAMBDA_CONCURRENCY_MAXIMUM;
 import static sleeper.core.properties.instance.TableStateProperty.TRANSACTION_DELETION_LAMBDA_CONCURRENCY_RESERVED;
 import static sleeper.core.properties.instance.TableStateProperty.TRANSACTION_DELETION_LAMBDA_PERIOD_IN_MINUTES;
-import static sleeper.core.properties.instance.TableStateProperty.TRANSACTION_DELETION_LAMBDA_TIMEOUT;
+import static sleeper.core.properties.instance.TableStateProperty.TRANSACTION_DELETION_LAMBDA_TIMEOUT_SECS;
 
 public class TransactionLogTransactionStack extends NestedStack {
     public TransactionLogTransactionStack(
@@ -89,7 +89,7 @@ public class TransactionLogTransactionStack extends NestedStack {
                 .environment(Utils.createDefaultEnvironment(instanceProperties))
                 .reservedConcurrentExecutions(instanceProperties.getIntOrNull(TRANSACTION_DELETION_LAMBDA_CONCURRENCY_RESERVED))
                 .memorySize(1024)
-                .timeout(Duration.seconds(instanceProperties.getInt(TRANSACTION_DELETION_LAMBDA_TIMEOUT)))
+                .timeout(Duration.seconds(instanceProperties.getInt(TRANSACTION_DELETION_LAMBDA_TIMEOUT_SECS)))
                 .logGroup(coreStacks.getLogGroup(LogGroupRef.STATE_TRANSACTION_DELETION)));
 
         Rule rule = Rule.Builder.create(this, "TransactionLogTransactionDeletionSchedule")
@@ -114,7 +114,7 @@ public class TransactionLogTransactionStack extends NestedStack {
                         .queue(deadLetterQueue)
                         .build())
                 .fifo(true)
-                .visibilityTimeout(Duration.seconds(70))
+                .visibilityTimeout(Duration.seconds(instanceProperties.getInt(TRANSACTION_DELETION_LAMBDA_TIMEOUT_SECS)))
                 .build();
         instanceProperties.set(TRANSACTION_LOG_TRANSACTION_DELETION_QUEUE_URL, queue.getQueueUrl());
         instanceProperties.set(TRANSACTION_LOG_TRANSACTION_DELETION_QUEUE_ARN, queue.getQueueArn());

--- a/java/core/src/main/java/sleeper/core/properties/instance/TableStateProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/TableStateProperty.java
@@ -176,7 +176,7 @@ public interface TableStateProperty {
             .description("The maximum given concurrency allowed for the transaction deletion lambda.\n" +
                     "See maximum concurrency overview at: https://aws.amazon.com/blogs/compute/introducing-maximum-concurrency-of-aws-lambda-functions-when-using-amazon-sqs-as-an-event-source/")
             .propertyGroup(InstancePropertyGroup.TABLE_STATE).build();
-    UserDefinedInstanceProperty TRANSACTION_DELETION_LAMBDA_TIMEOUT = Index.propertyBuilder("sleeper.statestore.transaction.deletion.lambda.timeout.seconds")
+    UserDefinedInstanceProperty TRANSACTION_DELETION_LAMBDA_TIMEOUT_SECS = Index.propertyBuilder("sleeper.statestore.transaction.deletion.lambda.timeout.seconds")
             .description("The maximum timeout for the transaction deletion lambda in seconds.")
             .validationPredicate(SleeperPropertyValueUtils::isPositiveInteger)
             .defaultValue("900")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3913

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Will test in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
