### PR TITLE
Issue 5019 - Use dynamodb-toolsv2 only in tests for compaction-core

### DIFF
--- a/java/common/dynamodb-tools/src/main/java/sleeper/dynamodb/tools/DynamoDBUtils.java
+++ b/java/common/dynamodb-tools/src/main/java/sleeper/dynamodb/tools/DynamoDBUtils.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import sleeper.core.util.PollWithRetries;
+import sleeper.core.util.RetryOnDynamoDbThrottling;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -228,6 +229,10 @@ public class DynamoDBUtils {
             e = e.getCause();
         } while (e != null);
         return false;
+    }
+
+    public static RetryOnDynamoDbThrottling retryOnThrottlingException() {
+        return DynamoDBUtils::retryOnThrottlingException;
     }
 
     public static void retryOnThrottlingException(PollWithRetries pollWithRetries, Runnable runnable) throws InterruptedException {

--- a/java/common/dynamodb-toolsv2/src/main/java/sleeper/dynamodb/toolsv2/DynamoDBUtils.java
+++ b/java/common/dynamodb-toolsv2/src/main/java/sleeper/dynamodb/toolsv2/DynamoDBUtils.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledExcepti
 import software.amazon.awssdk.services.dynamodb.model.UpdateTimeToLiveRequest;
 
 import sleeper.core.util.PollWithRetries;
+import sleeper.core.util.RetryOnDynamoDbThrottling;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -237,6 +238,10 @@ public class DynamoDBUtils {
             e = e.getCause();
         } while (e != null);
         return false;
+    }
+
+    public static RetryOnDynamoDbThrottling retryOnThrottlingException() {
+        return DynamoDBUtils::retryOnThrottlingException;
     }
 
     public static void retryOnThrottlingException(PollWithRetries pollWithRetries, Runnable runnable) throws InterruptedException {

--- a/java/compaction/compaction-core/pom.xml
+++ b/java/compaction/compaction-core/pom.xml
@@ -32,17 +32,18 @@
             <artifactId>core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-        <dependency>
-            <groupId>sleeper</groupId>
-            <artifactId>dynamodb-tools</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>sleeper</groupId>
             <artifactId>core</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>sleeper</groupId>
+            <artifactId>dynamodb-toolsv2</artifactId>
+            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/StateStoreWaitForFilesTestHelper.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/StateStoreWaitForFilesTestHelper.java
@@ -21,6 +21,7 @@ import sleeper.core.tracker.compaction.job.CompactionJobTracker;
 import sleeper.core.util.ExponentialBackoffWithJitter;
 import sleeper.core.util.PollWithRetries;
 import sleeper.core.util.ThreadSleep;
+import sleeper.dynamodb.toolsv2.DynamoDBUtils;
 
 import java.time.Instant;
 import java.util.function.DoubleSupplier;
@@ -60,6 +61,7 @@ public class StateStoreWaitForFilesTestHelper {
             int attempts, DoubleSupplier jitter, PollWithRetries throttlingRetries) {
         return new StateStoreWaitForFiles(attempts,
                 new ExponentialBackoffWithJitter(StateStoreWaitForFiles.JOB_ASSIGNMENT_WAIT_RANGE, jitter, waiter),
+                DynamoDBUtils.retryOnThrottlingException(),
                 throttlingRetries.toBuilder()
                         .sleepInInterval(waiter::waitForMillis)
                         .build(),

--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/job/execution/ECSCompactionTaskRunner.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/job/execution/ECSCompactionTaskRunner.java
@@ -49,6 +49,7 @@ import sleeper.core.tracker.compaction.task.CompactionTaskTracker;
 import sleeper.core.util.LoggedDuration;
 import sleeper.core.util.ObjectFactory;
 import sleeper.core.util.ObjectFactoryException;
+import sleeper.dynamodb.toolsv2.DynamoDBUtils;
 import sleeper.parquet.utils.HadoopConfigurationProvider;
 import sleeper.sketchesv2.store.S3SketchesStore;
 import sleeper.statestorev2.StateStoreFactory;
@@ -108,7 +109,8 @@ public class ECSCompactionTaskRunner {
                     HadoopConfigurationProvider.getConfigurationForECS(instanceProperties),
                     new S3SketchesStore(s3Client, s3TransferManager));
 
-            StateStoreWaitForFiles waitForFiles = new StateStoreWaitForFiles(tablePropertiesProvider, stateStoreProvider, jobTracker);
+            StateStoreWaitForFiles waitForFiles = new StateStoreWaitForFiles(
+                    tablePropertiesProvider, stateStoreProvider, jobTracker, DynamoDBUtils.retryOnThrottlingException());
 
             CompactionJobCommitterOrSendToLambda committerOrLambda = committerOrSendToLambda(
                     tablePropertiesProvider, stateStoreProvider, jobTracker, instanceProperties, sqsClient);

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
@@ -70,6 +70,7 @@ import sleeper.core.tracker.compaction.task.CompactionTaskTracker;
 import sleeper.core.tracker.job.run.JobRunSummary;
 import sleeper.core.tracker.job.run.RecordsProcessed;
 import sleeper.core.util.ObjectFactory;
+import sleeper.dynamodb.toolsv2.DynamoDBUtils;
 import sleeper.ingest.runner.IngestFactory;
 import sleeper.ingest.runner.impl.IngestCoordinator;
 import sleeper.localstack.test.LocalStackTestBase;
@@ -467,7 +468,8 @@ public class ECSCompactionTaskRunnerLocalStackIT extends LocalStackTestBase {
         CompactionJobCommitterOrSendToLambda committer = ECSCompactionTaskRunner.committerOrSendToLambda(
                 tablePropertiesProvider, stateStoreProvider, jobTracker,
                 instanceProperties, sqsClientV2);
-        StateStoreWaitForFiles waitForFiles = new StateStoreWaitForFiles(tablePropertiesProvider, stateStoreProvider, jobTracker);
+        StateStoreWaitForFiles waitForFiles = new StateStoreWaitForFiles(
+                tablePropertiesProvider, stateStoreProvider, jobTracker, DynamoDBUtils.retryOnThrottlingException());
         CompactionTask task = new CompactionTask(instanceProperties, tablePropertiesProvider,
                 PropertiesReloader.neverReload(), stateStoreProvider, new SqsCompactionQueueHandler(sqsClientV2, instanceProperties),
                 waitForFiles, committer, jobTracker, taskTracker, selector, taskId,

--- a/java/core/src/main/java/sleeper/core/util/RetryOnDynamoDbThrottling.java
+++ b/java/core/src/main/java/sleeper/core/util/RetryOnDynamoDbThrottling.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.util;
+
+/**
+ * Performs some operation with retries if requests to the DynamoDB API are throttled. This is implemented in a separate
+ * module, in the class DynamoDBUtils.
+ */
+@FunctionalInterface
+public interface RetryOnDynamoDbThrottling {
+
+    void retryOnThrottlingException(PollWithRetries pollWithRetries, Runnable runnable) throws InterruptedException;
+
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/5019

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
