### PR TITLE
Issue 5067 - Stop query lambda failing when loading jar twice

### DIFF
--- a/java/configuration/src/main/java/sleeper/configuration/jars/S3UserJarsLoader.java
+++ b/java/configuration/src/main/java/sleeper/configuration/jars/S3UserJarsLoader.java
@@ -17,6 +17,7 @@ package sleeper.configuration.jars;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -30,6 +31,8 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -92,12 +95,35 @@ public class S3UserJarsLoader {
     private String loadJar(String jar) {
         String bucket = instanceProperties.get(CommonProperty.JARS_BUCKET);
         Path outputFile = localDir.resolve(jar);
-        GetObjectResponse response = s3Client.getObject(request -> request
-                .bucket(bucket).key(jar),
-                ResponseTransformer.toFile(outputFile));
-        outputFile.toFile().deleteOnExit();
-        LOGGER.info("Loaded jar {} of size {} from {} and wrote to {}",
-                jar, response.contentLength(), bucket, outputFile);
+        if (Files.exists(outputFile)) {
+            LOGGER.info("Found jar already exists locally, skipping: {}", outputFile);
+            return outputFile.toString();
+        }
+        try {
+            GetObjectResponse response = s3Client.getObject(request -> request
+                    .bucket(bucket).key(jar),
+                    ResponseTransformer.toFile(outputFile));
+            outputFile.toFile().deleteOnExit();
+            LOGGER.info("Loaded jar {} of size {} from {} and wrote to {}",
+                    jar, response.contentLength(), bucket, outputFile);
+        } catch (SdkClientException e) {
+            if (isFileAlreadyExists(e)) {
+                LOGGER.info("Found jar already exists locally after download attempt, skipping: {}", outputFile);
+            } else {
+                throw e;
+            }
+        }
         return outputFile.toString();
+    }
+
+    private static boolean isFileAlreadyExists(RuntimeException e) {
+        Throwable check = e;
+        do {
+            if (check instanceof FileAlreadyExistsException) {
+                return true;
+            }
+            check = check.getCause();
+        } while (check != null);
+        return false;
     }
 }

--- a/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
+++ b/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessor.java
@@ -18,14 +18,10 @@ package sleeper.query.lambda;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
-import sleeper.configuration.jars.S3UserJarsLoader;
 import sleeper.core.properties.instance.InstanceProperties;
-import sleeper.core.properties.instance.UserDefinedInstanceProperty;
 import sleeper.core.properties.table.TableProperties;
 import sleeper.core.properties.table.TablePropertiesProvider;
 import sleeper.core.statestore.StateStore;
@@ -40,27 +36,22 @@ import sleeper.query.core.model.QueryOrLeafPartitionQuery;
 import sleeper.query.core.model.QuerySerDe;
 import sleeper.query.core.output.ResultsOutputInfo;
 import sleeper.query.core.recordretrieval.QueryExecutor;
+import sleeper.query.core.tracker.QueryStatusReportListener;
 import sleeper.query.runner.recordretrieval.LeafPartitionRecordRetrieverImpl;
-import sleeper.query.runner.tracker.DynamoDBQueryTracker;
 import sleeper.query.runner.tracker.QueryStatusReportListeners;
-import sleeper.statestore.StateStoreFactory;
 
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.LEAF_PARTITION_QUERY_QUEUE_URL;
-import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSOR_LAMBDA_RECORD_RETRIEVAL_THREADS;
 import static sleeper.core.properties.table.TableProperty.TABLE_ID;
 
 public class SqsQueryProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqsQueryProcessor.class);
-    private static final UserDefinedInstanceProperty EXECUTOR_POOL_THREADS = QUERY_PROCESSOR_LAMBDA_RECORD_RETRIEVAL_THREADS;
 
     private final ExecutorService executorService;
     private final InstanceProperties instanceProperties;
@@ -68,17 +59,17 @@ public class SqsQueryProcessor {
     private final TablePropertiesProvider tablePropertiesProvider;
     private final StateStoreProvider stateStoreProvider;
     private final ObjectFactory objectFactory;
-    private final DynamoDBQueryTracker queryTracker;
+    private final QueryStatusReportListener queryListener;
     private final Map<String, QueryExecutor> queryExecutorCache = new HashMap<>();
 
     private SqsQueryProcessor(Builder builder) throws ObjectFactoryException {
         sqsClient = builder.sqsClient;
         instanceProperties = builder.instanceProperties;
         tablePropertiesProvider = builder.tablePropertiesProvider;
-        executorService = Executors.newFixedThreadPool(instanceProperties.getInt(EXECUTOR_POOL_THREADS));
-        objectFactory = new S3UserJarsLoader(instanceProperties, builder.s3Client, Path.of("/tmp")).buildObjectFactory();
-        queryTracker = new DynamoDBQueryTracker(instanceProperties, builder.dynamoClient);
-        stateStoreProvider = StateStoreFactory.createProvider(instanceProperties, builder.s3Client, builder.dynamoClient);
+        stateStoreProvider = builder.stateStoreProvider;
+        executorService = builder.executorService;
+        objectFactory = builder.objectFactory;
+        queryListener = builder.queryListener;
     }
 
     public static Builder builder() {
@@ -86,17 +77,17 @@ public class SqsQueryProcessor {
     }
 
     public void processQuery(QueryOrLeafPartitionQuery query) {
-        QueryStatusReportListeners queryTrackers = QueryStatusReportListeners.fromConfig(
+        QueryStatusReportListeners queryListeners = QueryStatusReportListeners.fromConfig(
                 query.getProcessingConfig().getStatusReportDestinations());
-        queryTrackers.add(queryTracker);
+        queryListeners.add(queryListener);
         try {
             TableProperties tableProperties = query.getTableProperties(tablePropertiesProvider);
             Query parentQuery = query.asParentQuery();
-            queryTrackers.queryInProgress(parentQuery);
-            processRangeQuery(parentQuery, tableProperties, queryTrackers);
+            queryListeners.queryInProgress(parentQuery);
+            processRangeQuery(parentQuery, tableProperties, queryListeners);
         } catch (RuntimeException | QueryException e) {
             LOGGER.error("Exception thrown executing query", e);
-            query.reportFailed(queryTrackers, e);
+            query.reportFailed(queryListeners, e);
         }
     }
 
@@ -135,26 +126,18 @@ public class SqsQueryProcessor {
 
     public static final class Builder {
         private SqsClient sqsClient;
-        private S3Client s3Client;
-        private DynamoDbClient dynamoClient;
         private InstanceProperties instanceProperties;
         private TablePropertiesProvider tablePropertiesProvider;
+        private StateStoreProvider stateStoreProvider;
+        private ObjectFactory objectFactory;
+        private ExecutorService executorService;
+        private QueryStatusReportListener queryListener;
 
         private Builder() {
         }
 
         public Builder sqsClient(SqsClient sqsClient) {
             this.sqsClient = sqsClient;
-            return this;
-        }
-
-        public Builder s3Client(S3Client s3Client) {
-            this.s3Client = s3Client;
-            return this;
-        }
-
-        public Builder dynamoClient(DynamoDbClient dynamoClient) {
-            this.dynamoClient = dynamoClient;
             return this;
         }
 
@@ -165,6 +148,26 @@ public class SqsQueryProcessor {
 
         public Builder tablePropertiesProvider(TablePropertiesProvider tablePropertiesProvider) {
             this.tablePropertiesProvider = tablePropertiesProvider;
+            return this;
+        }
+
+        public Builder stateStoreProvider(StateStoreProvider stateStoreProvider) {
+            this.stateStoreProvider = stateStoreProvider;
+            return this;
+        }
+
+        public Builder objectFactory(ObjectFactory objectFactory) {
+            this.objectFactory = objectFactory;
+            return this;
+        }
+
+        public Builder executorService(ExecutorService executorService) {
+            this.executorService = executorService;
+            return this;
+        }
+
+        public Builder queryListener(QueryStatusReportListener queryListener) {
+            this.queryListener = queryListener;
             return this;
         }
 

--- a/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessorLambda.java
+++ b/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessorLambda.java
@@ -18,7 +18,6 @@ package sleeper.query.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -36,7 +35,7 @@ import sleeper.query.core.recordretrieval.QueryExecutor;
 import sleeper.query.runner.tracker.DynamoDBQueryTracker;
 import sleeper.statestore.StateStoreFactory;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.concurrent.Executors;
 
@@ -103,7 +102,6 @@ public class SqsQueryProcessorLambda implements RequestHandler<SQSEvent, Void> {
         }
     }
 
-    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private void updateProperties(String configBucket) throws ObjectFactoryException {
         // Refresh properties and caches
         if (null == configBucket) {
@@ -118,7 +116,7 @@ public class SqsQueryProcessorLambda implements RequestHandler<SQSEvent, Void> {
                 .instanceProperties(instanceProperties).tablePropertiesProvider(tablePropertiesProvider)
                 .stateStoreProvider(StateStoreFactory.createProvider(instanceProperties, s3Client, dynamoClient))
                 .executorService(Executors.newFixedThreadPool(instanceProperties.getInt(QUERY_PROCESSOR_LAMBDA_RECORD_RETRIEVAL_THREADS)))
-                .objectFactory(new S3UserJarsLoader(instanceProperties, s3Client, Paths.get("/tmp")).buildObjectFactory())
+                .objectFactory(new S3UserJarsLoader(instanceProperties, s3Client, Path.of("/tmp")).buildObjectFactory())
                 .queryListener(new DynamoDBQueryTracker(instanceProperties, dynamoClient))
                 .build();
         lastUpdateTime = Instant.now();

--- a/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessorLambda.java
+++ b/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessorLambda.java
@@ -18,6 +18,7 @@ package sleeper.query.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -102,6 +103,7 @@ public class SqsQueryProcessorLambda implements RequestHandler<SQSEvent, Void> {
         }
     }
 
+    @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
     private void updateProperties(String configBucket) throws ObjectFactoryException {
         // Refresh properties and caches
         if (null == configBucket) {

--- a/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessorLambda.java
+++ b/java/query/query-lambda/src/main/java/sleeper/query/lambda/SqsQueryProcessorLambda.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
+import sleeper.configuration.jars.S3UserJarsLoader;
 import sleeper.configuration.properties.S3InstanceProperties;
 import sleeper.configuration.properties.S3TableProperties;
 import sleeper.core.properties.instance.InstanceProperties;
@@ -32,12 +33,16 @@ import sleeper.core.util.LoggedDuration;
 import sleeper.core.util.ObjectFactoryException;
 import sleeper.query.core.recordretrieval.QueryExecutor;
 import sleeper.query.runner.tracker.DynamoDBQueryTracker;
+import sleeper.statestore.StateStoreFactory;
 
+import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.concurrent.Executors;
 
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
 import static sleeper.core.properties.instance.CommonProperty.FORCE_RELOAD_PROPERTIES;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSING_LAMBDA_STATE_REFRESHING_PERIOD_IN_SECONDS;
+import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSOR_LAMBDA_RECORD_RETRIEVAL_THREADS;
 
 /**
  * A lambda that is triggered when a serialised query arrives on an SQS queue. A processor executes the request using a
@@ -108,9 +113,11 @@ public class SqsQueryProcessorLambda implements RequestHandler<SQSEvent, Void> {
         messageHandler = new QueryMessageHandler(tablePropertiesProvider, new DynamoDBQueryTracker(instanceProperties, dynamoClient));
         processor = SqsQueryProcessor.builder()
                 .sqsClient(sqsClient)
-                .s3Client(s3Client)
-                .dynamoClient(dynamoClient)
                 .instanceProperties(instanceProperties).tablePropertiesProvider(tablePropertiesProvider)
+                .stateStoreProvider(StateStoreFactory.createProvider(instanceProperties, s3Client, dynamoClient))
+                .executorService(Executors.newFixedThreadPool(instanceProperties.getInt(QUERY_PROCESSOR_LAMBDA_RECORD_RETRIEVAL_THREADS)))
+                .objectFactory(new S3UserJarsLoader(instanceProperties, s3Client, Paths.get("/tmp")).buildObjectFactory())
+                .queryListener(new DynamoDBQueryTracker(instanceProperties, dynamoClient))
                 .build();
         lastUpdateTime = Instant.now();
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/5067

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated S3UserJarsLoaderIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
