### PR TITLE
Issue 4240 - Write statistics truncation property in DataFusion compaction

### DIFF
--- a/rust/compaction/src/datafusion.rs
+++ b/rust/compaction/src/datafusion.rs
@@ -406,6 +406,10 @@ fn create_session_cfg<T>(input_data: &CompactionInput, input_paths: &[T]) -> Ses
         .execution
         .parquet
         .column_index_truncate_length = Some(input_data.column_truncate_length);
+    sf.options_mut()
+        .execution
+        .parquet
+        .statistics_truncate_length = Some(input_data.stats_truncate_length);
     sf
 }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4240

### Tests

- [X] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Restoring original behaviour before bug occured.

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
