### PR TITLE
Revert "Issue 5186 - Add extra sort stage to workaround DF breaking sort order"

### DIFF
--- a/rust/compaction/src/datafusion.rs
+++ b/rust/compaction/src/datafusion.rs
@@ -127,11 +127,9 @@ pub async fn compact(
         .collect::<Vec<_>>();
 
     // Apply sort to DataFrame, then aggregate if necessary, then project for DataSketch
-    frame = frame.sort(sort_order.clone())?;
+    frame = frame.sort(sort_order)?;
     frame = apply_aggregations(&input_data.row_key_cols, frame, filter_agg_conf.as_ref())?;
     frame = frame.select(col_names_expr)?;
-    // Sort again, to ensure correct coalescing of batches after parallel projection
-    frame = frame.sort(sort_order)?;
 
     // Show explanation of plan
     let explained = frame.clone().explain(false, false)?.collect().await?;

--- a/rust/compaction/src/datafusion/sketch_udf.rs
+++ b/rust/compaction/src/datafusion/sketch_udf.rs
@@ -221,11 +221,4 @@ impl ScalarUDFImpl for SketchUDF {
 
         Ok(args.args[0].clone())
     }
-
-    fn preserves_lex_ordering(
-        &self,
-        _inputs: &[datafusion::logical_expr::sort_properties::ExprProperties],
-    ) -> Result<bool> {
-        Ok(true)
-    }
 }


### PR DESCRIPTION
Reverts gchq/sleeper#5187

This seems to have caused compaction tasks to run out of memory during large compactions. This was found by running the system test CompactionDataFusionPerformanceST.