### PR TITLE
2090: Add javadoc to ResultsOutput group

### DIFF
--- a/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutput.java
+++ b/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutput.java
@@ -24,5 +24,13 @@ import sleeper.query.core.model.QueryOrLeafPartitionQuery;
  */
 public interface ResultsOutput {
 
+    /**
+     * Publish the results from a query or leaf peartition query.
+     *
+     * @param  query   the query definition
+     * @param  results the query results to publish
+     * @return         A ResultsOutputInfo that contains a count of the records in the result
+     *                 and the location of where the results are stored.
+     */
     ResultsOutputInfo publish(QueryOrLeafPartitionQuery query, CloseableIterator<Row> results);
 }

--- a/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutputConstants.java
+++ b/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutputConstants.java
@@ -15,6 +15,9 @@
  */
 package sleeper.query.core.output;
 
+/**
+ * Define constant values that are used to store the output of query results.
+ */
 public class ResultsOutputConstants {
 
     private ResultsOutputConstants() {

--- a/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutputInfo.java
+++ b/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutputInfo.java
@@ -17,6 +17,10 @@ package sleeper.query.core.output;
 
 import java.util.List;
 
+/**
+ * Provides info about the results from running a query. Contains details of the number of records in the result and
+ * the location of where results are stored.
+ */
 public class ResultsOutputInfo {
     private final long recordCount;
     private final List<ResultsOutputLocation> locations;

--- a/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutputLocation.java
+++ b/java/query/query-core/src/main/java/sleeper/query/core/output/ResultsOutputLocation.java
@@ -15,6 +15,9 @@
  */
 package sleeper.query.core.output;
 
+/**
+ * Provides information about the locaation of query results and the type of location.
+ */
 public class ResultsOutputLocation {
     private final String type;
     private final String location;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/XXX

### Tests

- [ ] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
