### PR TITLE
Issue 4715 - Datafusion compactor assumes output s3 bucket is same as input bucket

### DIFF
--- a/rust/compaction/src/datafusion.rs
+++ b/rust/compaction/src/datafusion.rs
@@ -70,10 +70,10 @@ pub async fn compact(
     let ctx = SessionContext::new_with_config(sf);
 
     // Register some object store from first input file and output file
-    let store = register_store(store_factory, input_paths, output_path, &ctx)?;
+    register_store(store_factory, input_paths, output_path, &ctx)?;
 
     // Set the upload size based upon size of input data
-    set_multipart_upload_hint(store_factory, input_paths, output_path, store).await?;
+    set_multipart_upload_hint(store_factory, input_paths, output_path).await?;
 
     // Sort on row key columns then sort key columns (nulls last)
     let sort_order = sort_order(input_data);
@@ -219,9 +219,11 @@ async fn set_multipart_upload_hint(
     store_factory: &ObjectStoreFactory,
     input_paths: &[Url],
     output_path: &Url,
-    store: Arc<dyn SizeHintableStore>,
 ) -> Result<(), DataFusionError> {
-    let input_size = calculate_input_size(input_paths, &store)
+    let input_store = store_factory
+        .get_object_store(&input_paths[0])
+        .map_err(|e| DataFusionError::External(e.into()))?;
+    let input_size = calculate_input_size(input_paths, &input_store)
         .await
         .inspect_err(|e| warn!("Error getting total input size {e}"));
     let multipart_size = std::cmp::max(
@@ -455,7 +457,7 @@ fn register_store(
     input_paths: &[Url],
     output_path: &Url,
     ctx: &SessionContext,
-) -> Result<Arc<dyn SizeHintableStore>, DataFusionError> {
+) -> Result<(), DataFusionError> {
     let in_store = store_factory
         .get_object_store(&input_paths[0])
         .map_err(|e| DataFusionError::External(e.into()))?;
@@ -466,5 +468,5 @@ fn register_store(
         .map_err(|e| DataFusionError::External(e.into()))?;
     ctx.runtime_env()
         .register_object_store(output_path, out_store.as_object_store());
-    Ok(in_store)
+    Ok(())
 }

--- a/rust/compaction/src/s3.rs
+++ b/rust/compaction/src/s3.rs
@@ -125,6 +125,17 @@ impl ObjectStoreFactory {
         }
     }
 
+    fn make_cache_key_for(url: &Url) -> String {
+        let scheme = url.scheme();
+        match scheme {
+            "s3" => {
+                // Amazon S3 object store implementation is bucket specific
+                let host = ext
+            }
+            _ => scheme.to_owned(),
+        }
+    }
+
     /// Retrieves the appropriate [`object_store::ObjectStore`] for a given URL.
     ///
     /// The object returned will be the same for each subsequent call to this method for a given URL scheme.

--- a/rust/compaction/src/s3.rs
+++ b/rust/compaction/src/s3.rs
@@ -125,14 +125,23 @@ impl ObjectStoreFactory {
         }
     }
 
-    fn make_cache_key_for(url: &Url) -> String {
+    /// Create a cache key for the given URL.
+    ///
+    /// Most are based purely off the scheme for the URL,
+    /// but some implementations like [`AmazonS3`] are configured
+    /// per bucket, so that needs to be part of the cache key.
+    ///
+    /// # Errors
+    /// If the URL host can't be obtained
+    fn make_cache_key_for(url: &Url) -> color_eyre::Result<String> {
         let scheme = url.scheme();
         match scheme {
             "s3" => {
                 // Amazon S3 object store implementation is bucket specific
-                let host = ext
+                let host = extract_bucket(&url)?;
+                Ok(format!("s3://{host}"))
             }
-            _ => scheme.to_owned(),
+            _ => Ok(scheme.to_owned()),
         }
     }
 
@@ -148,10 +157,9 @@ impl ObjectStoreFactory {
     ///
     /// If no credentials have been provided, then trying to access S3 URLs will fail.
     pub fn get_object_store(&self, src: &Url) -> color_eyre::Result<Arc<dyn SizeHintableStore>> {
-        let scheme = src.scheme();
         let mut borrow = self.store_map.borrow_mut();
         // Perform a single lookup into the cache map
-        match borrow.entry(scheme.to_owned()) {
+        match borrow.entry(ObjectStoreFactory::make_cache_key_for(&src)?) {
             // if entry found, then clone the shared pointer
             Entry::Occupied(occupied) => Ok(occupied.get().clone()),
             // otherwise, attempt to create the object store
@@ -216,7 +224,7 @@ mod tests {
     use color_eyre::eyre::Result;
     use url::Url;
 
-    use super::extract_bucket;
+    use super::{ObjectStoreFactory, extract_bucket};
 
     #[test]
     fn should_extract_bucket() -> Result<()> {
@@ -244,6 +252,32 @@ mod tests {
         let s = bucket.unwrap_err().to_string();
         assert_eq!(s, "invalid S3 bucket name");
 
+        Ok(())
+    }
+
+    #[test]
+    fn should_create_scheme_cache_key_for_local() -> Result<()> {
+        // Given
+        let url = Url::parse("file:///some/file")?;
+
+        // When
+        let cache_key = ObjectStoreFactory::make_cache_key_for(&url)?;
+
+        // Then
+        assert_eq!(cache_key, "file");
+        Ok(())
+    }
+
+    #[test]
+    fn should_create_bucket_cache_key_for_s3() -> Result<()> {
+        // Given
+        let url = Url::parse("s3://test-bucket/key")?;
+
+        // When
+        let cache_key = ObjectStoreFactory::make_cache_key_for(&url)?;
+
+        // Then
+        assert_eq!(cache_key, "s3://test-bucket");
         Ok(())
     }
 }

--- a/rust/compaction/src/s3.rs
+++ b/rust/compaction/src/s3.rs
@@ -138,7 +138,7 @@ impl ObjectStoreFactory {
         match scheme {
             "s3" => {
                 // Amazon S3 object store implementation is bucket specific
-                let host = extract_bucket(&url)?;
+                let host = extract_bucket(url)?;
                 Ok(format!("s3://{host}"))
             }
             _ => Ok(scheme.to_owned()),
@@ -159,7 +159,7 @@ impl ObjectStoreFactory {
     pub fn get_object_store(&self, src: &Url) -> color_eyre::Result<Arc<dyn SizeHintableStore>> {
         let mut borrow = self.store_map.borrow_mut();
         // Perform a single lookup into the cache map
-        match borrow.entry(ObjectStoreFactory::make_cache_key_for(&src)?) {
+        match borrow.entry(ObjectStoreFactory::make_cache_key_for(src)?) {
             // if entry found, then clone the shared pointer
             Entry::Occupied(occupied) => Ok(occupied.get().clone()),
             // otherwise, attempt to create the object store


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4716

### Tests

- [X] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - rust/compaction/src/s3.rs cache key tests

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
