### PR TITLE
Issue 3729 - Enable table metrics schedule rule in system tests

### DIFF
--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestInstanceConfiguration.java
@@ -29,6 +29,7 @@ import static java.util.stream.Collectors.toSet;
 import static sleeper.core.deploy.SleeperScheduleRule.COMPACTION_TASK_CREATION;
 import static sleeper.core.deploy.SleeperScheduleRule.INGEST_TASK_CREATION;
 import static sleeper.core.deploy.SleeperScheduleRule.QUERY_WARM_LAMBDA;
+import static sleeper.core.deploy.SleeperScheduleRule.TABLE_METRICS;
 import static sleeper.core.deploy.SleeperScheduleRule.TRANSACTION_LOG_SNAPSHOT_CREATION;
 import static sleeper.core.deploy.SleeperScheduleRule.TRANSACTION_LOG_SNAPSHOT_DELETION;
 import static sleeper.core.deploy.SleeperScheduleRule.TRANSACTION_LOG_TRANSACTION_DELETION;
@@ -102,6 +103,7 @@ public class SystemTestInstanceConfiguration {
                 TRANSACTION_LOG_SNAPSHOT_CREATION,
                 TRANSACTION_LOG_SNAPSHOT_DELETION,
                 TRANSACTION_LOG_TRANSACTION_DELETION,
+                TABLE_METRICS,
                 INGEST_TASK_CREATION,
                 COMPACTION_TASK_CREATION).collect(toSet());
         private String shortName;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestTables.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/instance/SystemTestTables.java
@@ -47,7 +47,11 @@ public class SystemTestTables {
     }
 
     public SystemTestTables create(List<String> names, Schema schema) {
-        names.forEach(name -> instance.createTable(name, schema, Map.of()));
+        return createWithProperties(names, schema, Map.of());
+    }
+
+    public SystemTestTables createWithProperties(List<String> names, Schema schema, Map<TableProperty, String> setProperties) {
+        names.forEach(name -> instance.createTable(name, schema, setProperties));
         return this;
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/MultipleTablesST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/MultipleTablesST.java
@@ -35,6 +35,7 @@ import static sleeper.core.properties.table.TableProperty.COMPACTION_FILES_BATCH
 import static sleeper.core.properties.table.TableProperty.COMPACTION_STRATEGY_CLASS;
 import static sleeper.core.properties.table.TableProperty.GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.core.properties.table.TableProperty.PARTITION_SPLIT_THRESHOLD;
+import static sleeper.core.properties.table.TableProperty.TABLE_ONLINE;
 import static sleeper.core.testutils.printers.FileReferencePrinter.printTableFilesExpectingIdentical;
 import static sleeper.core.testutils.printers.PartitionsPrinter.printTablePartitionsExpectingIdentical;
 import static sleeper.systemtest.dsl.sourcedata.GenerateNumberedValue.addPrefix;
@@ -152,6 +153,7 @@ public class MultipleTablesST {
         // Given we have several tables
         // And we ingest two source files as separate jobs
         sleeper.tables().createManyWithProperties(NUMBER_OF_TABLES, schema, Map.of(
+                TABLE_ONLINE, "false",
                 COMPACTION_STRATEGY_CLASS, BasicCompactionStrategy.class.getName(),
                 COMPACTION_FILES_BATCH_SIZE, "2",
                 GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION, "0"));


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/3729

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated MultipleTablesST, TableMetricsST
    - Will test in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
