### PR TITLE
Issue 4882 - Document pre-splitting a Sleeper table

### DIFF
--- a/docs/deployment/instance-configuration.md
+++ b/docs/deployment/instance-configuration.md
@@ -1,0 +1,107 @@
+Sleeper instance configuration
+==============================
+
+Sleeper is configured with a number of properties that control its behaviour. Instance properties are set for a whole
+deployed instance of Sleeper, and table properties are set for individual tables. Some instance properties are applied
+during deployment by the CDK, and some are applied at runtime by the system itself. All table properties are applied at
+runtime.
+
+You can find descriptions of all properties in the system [here](../usage/property-master.md).
+
+During automated deployment, these properties can be set to defaults. You can then edit these with the admin client.
+Alternatively you can manually create configuration files to set the values you want, which you can then version, e.g.
+with Git, to track and automate changes.
+
+There are examples of configuration files for an instance with a single table [here](../../example). You can use this as
+a starting point for your own configuration. As we improve support for deployment with infrastructure as code, we will
+add further examples.
+
+### Configuration folder structure
+
+You can include the following files in your configuration:
+
+* An `instance.properties` file - containing information about your Sleeper instance, as well as
+  default values used by tables if not specified.
+* A `tags.properties` file which lists the tags you want all of your Sleeper infrastructure to be tagged with.
+* A `table.properties` file which contains information about a table and a link to its schema file.
+* A `schema.json` file which describes the data stored in a Sleeper table.
+* A `splits.txt` file which allows you to pre-split partitions in a Sleeper table.
+
+The `.properties` files are Java properties files. The directory containing `instance.properties` will be considered
+the root directory of your configuration.
+
+You can optionally create a `tags.properties` file next to your `instance.properties`, to apply tags to AWS resources
+deployed by Sleeper. An example tags.properties file can be found [here](../../example/full/tags.properties).
+
+To include a table in your instance, your `table.properties` file can be in the same folder as
+your `instance.properties` file. You can add more than one by creating a `tables` directory in the same folder, with a
+subfolder for each table. See [tables](../usage/tables.md) for more information on creating and working with Sleeper
+tables.
+
+Each table will also need a `schema.json` file next to the `table.properties` file.
+See [create a schema](../usage/schema.md) for how to create a schema.
+
+You can optionally create a `splits.txt` file, which sets the starting split points for partitions when the table is
+created. These are the boundaries where one partition ends and another begins. If you do not set split points, the table
+will be initialised with a single root partition. Note that pre-splitting a table is important for any large-scale use
+of Sleeper, and is essential for running bulk import jobs.
+See [tables](../usage/tables.md#pre-split-partitions) for more information on how to create this file.
+
+At time of writing, the `splits.txt` file needs to be referenced from the `table.properties` file in
+the `sleeper.table.splits.file` property, as an absolute path. This will change in a future version of Sleeper.
+
+Here's a full example with two tables:
+
+```
+instance.properties
+tags.properties
+tables/table-1/table.properties
+tables/table-1/schema.json
+tables/table-1/splits.txt
+tables/table-2/table.properties
+tables/table-2/schema.json
+tables/table-2/splits.txt
+```
+
+### Optional Stacks
+
+By default all the stacks are deployed. However, if you don't need them, you can customise which stacks are deployed.
+
+Mandatory components are the configuration bucket and data bucket, the index of Sleeper tables, the state store,
+policies and roles to interact with the instance, and the `TopicStack` which creates an SNS topic used by other stacks
+to report errors.
+
+That leaves the following stacks as optional:
+
+* `CompactionStack` - for running compactions (in practice this is essential)
+* `GarbageCollectorStack` - for running garbage collection (in practice this is essential)
+* `IngestStack` - for ingesting files using the "standard" ingest method
+* `PartitionSplittingStack` - for splitting partitions when they get too large
+* `QueryStack` - for handling queries via SQS
+* `WebSocketQueryStack` - for handling queries via a web socket
+* `KeepLambdaWarmStack` - for sending dummy queries to avoid waiting for lambdas to start up during queries
+* `EmrServerlessBulkImportStack` - for running bulk import jobs using Spark running on EMR Serverless
+* `EmrStudioStack` - to create an EMR Studio containing the EMR Serverless application
+* `EmrBulkImportStack` - for running bulk import jobs using Spark running on an EMR cluster that is created on demand
+* `PersistentEmrBulkImportStack` - for running bulk import jobs using Spark running on a persistent EMR cluster, i.e. one
+  that is always running (and therefore always costing money). By default, this uses EMR's managed scaling to scale up
+  and down on demand.
+* `IngestBatcherStack` - for gathering files to be ingested or bulk imported in larger jobs
+* `TableMetricsStack` - for creating CloudWatch metrics showing statistics such as the number of records in a table over
+  time
+* `DashboardStack` - to create a CloudWatch dashboard showing recorded metrics
+* `BulkExportStack` - to export a whole table as parquet files
+
+The following stacks are optional and experimental:
+
+* `AthenaStack` - for running SQL analytics over the data
+* `EksBulkImportStack` - for running bulk import jobs using Spark running on EKS
+
+By default most of the optional stacks are included but to customise it, set the `sleeper.optional.stacks` sleeper
+property to a comma separated list of stack names, for example:
+
+```properties
+sleeper.optional.stacks=CompactionStack,IngestStack,QueryStack
+```
+
+Note that the system test stacks do not need to be specified. They will be included if you use the system test CDK app.

--- a/docs/usage/ingest.md
+++ b/docs/usage/ingest.md
@@ -703,24 +703,21 @@ This may be deployed by adding `IngestBatcherStack` to the list of optional stac
 Files to be ingested must be accessible to the ingest system you will use. See above for ways to provide access to an
 ingest source bucket, e.g. by setting the property `sleeper.ingest.source.bucket`.
 
-Files can be submitted as messages to the batcher submission SQS queue. You can find the URL of this queue in the
-system-defined property `sleeper.ingest.batcher.submit.queue.url`.
+Files can be submitted as messages to the batcher submission SQS queue. A script is available to do this:
 
-An example message is shown below:
-
-```json
-{
-  "tableName": "target-table",
-  "files": [
-    "source-bucket-name/file.parquet"
-  ]
-}
+```bash
+./scripts/utility/sendToIngestBatcher.sh <instance-id> <table-name> <parquet-paths-as-separate-args>
 ```
 
-Each message is a request to ingest a collection of files into a Sleeper table. If you provide a directory in S3
-instead of a file, the batcher will look in all subdirectories and track any files found in them.
+Paths to the files must be in an S3 bucket, specified with the bucket name and object key like
+this: `source-bucket-name/folder-prefix/file.parquet`. If you provide a directory in S3 instead of a file, the batcher
+will look in all subdirectories and track any files found in them.
 
-The batcher will then track these files and group them into jobs periodically, based on the configuration. The
+You can also submit requests to the queue manually as described [below](#manually-sending-files-to-the-batcher-queue).
+
+### Job creation
+
+The batcher will track all submitted files and group them into jobs periodically, based on its configuration. The
 configuration specifies minimum and maximum size of a batch, and a maximum age for files.
 
 The minimum batch size determines whether any jobs will be created. The maximum batch size splits the tracked files
@@ -748,3 +745,22 @@ types below:
 
 - ALL, which will show you files waiting to be batched, and files that have been batched.
 - PENDING, which will only show you files that are waiting to be batched.
+
+### Manually sending files to the batcher queue
+
+You can find the URL of the ingest batcher submission queue in the system-defined
+property `sleeper.ingest.batcher.submit.queue.url`.
+
+An example message is shown below:
+
+```json
+{
+  "tableName": "target-table",
+  "files": [
+    "source-bucket-name/folder-prefix/file.parquet"
+  ]
+}
+```
+
+Each message is a request to ingest a collection of files into a Sleeper table. If you provide a directory in S3
+instead of a file, the batcher will look in all subdirectories and track any files found in them.

--- a/docs/usage/ingest.md
+++ b/docs/usage/ingest.md
@@ -161,7 +161,7 @@ of `sleeper.ingest.max.local.records`). Using the bulk import method, there will
 the 1000 files are all imported in the same bulk import job).
 
 Note that it is vital that a table is pre-split before data is bulk
-imported ([see here](../usage/tables.md#reinitialise-a-table)).
+imported ([see here](../usage/tables.md#pre-split-partitions)).
 
 There are several stacks that allow data to be imported using the bulk import process:
 

--- a/docs/usage/tables.md
+++ b/docs/usage/tables.md
@@ -16,25 +16,18 @@ information.
 
 ## Add/edit a table
 
-Scripts can be used to add, rename and delete tables in a Sleeper instance.
+Scripts can be used to add, rename and delete tables in a Sleeper instance. If using the scripts, creating a new table
+will consist of the following steps:
 
-The `addTable.sh` script will create a new table with properties defined in `templates/tableproperties.template`, and a
-schema defined in `templates/schema.template`. Currently any changes must be done in those templates or in the admin
-client. We will add support for declarative deployment in the future.
+1. Use the `estimateSplitPoints.sh` script to estimate split points from your data.
+2. Use the `addTable.sh` script to create the table.
+3. Use the `reinitialiseTable.sh` script with the split points from the first step.
+4. Use the `sendToIngestBatcher.sh` script to send your data to the ingest batcher to be added to the table.
 
+All of these scripts will rely on a schema for your table, which should be created first.
 See [creating a schema](schema.md) for how to set up a schema for your table.
 
-```bash
-cd scripts
-editor templates/tableproperties.template
-editor templates/schema.template
-./utility/addTable.sh <instance-id> <table-name>
-./utility/renameTable.sh <instance-id> <old-table-name> <new-table-name>
-./utility/deleteTable.sh <instance-id> <table-name>
-```
-
-You can also pass `--force` as an additional argument to deleteTable.sh to skip the prompt to confirm you wish to delete
-all the data. This will permanently delete all data held in the table, as well as metadata.
+We also have scripts to rename and delete a table.
 
 ### Pre-split partitions
 
@@ -56,6 +49,19 @@ You can apply the resulting split points when adding a table by setting an absol
 table property `sleeper.table.splits.file`. If you haven't added any data to the table yet, you can apply the split
 points by reinitialising the table.
 
+### Add table
+
+The `addTable.sh` script will create a new table with properties defined in `templates/tableproperties.template`, and a
+schema defined in `templates/schema.template`. Currently any changes must be done in those templates or in the admin
+client. We will add support for declarative deployment in the future.
+
+```bash
+cd scripts
+editor templates/tableproperties.template
+editor templates/schema.template
+./utility/addTable.sh <instance-id> <table-name>
+```
+
 ### Reinitialise a table
 
 Reinitialising a table means deleting all its contents. This can sometimes be useful when you are experimenting
@@ -76,3 +82,15 @@ For example
 If you want to change the table schema you'll need to change it directly in the table properties file in the S3 config
 bucket, and then reinitialise the table. An alternative is to delete the table and create a new table with the same
 name.
+
+### Rename/delete a table
+
+You can rename or delete a table using the following commands:
+
+```bash
+./scripts/utility/renameTable.sh <instance-id> <old-table-name> <new-table-name>
+./scripts/utility/deleteTable.sh <instance-id> <table-name>
+```
+
+You can also pass `--force` as an additional argument to deleteTable.sh to skip the prompt to confirm you wish to delete
+all the data. This will permanently delete all data held in the table, as well as metadata.

--- a/docs/usage/tables.md
+++ b/docs/usage/tables.md
@@ -1,20 +1,18 @@
 Tables
 ======
 
-A Sleeper instance contains one or more tables. Each table has four important
-properties: a name, a schema for storing data for that table, a state store for 
-storing metadata about the table, and a flag to denote whether the table is 
-online or not (see [here](../design.md#Tables) for more information about 
-online tables). All resources for the instance, such as the S3 bucket used for 
-storing data in a table, ECS clusters and lambda functions are shared across 
-all the tables.
+A Sleeper instance contains one or more tables. Each table has four important properties: a name, a schema for storing
+data for that table, a state store for storing metadata about the table, and a flag to denote whether the table is
+online or not. See the [design documentation](../design.md#Tables) for more information about online tables.
+
+All resources for the instance, such as the S3 bucket used for storing data in a table, ECS clusters and lambda
+functions are shared across all the tables.
 
 ## The metadata store
 
-Each table has metadata associated to it. This metadata is stored in a
-state store and consists of information about files that are in the 
-system, and the partitions. See the [original design document](design/transaction-log-state-store.md)
-for the current state store backed by a transaction log.
+Each table has metadata associated to it. This metadata is stored in a state store and consists of information about
+files that are in the system, and the partitions. See the [design documentation](../design.md#State_store) for more
+information.
 
 ## Add/edit a table
 
@@ -38,7 +36,27 @@ editor templates/schema.template
 You can also pass `--force` as an additional argument to deleteTable.sh to skip the prompt to confirm you wish to delete
 all the data. This will permanently delete all data held in the table, as well as metadata.
 
-## Reinitialise a table
+### Pre-split partitions
+
+Before you create a Sleeper table, it is worthwhile to pre-split partitions for the table. One way to do this is by
+taking a sample of your data to generate a split points file:
+
+```bash
+./scripts/utility/estimateSplitPoints.sh <schema-file> <num-partitions> <sketch-size> <output-split-points-file> <parquet-paths-as-separate-args>
+```
+
+The schema file should be the `schema.json` file you created for your table. You can calculate the number of partitions
+by dividing the total number of rows you expect for your table by the average number of rows you want per partition.
+The sketch size controls the size and accuracy of the data sketches used to estimate the split points. It should be a
+power of 2 greater than 2 and less than 65536. See the Apache DataSketches documentation for more information:
+
+https://datasketches.apache.org/docs/Quantiles/ClassicQuantilesSketch.html
+
+You can apply the resulting split points when adding a table by setting an absolute path to the output file in the
+table property `sleeper.table.splits.file`. If you haven't added any data to the table yet, you can apply the split
+points by reinitialising the table.
+
+### Reinitialise a table
 
 Reinitialising a table means deleting all its contents. This can sometimes be useful when you are experimenting
 with Sleeper or if you created a table with the wrong schema.

--- a/docs/usage/tables.md
+++ b/docs/usage/tables.md
@@ -22,7 +22,8 @@ will consist of the following steps:
 1. Use the `estimateSplitPoints.sh` script to estimate split points from your data.
 2. Use the `addTable.sh` script to create the table.
 3. Use the `reinitialiseTable.sh` script with the split points from the first step.
-4. Use the `sendToIngestBatcher.sh` script to send your data to the ingest batcher to be added to the table.
+4. Use the `sendToIngestBatcher.sh` script to send your data to the ingest batcher to be added to the table. See
+   the [ingest documentation](ingest.md#ingest-batcher) for how to use this.
 
 All of these scripts will rely on a schema for your table, which should be created first.
 See [creating a schema](schema.md) for how to set up a schema for your table.

--- a/java/clients/src/main/java/sleeper/clients/table/SendToIngestBatcher.java
+++ b/java/clients/src/main/java/sleeper/clients/table/SendToIngestBatcher.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022-2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.table;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+
+import sleeper.clients.api.IngestBatcherSender;
+import sleeper.configuration.properties.S3InstanceProperties;
+import sleeper.configuration.table.index.DynamoDBTableIndex;
+import sleeper.core.properties.instance.InstanceProperties;
+import sleeper.core.table.TableIndex;
+import sleeper.ingest.batcher.core.IngestBatcherSubmitRequest;
+
+import java.util.List;
+
+public class SendToIngestBatcher {
+
+    private SendToIngestBatcher() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 3) {
+            System.out.println("Usage: <instanceId> <tableName> <file1> [<file2> ...]");
+            System.exit(1);
+        }
+        String instanceId = args[0];
+        String tableName = args[1];
+        List<String> files = List.of(args).subList(2, args.length);
+
+        AmazonS3 s3Client = AmazonS3ClientBuilder.defaultClient();
+        AmazonDynamoDB dynamoClient = AmazonDynamoDBClientBuilder.defaultClient();
+        AmazonSQS sqsClient = AmazonSQSClientBuilder.defaultClient();
+        try {
+            InstanceProperties instanceProperties = S3InstanceProperties.loadGivenInstanceId(s3Client, instanceId);
+            TableIndex tableIndex = new DynamoDBTableIndex(instanceProperties, dynamoClient);
+            if (!tableIndex.getTableByName(tableName).isPresent()) {
+                System.out.println("Table " + tableName + " not found in instance " + instanceId);
+                System.exit(1);
+            }
+            IngestBatcherSender.toSqs(instanceProperties, sqsClient)
+                    .submit(new IngestBatcherSubmitRequest(tableName, files));
+        } finally {
+            s3Client.shutdown();
+            dynamoClient.shutdown();
+            sqsClient.shutdown();
+        }
+    }
+
+}

--- a/scripts/utility/sendToIngestBatcher.sh
+++ b/scripts/utility/sendToIngestBatcher.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2022-2025 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+unset CDPATH
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")" && cd "../" && pwd)
+
+java -cp "${SCRIPTS_DIR}"/jars/clients-*-utility.jar sleeper.clients.table.SendToIngestBatcher "$@"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4882

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Just documentation

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
