### PR TITLE
Issue 5260 - Add option to not call `docker buildx create`

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
@@ -38,6 +38,7 @@ public class UploadDockerImages {
     private final Path baseDockerDirectory;
     private final Path jarsDirectory;
     private final String version;
+    private final boolean createMultiplatformBuilder;
 
     private UploadDockerImages(Builder builder) {
         commandRunner = requireNonNull(builder.commandRunner, "commandRunner must not be null");
@@ -45,6 +46,7 @@ public class UploadDockerImages {
         baseDockerDirectory = requireNonNull(builder.baseDockerDirectory, "baseDockerDirectory must not be null");
         jarsDirectory = requireNonNull(builder.jarsDirectory, "jarsDirectory must not be null");
         version = requireNonNull(builder.version, "version must not be null");
+        createMultiplatformBuilder = builder.createMultiplatformBuilder;
     }
 
     public static Builder builder() {
@@ -67,7 +69,7 @@ public class UploadDockerImages {
             callbacks.beforeAll();
         }
 
-        if (imagesToUpload.stream().anyMatch(StackDockerImage::isMultiplatform)) {
+        if (createMultiplatformBuilder && imagesToUpload.stream().anyMatch(StackDockerImage::isMultiplatform)) {
             commandRunner.run("docker", "buildx", "rm", "sleeper");
             commandRunner.runOrThrow("docker", "buildx", "create", "--name", "sleeper", "--use");
         }
@@ -111,6 +113,7 @@ public class UploadDockerImages {
         private Path baseDockerDirectory;
         private Path jarsDirectory;
         private String version = SleeperVersion.getVersion();
+        private boolean createMultiplatformBuilder = true;
 
         private Builder() {
         }
@@ -137,6 +140,11 @@ public class UploadDockerImages {
 
         public Builder version(String version) {
             this.version = version;
+            return this;
+        }
+
+        public Builder createMultiplatformBuilder(boolean createMultiplatformBuilder) {
+            this.createMultiplatformBuilder = createMultiplatformBuilder;
             return this;
         }
 

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImagesToRepository.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImagesToRepository.java
@@ -18,22 +18,30 @@ package sleeper.clients.deploy.container;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static sleeper.clients.util.ClientUtils.optionalArgument;
+
 public class UploadDockerImagesToRepository {
 
     private UploadDockerImagesToRepository() {
     }
 
     public static void main(String[] args) throws Exception {
-        if (args.length != 2) {
-            System.out.println("Usage: <scripts-dir> <repository-prefix-path>");
+        if (args.length < 2 || args.length > 3) {
+            System.out.println("Usage: <scripts-dir> <repository-prefix-path> <optional-create-buildx-builder-true-or-false>");
             System.exit(1);
             return;
         }
 
         Path scriptsDirectory = Path.of(args[0]);
         String repositoryPrefix = args[1];
+        boolean createMultiplatformBuilder = optionalArgument(args, 2).map(Boolean::parseBoolean).orElse(true);
 
-        uploadAllImages(DockerImageConfiguration.getDefault(), UploadDockerImages.fromScriptsDirectory(scriptsDirectory), repositoryPrefix);
+        UploadDockerImages uploader = UploadDockerImages.builder()
+                .baseDockerDirectory(scriptsDirectory.resolve("docker"))
+                .jarsDirectory(scriptsDirectory.resolve("jars"))
+                .createMultiplatformBuilder(createMultiplatformBuilder)
+                .build();
+        uploadAllImages(DockerImageConfiguration.getDefault(), uploader, repositoryPrefix);
     }
 
     public static void uploadAllImages(DockerImageConfiguration imageConfig, UploadDockerImages uploader, String repositoryPrefix) throws IOException, InterruptedException {

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
@@ -539,24 +539,13 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
 
     @Override
     protected UploadDockerImagesToEcr uploader() {
-        return uploaderWith(uploaderBuilder().build());
-    }
-
-    protected UploadDockerImagesToEcr uploaderWithNoBuildxBuilderCreate() {
-        return uploaderWith(uploaderBuilder()
-                .createMultiplatformBuilder(false)
-                .build());
-    }
-
-    protected UploadDockerImagesToEcr uploaderWith(UploadDockerImages uploader) {
-        return new UploadDockerImagesToEcr(uploader, ecrClient);
-    }
-
-    private UploadDockerImages.Builder uploaderBuilder() {
-        return UploadDockerImages.builder()
-                .commandRunner(commandRunner)
-                .copyFile((source, target) -> files.put(target, files.get(source)))
-                .baseDockerDirectory(Path.of("./docker")).jarsDirectory(Path.of("./jars"))
-                .version("1.0.0");
+        return new UploadDockerImagesToEcr(
+                UploadDockerImages.builder()
+                        .commandRunner(commandRunner)
+                        .copyFile((source, target) -> files.put(target, files.get(source)))
+                        .baseDockerDirectory(Path.of("./docker")).jarsDirectory(Path.of("./jars"))
+                        .version("1.0.0")
+                        .build(),
+                ecrClient);
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
@@ -362,25 +362,6 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
             assertThat(ecrClient.getRepositories())
                     .containsExactlyInAnyOrder("test-instance/compaction", "test-instance/ingest");
         }
-
-        @Test
-        void shouldDisableBuildxBuilderCreation() throws Exception {
-            // Given
-            properties.setEnum(OPTIONAL_STACKS, OptionalStack.CompactionStack);
-
-            // When
-            uploaderWithNoBuildxBuilderCreate()
-                    .upload(UploadDockerImagesToEcrRequest.forDeployment(properties, dockerDeploymentImageConfig()));
-
-            // Then
-            String expectedTag = "123.dkr.ecr.test-region.amazonaws.com/test-instance/compaction:1.0.0";
-            assertThat(commandsThatRan).containsExactly(
-                    loginDockerCommand(),
-                    buildAndPushMultiplatformImageCommand(expectedTag, "./docker/compaction"));
-
-            assertThat(ecrClient.getRepositories())
-                    .containsExactlyInAnyOrder("test-instance/compaction");
-        }
     }
 
     @Nested

--- a/scripts/deploy/deployToDockerRepository.sh
+++ b/scripts/deploy/deployToDockerRepository.sh
@@ -16,8 +16,8 @@
 set -e
 unset CDPATH
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <repository-prefix-path>"
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "Usage: $0 <repository-prefix-path> <optional-create-buildx-builder-true-or-false>"
   exit 1
 fi
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/5260

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Updated UploadDockerImagesTest, UploadDockerImagesFileIT, UploadDockerImagesToRepositoryTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
