### PR TITLE
Issue 4897 - Fix system test data generation jobs defaulting to 1 ingest

### DIFF
--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestDataGenerationJob.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestDataGenerationJob.java
@@ -142,7 +142,7 @@ public class SystemTestDataGenerationJob {
         private String tableName;
         private SystemTestIngestMode ingestMode;
         private IngestQueue ingestQueue;
-        private int numberOfIngests;
+        private int numberOfIngests = 1;
         private long recordsPerIngest;
         private SystemTestRandomDataSettings randomDataSettings;
 

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/sourcedata/SystemTestClusterTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/sourcedata/SystemTestClusterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.dsl.sourcedata;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import sleeper.systemtest.dsl.SleeperSystemTest;
+import sleeper.systemtest.dsl.testutil.InMemoryDslTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.systemtest.configuration.SystemTestIngestMode.DIRECT;
+import static sleeper.systemtest.dsl.testutil.InMemoryTestInstance.IN_MEMORY_MAIN;
+
+@InMemoryDslTest
+public class SystemTestClusterTest {
+
+    @BeforeEach
+    void setUp(SleeperSystemTest sleeper) {
+        sleeper.connectToInstanceAddOnlineTable(IN_MEMORY_MAIN);
+    }
+
+    @Test
+    void shouldIngestDirectlyWithSystemTestCluster(SleeperSystemTest sleeper) {
+        // When
+        sleeper.systemTestCluster().runDataGenerationJobs(2,
+                builder -> builder.ingestMode(DIRECT).recordsPerIngest(123))
+                .waitForTotalFileReferences(2);
+
+        // Then
+        assertThat(sleeper.directQuery().allRecordsInTable())
+                .hasSize(246);
+        assertThat(sleeper.systemTestCluster().findIngestJobIdsInSourceBucket())
+                .isEmpty();
+    }
+
+}

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/InMemorySystemTestDrivers.java
@@ -41,11 +41,13 @@ import sleeper.systemtest.dsl.reporting.CompactionReportsDriver;
 import sleeper.systemtest.dsl.reporting.IngestReportsDriver;
 import sleeper.systemtest.dsl.reporting.PartitionReportDriver;
 import sleeper.systemtest.dsl.snapshot.SnapshotsDriver;
+import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 import sleeper.systemtest.dsl.sourcedata.IngestSourceFilesDriver;
 import sleeper.systemtest.dsl.statestore.StateStoreCommitterDriver;
 import sleeper.systemtest.dsl.statestore.StateStoreCommitterLogsDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryCompaction;
+import sleeper.systemtest.dsl.testutil.drivers.InMemoryDataGenerationTasksDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryDirectIngestDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryDirectQueryDriver;
 import sleeper.systemtest.dsl.testutil.drivers.InMemoryGarbageCollectionDriver;
@@ -218,6 +220,11 @@ public class InMemorySystemTestDrivers extends SystemTestDriversBase {
     @Override
     public PartitionReportDriver partitionReports(SystemTestContext context) {
         return reports.partitions(context.instance());
+    }
+
+    @Override
+    public DataGenerationTasksDriver dataGenerationTasks(SystemTestContext context) {
+        return new InMemoryDataGenerationTasksDriver(context.instance(), data, sketches);
     }
 
     @Override

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryDataGenerationTasksDriver.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryDataGenerationTasksDriver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022-2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.dsl.testutil.drivers;
+
+import sleeper.core.iterator.IteratorCreationException;
+import sleeper.core.properties.table.TableProperties;
+import sleeper.core.record.Record;
+import sleeper.core.record.testutils.InMemoryRecordStore;
+import sleeper.core.util.PollWithRetries;
+import sleeper.ingest.runner.impl.IngestCoordinator;
+import sleeper.ingest.runner.testutils.InMemoryIngest;
+import sleeper.ingest.runner.testutils.InMemorySketchesStore;
+import sleeper.systemtest.configuration.SystemTestDataGenerationJob;
+import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
+import sleeper.systemtest.dsl.sourcedata.DataGenerationTasksDriver;
+import sleeper.systemtest.dsl.sourcedata.GenerateNumberedRecords;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+public class InMemoryDataGenerationTasksDriver implements DataGenerationTasksDriver {
+
+    private final SystemTestInstanceContext instance;
+    private final InMemoryRecordStore data;
+    private final InMemorySketchesStore sketches;
+    private final Random random = new Random(0);
+
+    public InMemoryDataGenerationTasksDriver(SystemTestInstanceContext instance, InMemoryRecordStore data, InMemorySketchesStore sketches) {
+        this.instance = instance;
+        this.data = data;
+        this.sketches = sketches;
+    }
+
+    @Override
+    public void runDataGenerationJobs(List<SystemTestDataGenerationJob> jobs, PollWithRetries poll) {
+        for (SystemTestDataGenerationJob job : jobs) {
+            TableProperties tableProperties = instance.getTablePropertiesByDeployedName(job.getTableName()).orElseThrow();
+            for (int i = 0; i < job.getNumberOfIngests(); i++) {
+                try (IngestCoordinator<Record> coordinator = ingest(tableProperties).createCoordinator()) {
+                    for (Record record : generateRecords(job, tableProperties)) {
+                        coordinator.write(record);
+                    }
+                } catch (IteratorCreationException e) {
+                    throw new RuntimeException(e);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+    }
+
+    private InMemoryIngest ingest(TableProperties tableProperties) {
+        return new InMemoryIngest(
+                instance.getInstanceProperties(), tableProperties,
+                instance.getStateStore(tableProperties),
+                data, sketches);
+    }
+
+    private Iterable<Record> generateRecords(SystemTestDataGenerationJob job, TableProperties tableProperties) {
+        List<Long> recordNumbers = LongStream.range(0, job.getRecordsPerIngest())
+                .mapToObj(num -> num)
+                .collect(Collectors.toList());
+        Collections.shuffle(recordNumbers, random);
+        GenerateNumberedRecords generator = instance.numberedRecords(tableProperties.getSchema());
+        return () -> recordNumbers.stream().map(generator::generateRecord).iterator();
+    }
+
+}

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryGeneratedIngestSourceFilesDriver.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/testutil/drivers/InMemoryGeneratedIngestSourceFilesDriver.java
@@ -20,6 +20,8 @@ import sleeper.core.record.testutils.InMemoryRecordStore;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFiles;
 import sleeper.systemtest.dsl.sourcedata.GeneratedIngestSourceFilesDriver;
 
+import java.util.List;
+
 public class InMemoryGeneratedIngestSourceFilesDriver implements GeneratedIngestSourceFilesDriver {
     private final InMemoryRecordStore sourceFiles;
 
@@ -29,7 +31,7 @@ public class InMemoryGeneratedIngestSourceFilesDriver implements GeneratedIngest
 
     @Override
     public GeneratedIngestSourceFiles findGeneratedFiles() {
-        throw new UnsupportedOperationException();
+        return new GeneratedIngestSourceFiles("in-memory", List.of());
     }
 
     @Override


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/4897

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Added SystemTestClusterTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
