### PR TITLE
Issue 5168 - datafusion age off filter udf should use milliseconds not seconds

### DIFF
--- a/rust/compaction/src/datafusion/ageoff_udf.rs
+++ b/rust/compaction/src/datafusion/ageoff_udf.rs
@@ -253,7 +253,7 @@ mod tests {
             max_age: 1000,
         };
         let now = SystemTime::UNIX_EPOCH;
-        let origin_time = now.checked_add(Duration::from_secs(2000)).unwrap();
+        let origin_time = now.checked_add(Duration::from_millis(2000)).unwrap();
 
         // When
         let filter = AgeOff::try_from_relative_to(&filter, origin_time)?;
@@ -271,7 +271,7 @@ mod tests {
             max_age: -1000,
         };
         let now = SystemTime::UNIX_EPOCH;
-        let origin_time = now.checked_add(Duration::from_secs(2000)).unwrap();
+        let origin_time = now.checked_add(Duration::from_millis(2000)).unwrap();
 
         // When
         let filter = AgeOff::try_from_relative_to(&filter, origin_time)?;
@@ -294,25 +294,6 @@ mod tests {
 
         // Then
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn try_from_should_produce_error_on_large_negative_timestamp() {
-        // Given
-        let filter = Filter::Ageoff {
-            column: "test".into(),
-            max_age: i64::MIN,
-        };
-
-        // When
-        let result = AgeOff::try_from(&filter);
-
-        // Then
-        assert_error!(
-            result,
-            DataFusionError::Plan,
-            "Age off filter max_age not representable as a SystemTime timestamp"
-        );
     }
 
     #[test]

--- a/rust/compaction/src/datafusion/ageoff_udf.rs
+++ b/rust/compaction/src/datafusion/ageoff_udf.rs
@@ -39,7 +39,7 @@ use std::{
 /// lower than the given threshold, it will be filtered out.
 #[derive(Debug)]
 pub struct AgeOff {
-    /// Threshold value (seconds since UNIX epoch)
+    /// Threshold value (milliseconds since UNIX epoch)
     threshold: i64,
     /// Signature for this filter expression
     signature: Signature,
@@ -87,9 +87,9 @@ impl AgeOff {
                 // and then add or subtract the duration from the time_origin to derive
                 // the absolute threshold time.
                 let absolute_instant = if *max_age >= 0 {
-                    time_origin.checked_sub(Duration::from_secs(max_age.unsigned_abs()))
+                    time_origin.checked_sub(Duration::from_millis(max_age.unsigned_abs()))
                 } else {
-                    time_origin.checked_add(Duration::from_secs(max_age.unsigned_abs()))
+                    time_origin.checked_add(Duration::from_millis(max_age.unsigned_abs()))
                 }
                 // Convert Option to Result with DataFusionError
                 .ok_or(plan_datafusion_err!(
@@ -100,7 +100,7 @@ impl AgeOff {
                     let time_before_epoch = UNIX_EPOCH
                         .duration_since(absolute_instant)
                         .map_err(|e| DataFusionError::External(Box::new(e)))?
-                        .as_secs();
+                        .as_millis();
                     // Ensure time difference is negative in filter
                     0 - i64::try_from(time_before_epoch)
                         .map_err(|e| DataFusionError::External(Box::new(e)))?
@@ -108,7 +108,7 @@ impl AgeOff {
                     let time_after_epoch = absolute_instant
                         .duration_since(UNIX_EPOCH)
                         .map_err(|e| DataFusionError::External(Box::new(e)))?
-                        .as_secs();
+                        .as_millis();
                     i64::try_from(time_after_epoch)
                         .map_err(|e| DataFusionError::External(Box::new(e)))?
                 };


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/XXX

### Tests

- [X] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Tests updated in age_off

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
