### PR TITLE
Issue 4161 - Use Maven logger when invoking Rust build

### DIFF
--- a/java/compaction/compaction-rust/pom.xml
+++ b/java/compaction/compaction-rust/pom.xml
@@ -146,6 +146,7 @@
                                 <configuration>
                                     <executable>cross</executable>
                                     <workingDirectory>${maven.multiModuleProjectDirectory}/../rust</workingDirectory>
+                                    <useMavenLogger>true</useMavenLogger>
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--release</argument>
@@ -163,6 +164,7 @@
                                 <configuration>
                                     <executable>cross</executable>
                                     <workingDirectory>${maven.multiModuleProjectDirectory}/../rust</workingDirectory>
+                                    <useMavenLogger>true</useMavenLogger>
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--release</argument>

--- a/java/compaction/compaction-rust/pom.xml
+++ b/java/compaction/compaction-rust/pom.xml
@@ -147,6 +147,7 @@
                                     <executable>cross</executable>
                                     <workingDirectory>${maven.multiModuleProjectDirectory}/../rust</workingDirectory>
                                     <useMavenLogger>true</useMavenLogger>
+                                    <quietLogs>true</quietLogs>
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--release</argument>
@@ -165,6 +166,7 @@
                                     <executable>cross</executable>
                                     <workingDirectory>${maven.multiModuleProjectDirectory}/../rust</workingDirectory>
                                     <useMavenLogger>true</useMavenLogger>
+                                    <quietLogs>true</quietLogs>
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--release</argument>

--- a/java/compaction/compaction-rust/pom.xml
+++ b/java/compaction/compaction-rust/pom.xml
@@ -144,10 +144,9 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>cross</executable>
+                                    <executable>${maven.multiModuleProjectDirectory}/../rust/buildForMaven.sh</executable>
                                     <workingDirectory>${maven.multiModuleProjectDirectory}/../rust</workingDirectory>
                                     <useMavenLogger>true</useMavenLogger>
-                                    <quietLogs>true</quietLogs>
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--release</argument>
@@ -163,10 +162,9 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>cross</executable>
+                                    <executable>${maven.multiModuleProjectDirectory}/../rust/buildForMaven.sh</executable>
                                     <workingDirectory>${maven.multiModuleProjectDirectory}/../rust</workingDirectory>
                                     <useMavenLogger>true</useMavenLogger>
-                                    <quietLogs>true</quietLogs>
                                     <arguments>
                                         <argument>build</argument>
                                         <argument>--release</argument>

--- a/rust/buildForMaven.sh
+++ b/rust/buildForMaven.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright 2022-2024 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Redirect stderr to stdout, so that Maven will log the output at INFO level instead of ERROR
+cross "$@" 2>&1

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -30,6 +30,7 @@ pushd "$MAVEN_DIR"
 echo "-------------------------------------------------------------------------------"
 echo "Building Project"
 echo "-------------------------------------------------------------------------------"
+echo "Running Maven in quiet mode, this may take several minutes."
 echo "Started at $(recorded_time_str "$START_BUILD_TIME")"
 
 VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4161

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - See "Build Rust Modules" GitHub Actions run for non-quiet mode
    - Ran build script manually and checked output

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
