### PR TITLE
Issue 4559 - Install Java 21 in dev container

### DIFF
--- a/scripts/cli/builder/Dockerfile
+++ b/scripts/cli/builder/Dockerfile
@@ -16,7 +16,7 @@ ARG DEPENDENCIES_IMAGE="sleeper-dependencies:current"
 FROM ${DEPENDENCIES_IMAGE}
 
 RUN apt-get update && apt-get install -y \
-    java-21-amazon-corretto \
+    java-21-amazon-corretto-jdk \
     maven \
     git \
     python3 \

--- a/scripts/cli/builder/Dockerfile
+++ b/scripts/cli/builder/Dockerfile
@@ -16,6 +16,7 @@ ARG DEPENDENCIES_IMAGE="sleeper-dependencies:current"
 FROM ${DEPENDENCIES_IMAGE}
 
 RUN apt-get update && apt-get install -y \
+    java-21-amazon-corretto \
     maven \
     git \
     python3 \
@@ -28,6 +29,9 @@ RUN apt-get update && apt-get install -y \
     gcc g++ cmake make \
     pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# VS Code Java extension requires Java 21, so we install that but set the preferred version to match AWS EMR.
+RUN update-java-alternatives --set java-17-amazon-corretto
 
 # Install Rust
 # Change install location because the default is in the home directory, which is overwritten by Dev Containers.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4559

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Ran locally in VS Code with the commands below

Ran the following commands in a terminal to rebuild the builder image and set it to be used in the dev container:
```bash
cd ./scripts/cli
./dependencies/build.sh
./builder/build.sh
docker tag sleeper-builder:current ghcr.io/gchq/sleeper-builder:latest
```

Then used VS Code's "Dev Containers: Rebuild Container" command, and waited for it to rebuild the container and reinstall all the extensions.

Once this PR is merged and the build has finished against develop in GitHub Actions, the commands above will not be needed and you can just run "Dev Containers: Rebuild Container" in VS Code. It still takes some time to rebuild the container and install the extensions.

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
