### PR TITLE
Issue 4013 - Take table offline after jobs are created in compaction performance tests

### DIFF
--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
@@ -64,6 +64,12 @@ public class SystemTestCompaction {
         return this;
     }
 
+    public SystemTestCompaction putTableOnlineUntilJobsAreCreated(int expectedJobs) {
+        putTablesOnlineWaitForJobCreation(expectedJobs);
+        instance.updateTableProperties(Map.of(TABLE_ONLINE, "false"));
+        return this;
+    }
+
     public SystemTestCompaction putTableOnlineWaitForJobCreation(int expectedJobs) {
         return putTablesOnlineWaitForJobCreation(expectedJobs);
     }

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionDataFusionPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionDataFusionPerformanceST.java
@@ -70,7 +70,7 @@ public class CompactionDataFusionPerformanceST {
                 .waitForTotalFileReferences(110);
 
         // When
-        sleeper.compaction().putTableOnlineWaitForJobCreation(10).waitForTasks(10)
+        sleeper.compaction().putTableOnlineUntilJobsAreCreated(10).waitForTasks(10)
                 .waitForJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofHours(1)));
 
         // Then

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceST.java
@@ -67,7 +67,7 @@ public class CompactionPerformanceST {
                 .waitForTotalFileReferences(110);
 
         // When
-        sleeper.compaction().putTableOnlineWaitForJobCreation(10).waitForTasks(10)
+        sleeper.compaction().putTableOnlineUntilJobsAreCreated(10).waitForTasks(10)
                 .waitForJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofHours(1)));
 
         // Then


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4013

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated CompactionPerformanceST, CompactionDataFusionPerformanceST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
