### PR TITLE
Issue 5315 - Add Javadoc to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,5 @@ Make sure you have checked _all_ steps below.
 
 - [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
   separate issue for that below.
+- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](../docs/development/conventions.md#javadoc).
 - [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -77,7 +77,7 @@ Note that many classes will not contain many of these elements.
 ## Javadoc
 
 We try to ensure that all classes have Javadoc. Most methods should also have Javadoc. Javadoc should generally explain
-the public API and high level behaviour of a class, and avoid implementation details.
+purpose, usage and high level behaviour, and avoid implementation details.
 
 An exception to this is test classes, e.g. SomeFeatureTest, SomeFeatureIT, SomeFeatureST (unit, integration and system
 tests). These classes should not have Javadoc, to put focus on the tests themselves. Other test code should have


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/5315

### Tests

- [x] My PR adds the following tests __OR__ does not need testing for this extremely good reason:
    - Just documentation

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
