### PR TITLE
Issue 4484 - Configure maximum files to delete per GC invocation

### DIFF
--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -976,8 +976,9 @@ sleeper.gc.offline.enabled=false
 sleeper.gc.batch.size=10000
 
 # The maximum number of files that can be deleted per invocation of the garbage collector.
-# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, and
-# leaving deleted but uncommitted files in the state store until the next run.
+# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, which
+# would leave deleted but uncommitted files in the state store until the next run.
+# If a batch of files exceeds this limit, the whole batch will be deleted before terminating.
 sleeper.gc.files.maximum=1000000
 
 # A file will not be deleted until this number of minutes have passed after it has been marked as

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -975,6 +975,11 @@ sleeper.gc.offline.enabled=false
 # and updates the state store whenever it has deleted this many files.
 sleeper.gc.batch.size=10000
 
+# The maximum number of files that can be deleted per invocation of the garbage collector.
+# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, and
+# leaving deleted but uncommitted files in the state store until the next run.
+sleeper.gc.files.maximum=1000000
+
 # A file will not be deleted until this number of minutes have passed after it has been marked as
 # ready for garbage collection. The reason for not deleting files immediately after they have been
 # marked as ready for garbage collection is that they may still be in use by queries. This property

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -976,11 +976,13 @@ sleeper.gc.offline.enabled=false
 sleeper.gc.batch.size=10000
 
 # The maximum number of files that can be deleted per invocation of the garbage collector.
-# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, which
-# would leave deleted but uncommitted files in the state store until the next run.
 # If a batch of files exceeds this limit, the whole batch will be deleted before terminating.
 # This limit is applied separately for each Sleeper table.
-sleeper.gc.files.maximum=1000000
+# This restriction is placed to avoid reaching the lambda timeout for the garbage collector. If this
+# timeout is met, it is most likely to happen whilst deleting a batch of files. This would result in
+# files being deleted, but the state store not being updated. Any files caught in such a state will be
+# found on the next garbage collector run and deleted again, updating the state store as expected.
+sleeper.gc.files.maximum=750000
 
 # A file will not be deleted until this number of minutes have passed after it has been marked as
 # ready for garbage collection. The reason for not deleting files immediately after they have been

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -979,6 +979,7 @@ sleeper.gc.batch.size=10000
 # This restriction is placed to avoid reaching the lambda timeout for the garbage collector, which
 # would leave deleted but uncommitted files in the state store until the next run.
 # If a batch of files exceeds this limit, the whole batch will be deleted before terminating.
+# This limit is applied separately for each Sleeper table.
 sleeper.gc.files.maximum=1000000
 
 # A file will not be deleted until this number of minutes have passed after it has been marked as

--- a/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
@@ -76,7 +76,8 @@ public interface GarbageCollectionProperty {
             .description("The maximum number of files that can be deleted per invocation of the garbage collector.\n" +
                     "This restriction is placed to avoid reaching the lambda timeout for the garbage collector, " +
                     "which would leave deleted but uncommitted files in the state store until the next run.\n" +
-                    "If a batch of files exceeds this limit, the whole batch will be deleted before terminating.")
+                    "If a batch of files exceeds this limit, the whole batch will be deleted before terminating.\n" +
+                    "This limit is applied separately for each Sleeper table.")
             .defaultValue("1000000")
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
     UserDefinedInstanceProperty DEFAULT_GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION = Index.propertyBuilder("sleeper.default.gc.delay.minutes")

--- a/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
@@ -74,11 +74,14 @@ public interface GarbageCollectionProperty {
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
     UserDefinedInstanceProperty GARBAGE_COLLECTOR_MAXIMUM_FILE_DELETION_PER_INVOCATION = Index.propertyBuilder("sleeper.gc.files.maximum")
             .description("The maximum number of files that can be deleted per invocation of the garbage collector.\n" +
-                    "This restriction is placed to avoid reaching the lambda timeout for the garbage collector, " +
-                    "which would leave deleted but uncommitted files in the state store until the next run.\n" +
                     "If a batch of files exceeds this limit, the whole batch will be deleted before terminating.\n" +
-                    "This limit is applied separately for each Sleeper table.")
-            .defaultValue("1000000")
+                    "This limit is applied separately for each Sleeper table.\n" +
+                    "This restriction is placed to avoid reaching the lambda timeout for the garbage collector. " +
+                    "If this timeout is met, it is most likely to happen whilst deleting a batch of files. " +
+                    "This would result in files being deleted, but the state store not being updated. " +
+                    "Any files caught in such a state will be found on the next garbage collector run and deleted again, " +
+                    "updating the state store as expected.")
+            .defaultValue("750000")
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
     UserDefinedInstanceProperty DEFAULT_GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION = Index.propertyBuilder("sleeper.default.gc.delay.minutes")
             .description("A file will not be deleted until this number of minutes have passed after it has been marked as ready for " +

--- a/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
@@ -72,6 +72,12 @@ public interface GarbageCollectionProperty {
                     "store, and updates the state store whenever it has deleted this many files.")
             .defaultValue("10000")
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
+    UserDefinedInstanceProperty GARBAGE_COLLECTOR_MAXIMUM_FILE_DELETION_PER_INVOCATION = Index.propertyBuilder("sleeper.gc.files.maximum")
+            .description("The maximum number of files that can be deleted per invocation of the garbage collector.\n" +
+                    "This restriction is placed to avoid reaching the lambda timeout for the garbage collector, and leaving " +
+                    "deleted but uncommitted files in the state store until the next run.")
+            .defaultValue("1000000")
+            .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
     UserDefinedInstanceProperty DEFAULT_GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION = Index.propertyBuilder("sleeper.default.gc.delay.minutes")
             .description("A file will not be deleted until this number of minutes have passed after it has been marked as ready for " +
                     "garbage collection. The reason for not deleting files immediately after they have been marked as ready for " +

--- a/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/GarbageCollectionProperty.java
@@ -74,8 +74,9 @@ public interface GarbageCollectionProperty {
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
     UserDefinedInstanceProperty GARBAGE_COLLECTOR_MAXIMUM_FILE_DELETION_PER_INVOCATION = Index.propertyBuilder("sleeper.gc.files.maximum")
             .description("The maximum number of files that can be deleted per invocation of the garbage collector.\n" +
-                    "This restriction is placed to avoid reaching the lambda timeout for the garbage collector, and leaving " +
-                    "deleted but uncommitted files in the state store until the next run.")
+                    "This restriction is placed to avoid reaching the lambda timeout for the garbage collector, " +
+                    "which would leave deleted but uncommitted files in the state store until the next run.\n" +
+                    "If a batch of files exceeds this limit, the whole batch will be deleted before terminating.")
             .defaultValue("1000000")
             .propertyGroup(InstancePropertyGroup.GARBAGE_COLLECTOR).build();
     UserDefinedInstanceProperty DEFAULT_GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION = Index.propertyBuilder("sleeper.default.gc.delay.minutes")

--- a/java/garbage-collector/src/main/java/sleeper/garbagecollector/GarbageCollector.java
+++ b/java/garbage-collector/src/main/java/sleeper/garbagecollector/GarbageCollector.java
@@ -94,15 +94,16 @@ public class GarbageCollector {
     }
 
     private void deleteInBatches(TableProperties tableProperties, Instant startTime, TableFilesDeleted deleted) {
-        int garbageCollectorBatchSize = instanceProperties.getInt(GARBAGE_COLLECTOR_BATCH_SIZE);
+        int batchSize = instanceProperties.getInt(GARBAGE_COLLECTOR_BATCH_SIZE);
+        int maxFiles = instanceProperties.getInt(GARBAGE_COLLECTOR_MAXIMUM_FILE_DELETION_PER_INVOCATION);
         StateStore stateStore = stateStoreProvider.getStateStore(tableProperties);
         Iterator<String> readyForGC = getReadyForGCIterator(tableProperties, startTime, stateStore);
         List<String> batch = new ArrayList<>();
         while (readyForGC.hasNext() &&
-                deleted.getDeletedFileCount() < instanceProperties.getInt(GARBAGE_COLLECTOR_MAXIMUM_FILE_DELETION_PER_INVOCATION)) {
+                deleted.getDeletedFileCount() < maxFiles) {
             String filename = readyForGC.next();
             batch.add(filename);
-            if (batch.size() == garbageCollectorBatchSize) {
+            if (batch.size() == batchSize) {
                 deleteBatch(batch, tableProperties, stateStore, deleted);
                 batch.clear();
             }

--- a/java/garbage-collector/src/main/java/sleeper/garbagecollector/GarbageCollector.java
+++ b/java/garbage-collector/src/main/java/sleeper/garbagecollector/GarbageCollector.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static sleeper.core.properties.instance.GarbageCollectionProperty.GARBAGE_COLLECTOR_BATCH_SIZE;
+import static sleeper.core.properties.instance.GarbageCollectionProperty.GARBAGE_COLLECTOR_MAXIMUM_FILE_DELETION_PER_INVOCATION;
 import static sleeper.core.properties.table.TableProperty.GARBAGE_COLLECTOR_ASYNC_COMMIT;
 import static sleeper.core.properties.table.TableProperty.GARBAGE_COLLECTOR_DELAY_BEFORE_DELETION;
 import static sleeper.core.properties.table.TableProperty.TABLE_ID;
@@ -97,7 +98,8 @@ public class GarbageCollector {
         StateStore stateStore = stateStoreProvider.getStateStore(tableProperties);
         Iterator<String> readyForGC = getReadyForGCIterator(tableProperties, startTime, stateStore);
         List<String> batch = new ArrayList<>();
-        while (readyForGC.hasNext()) {
+        while (readyForGC.hasNext() &&
+                deleted.getDeletedFileCount() < instanceProperties.getInt(GARBAGE_COLLECTOR_MAXIMUM_FILE_DELETION_PER_INVOCATION)) {
             String filename = readyForGC.next();
             batch.add(filename);
             if (batch.size() == garbageCollectorBatchSize) {

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1008,11 +1008,13 @@ sleeper.gc.offline.enabled=false
 sleeper.gc.batch.size=10000
 
 # The maximum number of files that can be deleted per invocation of the garbage collector.
-# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, which
-# would leave deleted but uncommitted files in the state store until the next run.
 # If a batch of files exceeds this limit, the whole batch will be deleted before terminating.
 # This limit is applied separately for each Sleeper table.
-sleeper.gc.files.maximum=1000000
+# This restriction is placed to avoid reaching the lambda timeout for the garbage collector. If this
+# timeout is met, it is most likely to happen whilst deleting a batch of files. This would result in
+# files being deleted, but the state store not being updated. Any files caught in such a state will be
+# found on the next garbage collector run and deleted again, updating the state store as expected.
+sleeper.gc.files.maximum=750000
 
 # A file will not be deleted until this number of minutes have passed after it has been marked as
 # ready for garbage collection. The reason for not deleting files immediately after they have been

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1011,6 +1011,7 @@ sleeper.gc.batch.size=10000
 # This restriction is placed to avoid reaching the lambda timeout for the garbage collector, which
 # would leave deleted but uncommitted files in the state store until the next run.
 # If a batch of files exceeds this limit, the whole batch will be deleted before terminating.
+# This limit is applied separately for each Sleeper table.
 sleeper.gc.files.maximum=1000000
 
 # A file will not be deleted until this number of minutes have passed after it has been marked as

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1008,8 +1008,9 @@ sleeper.gc.offline.enabled=false
 sleeper.gc.batch.size=10000
 
 # The maximum number of files that can be deleted per invocation of the garbage collector.
-# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, and
-# leaving deleted but uncommitted files in the state store until the next run.
+# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, which
+# would leave deleted but uncommitted files in the state store until the next run.
+# If a batch of files exceeds this limit, the whole batch will be deleted before terminating.
 sleeper.gc.files.maximum=1000000
 
 # A file will not be deleted until this number of minutes have passed after it has been marked as

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1007,6 +1007,11 @@ sleeper.gc.offline.enabled=false
 # and updates the state store whenever it has deleted this many files.
 sleeper.gc.batch.size=10000
 
+# The maximum number of files that can be deleted per invocation of the garbage collector.
+# This restriction is placed to avoid reaching the lambda timeout for the garbage collector, and
+# leaving deleted but uncommitted files in the state store until the next run.
+sleeper.gc.files.maximum=1000000
+
 # A file will not be deleted until this number of minutes have passed after it has been marked as
 # ready for garbage collection. The reason for not deleting files immediately after they have been
 # marked as ready for garbage collection is that they may still be in use by queries. This property


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4484

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - New test within GarbageCollectionTest - shouldDeleteFilesUpToLimitWithinSingleInvocation

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
