### PR TITLE
Issue 4175 - Reduce waits in parallel compaction system test

### DIFF
--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
@@ -86,7 +86,7 @@ public class SystemTestInstance {
     public static final SystemTestInstanceConfiguration MAIN = usingSystemTestDefaults("main", SystemTestInstance::createMainConfiguration);
     public static final SystemTestInstanceConfiguration INGEST_PERFORMANCE = usingSystemTestDefaults("ingest", SystemTestInstance::createIngestPerformanceConfiguration);
     public static final SystemTestInstanceConfiguration COMPACTION_PERFORMANCE = usingSystemTestDefaults("cptprf", SystemTestInstance::createCompactionPerformanceConfiguration);
-    public static final SystemTestInstanceConfiguration COMPACTION_ON_DATAFUSION = usingSystemTestDefaults("cpt-df", SystemTestInstance::createCompactionOnDataFusionConfiguration);
+    public static final SystemTestInstanceConfiguration COMPACTION_PERFORMANCE_DATAFUSION = usingSystemTestDefaults("cpt-df", SystemTestInstance::createCompactionPerformanceOnDataFusionConfiguration);
     public static final SystemTestInstanceConfiguration COMPACTION_CREATION = SystemTestInstanceConfiguration.builder()
             .shortName("cpt-cr")
             .deployConfig(SystemTestInstance::createCompactionCreationConfiguration)
@@ -181,8 +181,8 @@ public class SystemTestInstance {
         return createInstanceConfiguration(properties);
     }
 
-    private static DeployInstanceConfiguration createCompactionOnDataFusionConfiguration() {
-        InstanceProperties properties = createInstanceProperties();
+    private static DeployInstanceConfiguration createCompactionPerformanceOnDataFusionConfiguration() {
+        InstanceProperties properties = createInstancePropertiesWithDefaults();
         properties.setEnum(OPTIONAL_STACKS, OptionalStack.CompactionStack);
         properties.set(COMPACTION_ECS_LAUNCHTYPE, "EC2");
         properties.set(COMPACTION_TASK_CPU_ARCHITECTURE, "X86_64");

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionDataFusionPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionDataFusionPerformanceST.java
@@ -38,7 +38,7 @@ import static sleeper.systemtest.configuration.SystemTestProperty.INGEST_MODE;
 import static sleeper.systemtest.configuration.SystemTestProperty.NUMBER_OF_RECORDS_PER_INGEST;
 import static sleeper.systemtest.configuration.SystemTestProperty.NUMBER_OF_WRITERS;
 import static sleeper.systemtest.dsl.util.SystemTestSchema.DEFAULT_SCHEMA;
-import static sleeper.systemtest.suite.fixtures.SystemTestInstance.COMPACTION_ON_DATAFUSION;
+import static sleeper.systemtest.suite.fixtures.SystemTestInstance.COMPACTION_PERFORMANCE_DATAFUSION;
 import static sleeper.systemtest.suite.testutil.FileReferenceSystemTestHelper.numberOfRecordsIn;
 
 @SystemTest
@@ -47,7 +47,7 @@ public class CompactionDataFusionPerformanceST {
 
     @BeforeEach
     void setUp(SleeperSystemTest sleeper, AfterTestReports reporting) {
-        sleeper.connectToInstanceNoTables(COMPACTION_ON_DATAFUSION);
+        sleeper.connectToInstanceNoTables(COMPACTION_PERFORMANCE_DATAFUSION);
         reporting.reportAlways(SystemTestReports.SystemTestBuilder::compactionTasksAndJobs);
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
@@ -78,13 +78,13 @@ public class ParallelCompactionsST {
         sleeper.compaction()
                 .putTableOnlineWaitForJobCreation(8192,
                         PollWithRetries.intervalAndPollingTimeout(
-                                Duration.ofSeconds(10), Duration.ofMinutes(10)))
+                                Duration.ofSeconds(10), Duration.ofMinutes(2)))
                 .waitForTasks(300)
                 .waitForJobsToFinishThenCommit(
                         PollWithRetries.intervalAndPollingTimeout(
                                 Duration.ofSeconds(10), Duration.ofMinutes(5)),
                         PollWithRetries.intervalAndPollingTimeout(
-                                Duration.ofSeconds(10), Duration.ofMinutes(5)));
+                                Duration.ofSeconds(10), Duration.ofMinutes(2)));
 
         // Then we have one file per partition
         assertThat(sleeper.tableFiles().references())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4175

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - ParallelCompactionsST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
