### PR TITLE
Issue 4132 - Option to disable job tracker update when a compaction job is committed

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1088,6 +1088,10 @@ sleeper.compaction.ec2.root.size=50
 # Flag to enable/disable storage of tracking information for compaction jobs and tasks.
 sleeper.compaction.tracker.enabled=true
 
+# Flag to enable/disable tracking async commits of compaction jobs. This is primarily used for
+# testing, in particular when a large number of compactions are present.
+sleeper.compaction.tracker.async.commit.updates.enabled=true
+
 # The time to live in seconds for compaction job updates in the job tracker. Default is 1 week.
 # The expiry time is fixed when an update is saved to the store, so changing this will only affect new
 # data.

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1088,8 +1088,8 @@ sleeper.compaction.ec2.root.size=50
 # Flag to enable/disable storage of tracking information for compaction jobs and tasks.
 sleeper.compaction.tracker.enabled=true
 
-# Flag to enable/disable tracking async commits of compaction jobs. This is primarily used for
-# testing, in particular when a large number of compactions are present.
+# Flag to enable/disable storing an update to the tracker during async commits of compaction jobs.
+# This is primarily used for testing, in particular when a large number of compactions are present.
 sleeper.compaction.tracker.async.commit.updates.enabled=true
 
 # The time to live in seconds for compaction job updates in the job tracker. Default is 1 week.

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1089,7 +1089,9 @@ sleeper.compaction.ec2.root.size=50
 sleeper.compaction.tracker.enabled=true
 
 # Flag to enable/disable storing an update to the tracker during async commits of compaction jobs.
-# This is primarily used for testing, in particular when a large number of compactions are present.
+# This may be disabled if there are enough compactions that the system is unable to apply all the
+# updates to the tracker. This is mainly used for testing. Reports may show compactions as unfinished
+# if this update is not present in the tracker.
 sleeper.compaction.tracker.async.commit.updates.enabled=true
 
 # The time to live in seconds for compaction job updates in the job tracker. Default is 1 week.

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -289,8 +289,8 @@ public interface CompactionProperty {
             .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TRACKER_ASYNC_COMMIT_UPDATES_ENABLED = Index.propertyBuilder("sleeper.compaction.tracker.async.commit.updates.enabled")
-            .description("Flag to enable/disable tracking async commits of compaction jobs. This is primarily used " +
-                    "for testing, in particular when a large number of compactions are present.")
+            .description("Flag to enable/disable storing an update to the tracker during async commits of compaction jobs. " +
+                    "This is primarily used for testing, in particular when a large number of compactions are present.")
             .defaultValue("true")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -289,8 +289,10 @@ public interface CompactionProperty {
             .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty COMPACTION_TRACKER_ASYNC_COMMIT_UPDATES_ENABLED = Index.propertyBuilder("sleeper.compaction.tracker.async.commit.updates.enabled")
-            .description("Flag to enable/disable storing an update to the tracker during async commits of compaction jobs. " +
-                    "This is primarily used for testing, in particular when a large number of compactions are present.")
+            .description("Flag to enable/disable storing an update to the tracker during async commits of compaction " +
+                    "jobs. This may be disabled if there are enough compactions that the system is unable to apply " +
+                    "all the updates to the tracker. This is mainly used for testing. Reports may show compactions " +
+                    "as unfinished if this update is not present in the tracker.")
             .defaultValue("true")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
             .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)

--- a/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CompactionProperty.java
@@ -286,7 +286,15 @@ public interface CompactionProperty {
             .description("Flag to enable/disable storage of tracking information for compaction jobs and tasks.")
             .defaultValue("true")
             .propertyGroup(InstancePropertyGroup.COMPACTION)
+            .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)
             .runCdkDeployWhenChanged(true).build();
+    UserDefinedInstanceProperty COMPACTION_TRACKER_ASYNC_COMMIT_UPDATES_ENABLED = Index.propertyBuilder("sleeper.compaction.tracker.async.commit.updates.enabled")
+            .description("Flag to enable/disable tracking async commits of compaction jobs. This is primarily used " +
+                    "for testing, in particular when a large number of compactions are present.")
+            .defaultValue("true")
+            .propertyGroup(InstancePropertyGroup.COMPACTION)
+            .validationPredicate(SleeperPropertyValueUtils::isTrueOrFalse)
+            .build();
     UserDefinedInstanceProperty COMPACTION_JOB_STATUS_TTL_IN_SECONDS = Index.propertyBuilder("sleeper.compaction.job.status.ttl")
             .description("The time to live in seconds for compaction job updates in the job tracker. Default is 1 week.\n" +
                     "The expiry time is fixed when an update is saved to the store, so changing this will only affect new data.")

--- a/java/statestore-committer-core/src/test/java/sleeper/statestore/committer/StateStoreCommitterThroughputIT.java
+++ b/java/statestore-committer-core/src/test/java/sleeper/statestore/committer/StateStoreCommitterThroughputIT.java
@@ -156,12 +156,12 @@ public class StateStoreCommitterThroughputIT {
     private StateStoreCommitter committer() {
         TablePropertiesProvider tablePropertiesProvider = tablePropertiesProvider();
         return new StateStoreCommitter(
-                CompactionJobTrackerFactory.getTracker(dynamoDB, instanceProperties),
-                IngestJobTrackerFactory.getTracker(dynamoDB, instanceProperties),
+                instanceProperties,
                 tablePropertiesProvider,
                 stateStoreProvider(),
-                new S3TransactionBodyStore(instanceProperties, s3, TransactionSerDeProvider.from(tablePropertiesProvider)),
-                Instant::now);
+                CompactionJobTrackerFactory.getTracker(dynamoDB, instanceProperties),
+                IngestJobTrackerFactory.getTracker(dynamoDB, instanceProperties),
+                new S3TransactionBodyStore(instanceProperties, s3, TransactionSerDeProvider.from(tablePropertiesProvider)), Instant::now);
     }
 
     private TablePropertiesProvider tablePropertiesProvider() {

--- a/java/statestore-lambda/src/main/java/sleeper/statestore/lambda/committer/StateStoreCommitterLambda.java
+++ b/java/statestore-lambda/src/main/java/sleeper/statestore/lambda/committer/StateStoreCommitterLambda.java
@@ -82,11 +82,11 @@ public class StateStoreCommitterLambda implements RequestHandler<SQSEvent, SQSBa
         stateStoreProvider = new StateStoreProvider(instanceProperties, stateStoreFactory);
         serDe = new StateStoreCommitRequestSerDe(tablePropertiesProvider);
         committer = new StateStoreCommitter(
-                CompactionJobTrackerFactory.getTracker(dynamoDBClient, instanceProperties),
+                instanceProperties,
+                tablePropertiesProvider,
+                stateStoreProvider, CompactionJobTrackerFactory.getTracker(dynamoDBClient, instanceProperties),
                 IngestJobTrackerFactory.getTracker(dynamoDBClient, instanceProperties),
-                tablePropertiesProvider, stateStoreProvider,
-                new S3TransactionBodyStore(instanceProperties, s3Client, TransactionSerDeProvider.from(tablePropertiesProvider)),
-                Instant::now);
+                new S3TransactionBodyStore(instanceProperties, s3Client, TransactionSerDeProvider.from(tablePropertiesProvider)), Instant::now);
         throttlingRetriesConfig = PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(5), Duration.ofMinutes(10));
     }
 

--- a/java/statestore-lambda/src/test/java/sleeper/statestore/lambda/committer/StateStoreCommitterLambdaTest.java
+++ b/java/statestore-lambda/src/test/java/sleeper/statestore/lambda/committer/StateStoreCommitterLambdaTest.java
@@ -135,9 +135,9 @@ public class StateStoreCommitterLambdaTest {
     }
 
     private StateStoreCommitter committer(TablePropertiesProvider tablePropertiesProvider, StateStoreProvider stateStoreProvider) {
-        return new StateStoreCommitter(CompactionJobTracker.NONE, IngestJobTracker.NONE,
-                tablePropertiesProvider, stateStoreProvider, transactionLogs.getTransactionBodyStore(),
-                Instant::now);
+        return new StateStoreCommitter(instanceProperties, tablePropertiesProvider,
+                stateStoreProvider, CompactionJobTracker.NONE, IngestJobTracker.NONE,
+                transactionLogs.getTransactionBodyStore(), Instant::now);
     }
 
     private SQSEvent event(SQSMessage... messages) {

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryStateStoreCommitter.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryStateStoreCommitter.java
@@ -89,9 +89,9 @@ public class InMemoryStateStoreCommitter {
             instance = context.instance();
             TablePropertiesProvider tablePropertiesProvider = instance.getTablePropertiesProvider();
             committer = new StateStoreCommitter(
-                    compaction.jobTracker(), ingest.jobTracker(),
-                    tablePropertiesProvider, instance.getStateStoreProvider(), transactionBodyStore,
-                    Instant::now);
+                    instance.getInstanceProperties(), tablePropertiesProvider,
+                    instance.getStateStoreProvider(), compaction.jobTracker(), ingest.jobTracker(),
+                    transactionBodyStore, Instant::now);
         }
 
         @Override

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1113,7 +1113,9 @@ sleeper.compaction.ec2.root.size=50
 sleeper.compaction.tracker.enabled=true
 
 # Flag to enable/disable storing an update to the tracker during async commits of compaction jobs.
-# This is primarily used for testing, in particular when a large number of compactions are present.
+# This may be disabled if there are enough compactions that the system is unable to apply all the
+# updates to the tracker. This is mainly used for testing. Reports may show compactions as unfinished
+# if this update is not present in the tracker.
 sleeper.compaction.tracker.async.commit.updates.enabled=true
 
 # The time to live in seconds for compaction job updates in the job tracker. Default is 1 week.

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1112,6 +1112,10 @@ sleeper.compaction.ec2.root.size=50
 # Flag to enable/disable storage of tracking information for compaction jobs and tasks.
 sleeper.compaction.tracker.enabled=true
 
+# Flag to enable/disable tracking async commits of compaction jobs. This is primarily used for
+# testing, in particular when a large number of compactions are present.
+sleeper.compaction.tracker.async.commit.updates.enabled=true
+
 # The time to live in seconds for compaction job updates in the job tracker. Default is 1 week.
 # The expiry time is fixed when an update is saved to the store, so changing this will only affect new
 # data.

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1112,8 +1112,8 @@ sleeper.compaction.ec2.root.size=50
 # Flag to enable/disable storage of tracking information for compaction jobs and tasks.
 sleeper.compaction.tracker.enabled=true
 
-# Flag to enable/disable tracking async commits of compaction jobs. This is primarily used for
-# testing, in particular when a large number of compactions are present.
+# Flag to enable/disable storing an update to the tracker during async commits of compaction jobs.
+# This is primarily used for testing, in particular when a large number of compactions are present.
 sleeper.compaction.tracker.async.commit.updates.enabled=true
 
 # The time to live in seconds for compaction job updates in the job tracker. Default is 1 week.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4132

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated StateStoreCommitterTest 

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
