### PR TITLE
Issue 4408 - Docs should have a page with tables of all instance and table properties

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/util/table/TableWriterFactory.java
+++ b/java/clients/src/main/java/sleeper/clients/util/table/TableWriterFactory.java
@@ -65,6 +65,13 @@ public class TableWriterFactory {
             return this;
         }
 
+        public Builder addFields(List<String> fieldList) {
+            for (String fieldString : fieldList) {
+                addField(fieldString);
+            }
+            return this;
+        }
+
         TableField addField(TableField field) {
             fields.add(field);
             return field;
@@ -73,6 +80,10 @@ public class TableWriterFactory {
         public Builder structure(TableStructure structure) {
             this.structure = structure;
             return this;
+        }
+
+        public List<TableField> getFields() {
+            return this.fields;
         }
 
         public TableWriterFactory build() {

--- a/java/clients/src/main/java/sleeper/clients/util/table/TableWriterPropertyHelper.java
+++ b/java/clients/src/main/java/sleeper/clients/util/table/TableWriterPropertyHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.util.table;
+
+import sleeper.clients.util.table.TableRow.Builder;
+import sleeper.core.properties.instance.InstanceProperty;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public class TableWriterPropertyHelper {
+
+    private TableWriterPropertyHelper() {
+    }
+
+    public static List<String> getMarkdownFields() {
+        return List.of("Property Name", "Description", "Default Value", "Run CdkDeploy When Changed");
+    }
+
+    public static Consumer<Builder> generatePropertyDetails(List<TableField> fields, InstanceProperty property) {
+        return row -> {
+            row.value(fields.get(0), property.getPropertyName());
+            row.value(fields.get(1), property.getDescription());
+            row.value(fields.get(2), property.getDefaultValue());
+            row.value(fields.get(3), property.isRunCdkDeployWhenChanged());
+        };
+    }
+}

--- a/java/clients/src/test/java/sleeper/clients/util/table/TableWriterTest.java
+++ b/java/clients/src/test/java/sleeper/clients/util/table/TableWriterTest.java
@@ -18,6 +18,8 @@ package sleeper.clients.util.table;
 import org.junit.jupiter.api.Test;
 
 import sleeper.clients.testutil.ToStringConsoleOutput;
+import sleeper.core.properties.instance.CommonProperty;
+import sleeper.core.properties.instance.InstanceProperty;
 
 import java.io.IOException;
 
@@ -157,5 +159,27 @@ class TableWriterTest {
                 .build().write(output.getPrintStream());
         // Then
         assertThat(output).hasToString(example("reports/table/markdown.txt"));
+    }
+
+    @Test
+    void shouldCreateMarkdownTableWithProvidedInstanceProperties() throws IOException {
+        // Given
+        TableStructure structure = TableStructure.MARKDOWN_FORMAT;
+        TableWriterFactory.Builder factoryBuilder = TableWriterFactory.builder().structure(structure);
+        factoryBuilder.addFields(TableWriterPropertyHelper.getMarkdownFields());
+
+        TableWriterFactory factory = factoryBuilder.build();
+        ToStringConsoleOutput output = new ToStringConsoleOutput();
+
+        InstanceProperty property1 = CommonProperty.JARS_BUCKET;
+        InstanceProperty property2 = CommonProperty.FILE_SYSTEM;
+
+        // When
+        factory.tableBuilder()
+                .row(TableWriterPropertyHelper.generatePropertyDetails(factoryBuilder.getFields(), property1))
+                .row(TableWriterPropertyHelper.generatePropertyDetails(factoryBuilder.getFields(), property2))
+                .build().write(output.getPrintStream());
+        // Then
+        assertThat(output).hasToString(example("reports/table/property.txt"));
     }
 }

--- a/java/clients/src/test/resources/reports/table/property.txt
+++ b/java/clients/src/test/resources/reports/table/property.txt
@@ -1,0 +1,6 @@
+
+| Property Name       | Description                                                       | Default Value | Run CdkDeploy When Changed |
+|---------------------|-------------------------------------------------------------------|---------------|----------------------------|
+| sleeper.jars.bucket | The S3 bucket containing the jar files of the Sleeper components. |               | true                       |
+| sleeper.filesystem  | The Hadoop filesystem used to connect to S3.                      | s3a://        | false                      |
+


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4408

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - New tests in TablewriterTests

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
