### PR TITLE
4519: Change queryExecutorCache in SqsQueryProcessor to use TableId i…

### DIFF
--- a/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
+++ b/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
@@ -54,7 +54,7 @@ import java.util.concurrent.Executors;
 
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.LEAF_PARTITION_QUERY_QUEUE_URL;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSOR_LAMBDA_RECORD_RETRIEVAL_THREADS;
-import static sleeper.core.properties.table.TableProperty.TABLE_NAME;
+import static sleeper.core.properties.table.TableProperty.TABLE_ID;
 
 public class SqsQueryProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqsQueryProcessor.class);
@@ -68,7 +68,6 @@ public class SqsQueryProcessor {
     private final ObjectFactory objectFactory;
     private final DynamoDBQueryTracker queryTracker;
     private final Map<String, QueryExecutor> queryExecutorCache = new HashMap<>();
-    private final Map<String, Configuration> configurationCache = new HashMap<>();
 
     private SqsQueryProcessor(Builder builder) throws ObjectFactoryException {
         sqsClient = builder.sqsClient;
@@ -103,9 +102,9 @@ public class SqsQueryProcessor {
     }
 
     private void processRangeQuery(Query query, TableProperties tableProperties, QueryStatusReportListeners queryTrackers) throws QueryException {
-        QueryExecutor queryExecutor = queryExecutorCache.computeIfAbsent(query.getTableName(), tableName -> {
+        QueryExecutor queryExecutor = queryExecutorCache.computeIfAbsent(tableProperties.get(TABLE_ID), tableID -> {
             StateStore stateStore = stateStoreProvider.getStateStore(tableProperties);
-            Configuration conf = getConfiguration(tableProperties);
+            Configuration conf = HadoopConfigurationProvider.getConfigurationForQueryLambdas(instanceProperties, tableProperties);
             return new QueryExecutor(objectFactory, tableProperties, stateStore,
                     new LeafPartitionRecordRetrieverImpl(executorService, conf, tableProperties));
         });
@@ -130,15 +129,6 @@ public class SqsQueryProcessor {
         }
         queryTrackers.subQueriesCreated(query, subQueries);
         LOGGER.info("Submitted {} subqueries to queue", subQueries.size());
-    }
-
-    private Configuration getConfiguration(TableProperties tableProperties) {
-        String tableName = tableProperties.get(TABLE_NAME);
-        if (!configurationCache.containsKey(tableName)) {
-            Configuration conf = HadoopConfigurationProvider.getConfigurationForQueryLambdas(instanceProperties, tableProperties);
-            configurationCache.put(tableName, conf);
-        }
-        return configurationCache.get(tableName);
     }
 
     public static final class Builder {


### PR DESCRIPTION
…nstead of tableName

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4519

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Test coverage sufficient in SqsProcessorLambdaIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
