### PR TITLE
5368: Fix issue with ingest when user uses a double slash in the path

### DIFF
--- a/java/configuration/src/main/java/sleeper/configuration/utils/S3Path.java
+++ b/java/configuration/src/main/java/sleeper/configuration/utils/S3Path.java
@@ -32,7 +32,6 @@ public record S3Path(String requestedPath, String bucket, String prefix) {
      */
     public static S3Path parse(String path) {
         String bucketPath = pathStartsWithScheme(path) ? path.substring(path.indexOf("//") + 2) : path;
-        bucketPath = trimEndingSlashes(bucketPath);
 
         if (!bucketPath.contains("/")) {
             return new S3Path(path, bucketPath, "");
@@ -46,13 +45,6 @@ public record S3Path(String requestedPath, String bucket, String prefix) {
 
     private static boolean pathStartsWithScheme(String path) {
         return path.startsWith("s3://") || path.startsWith("s3a://");
-    }
-
-    private static String trimEndingSlashes(String path) {
-        while (path.endsWith("/")) {
-            path = path.substring(0, path.length() - 1);
-        }
-        return path;
     }
 
     private static String getPrefixAfterSlashes(String path) {

--- a/java/configuration/src/main/java/sleeper/configuration/utils/S3Path.java
+++ b/java/configuration/src/main/java/sleeper/configuration/utils/S3Path.java
@@ -31,14 +31,34 @@ public record S3Path(String requestedPath, String bucket, String prefix) {
      * @return      the parsed location in S3
      */
     public static S3Path parse(String path) {
-        if (!path.contains("/")) {
-            return new S3Path(path, path, "");
-        } else {
-            String bucketPath = path.contains("//") ? path.substring(path.indexOf("//") + 2) : path;
+        String bucketPath = pathStartsWithScheme(path) ? path.substring(path.indexOf("//") + 2) : path;
+        bucketPath = trimEndingSlashes(bucketPath);
 
+        if (!bucketPath.contains("/")) {
+            return new S3Path(path, bucketPath, "");
+        } else {
+            int firstSlashLocation = bucketPath.indexOf("/");
             return new S3Path(path,
-                    bucketPath.substring(0, bucketPath.indexOf("/")),
-                    bucketPath.substring(bucketPath.indexOf("/") + 1));
+                    bucketPath.substring(0, firstSlashLocation),
+                    getPrefixAfterSlashes(bucketPath.substring(firstSlashLocation + 1)));
         }
+    }
+
+    private static boolean pathStartsWithScheme(String path) {
+        return path.startsWith("s3://") || path.startsWith("s3a://");
+    }
+
+    private static String trimEndingSlashes(String path) {
+        while (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    private static String getPrefixAfterSlashes(String path) {
+        while (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        return path;
     }
 }

--- a/java/configuration/src/test/java/sleeper/configuration/utils/S3ExpandDirectoriesIT.java
+++ b/java/configuration/src/test/java/sleeper/configuration/utils/S3ExpandDirectoriesIT.java
@@ -150,7 +150,7 @@ class S3ExpandDirectoriesIT extends LocalStackTestBase {
         }
 
         @Test
-        void shouldReadCorrectFilesWhenPathEndsInSlash() {
+        void shouldReadOnlyFolderContentWhenPathEndsInSlash() {
             // Given
             List<String> files = List.of(bucket + "/test-folder/");
             String objectKey1 = "test-folder";

--- a/java/configuration/src/test/java/sleeper/configuration/utils/S3ExpandDirectoriesIT.java
+++ b/java/configuration/src/test/java/sleeper/configuration/utils/S3ExpandDirectoriesIT.java
@@ -148,6 +148,24 @@ class S3ExpandDirectoriesIT extends LocalStackTestBase {
             assertThat(listFileSizeBytes(files))
                     .containsExactlyInAnyOrder(30L, 100L);
         }
+
+        @Test
+        void shouldReadCorrectFilesWhenPathEndsInSlash() {
+            // Given
+            List<String> files = List.of(bucket + "/test-folder/");
+            String objectKey1 = "test-folder";
+            String objectKey2 = "test-folder/file-1.parquet";
+            String objectKey3 = "test-folder/file-2.parquet";
+            putObject(bucket, objectKey1, "test-data");
+            putObject(bucket, objectKey2, "test-data");
+            putObject(bucket, objectKey3, "test-data");
+
+            // When / Then
+            assertThat(listPathsForJob(files))
+                    .containsExactlyInAnyOrder(
+                            bucket + "/" + objectKey2,
+                            bucket + "/" + objectKey3);
+        }
     }
 
     @Nested

--- a/java/configuration/src/test/java/sleeper/configuration/utils/S3PathTest.java
+++ b/java/configuration/src/test/java/sleeper/configuration/utils/S3PathTest.java
@@ -24,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class S3PathTest {
 
     @Test
-    public void shouldHandlePathWithoutPrefix() {
-        final String path = "justBucket";
+    public void shouldhandleMakingS3PathPathWithoutPrefix() {
+        String path = "justBucket";
 
         //When
         S3Path s3Path = S3Path.parse(path);
@@ -36,79 +36,41 @@ public class S3PathTest {
         assertThat(s3Path.prefix()).isEqualTo("");
     }
 
-    @ParameterizedTest
-    @CsvSource({"/", "//"})
-    public void shouldHandlePathEndingInSlashes(final String slashes) {
-        final String bucket = "justBucket";
-        final String path = bucket + slashes;
+    @Test
+    public void shouldhandleMakingS3PathPathWithPrefix() {
+        String path = "bucket/prefix";
 
         //When
         S3Path s3Path = S3Path.parse(path);
 
         //Then
         assertThat(s3Path.requestedPath()).isEqualTo(path);
-        assertThat(s3Path.bucket()).isEqualTo(bucket);
-        assertThat(s3Path.prefix()).isEqualTo("");
+        assertThat(s3Path.bucket()).isEqualTo("bucket");
+        assertThat(s3Path.prefix()).isEqualTo("prefix");
     }
 
     @Test
-    public void shouldHandlePathWithPrefix() {
-        final String bucket = "bucket";
-        final String prefix = "prefix";
-        final String path = bucket + '/' + prefix;
+    public void shouldhandleMakingS3PathPathWithPrefixAndDoubleSlash() {
+        String path = "bucket//prefix";
 
         //When
         S3Path s3Path = S3Path.parse(path);
 
         //Then
         assertThat(s3Path.requestedPath()).isEqualTo(path);
-        assertThat(s3Path.bucket()).isEqualTo(bucket);
-        assertThat(s3Path.prefix()).isEqualTo(prefix);
-    }
-
-    @Test
-    public void shouldHandlePathWithPrefixAndDoubleSlash() {
-        final String bucket = "bucket";
-        final String prefix = "prefix";
-        final String path = bucket + "//" + prefix;
-
-        //When
-        S3Path s3Path = S3Path.parse(path);
-
-        //Then
-        assertThat(s3Path.requestedPath()).isEqualTo(path);
-        assertThat(s3Path.bucket()).isEqualTo(bucket);
-        assertThat(s3Path.prefix()).isEqualTo(prefix);
-    }
-
-    @Test
-    public void shouldHandlePathWithPrefixAndEndSlash() {
-        final String bucket = "bucket";
-        final String prefix = "prefix";
-        final String path = bucket + '/' + prefix + '/';
-
-        //When
-        S3Path s3Path = S3Path.parse(path);
-
-        //Then
-        assertThat(s3Path.requestedPath()).isEqualTo(path);
-        assertThat(s3Path.bucket()).isEqualTo(bucket);
-        assertThat(s3Path.prefix()).isEqualTo(prefix);
+        assertThat(s3Path.bucket()).isEqualTo("bucket");
+        assertThat(s3Path.prefix()).isEqualTo("prefix");
     }
 
     @ParameterizedTest
-    @CsvSource({"s3://", "s3a://"})
-    public void shouldHandlePathWithScheme(final String scheme) {
-        final String bucket = "bucket";
-        final String prefix = "prefix";
-        final String path = scheme + bucket + '/' + prefix;
-
+    @CsvSource({"s3://bucket/prefix", "s3a://bucket/prefix"})
+    public void shouldhandleMakingS3PathPathWithScheme(String path) {
         //When
         S3Path s3Path = S3Path.parse(path);
 
         //Then
         assertThat(s3Path.requestedPath()).isEqualTo(path);
-        assertThat(s3Path.bucket()).isEqualTo(bucket);
-        assertThat(s3Path.prefix()).isEqualTo(prefix);
+        assertThat(s3Path.bucket()).isEqualTo("bucket");
+        assertThat(s3Path.prefix()).isEqualTo("prefix");
     }
 }

--- a/java/configuration/src/test/java/sleeper/configuration/utils/S3PathTest.java
+++ b/java/configuration/src/test/java/sleeper/configuration/utils/S3PathTest.java
@@ -36,11 +36,56 @@ public class S3PathTest {
         assertThat(s3Path.prefix()).isEqualTo("");
     }
 
+    @ParameterizedTest
+    @CsvSource({"/", "//"})
+    public void shouldHandlePathEndingInSlashes(final String slashes) {
+        final String bucket = "justBucket";
+        final String path = bucket + slashes;
+
+        //When
+        S3Path s3Path = S3Path.parse(path);
+
+        //Then
+        assertThat(s3Path.requestedPath()).isEqualTo(path);
+        assertThat(s3Path.bucket()).isEqualTo(bucket);
+        assertThat(s3Path.prefix()).isEqualTo("");
+    }
+
     @Test
     public void shouldHandlePathWithPrefix() {
         final String bucket = "bucket";
         final String prefix = "prefix";
         final String path = bucket + '/' + prefix;
+
+        //When
+        S3Path s3Path = S3Path.parse(path);
+
+        //Then
+        assertThat(s3Path.requestedPath()).isEqualTo(path);
+        assertThat(s3Path.bucket()).isEqualTo(bucket);
+        assertThat(s3Path.prefix()).isEqualTo(prefix);
+    }
+
+    @Test
+    public void shouldHandlePathWithPrefixAndDoubleSlash() {
+        final String bucket = "bucket";
+        final String prefix = "prefix";
+        final String path = bucket + "//" + prefix;
+
+        //When
+        S3Path s3Path = S3Path.parse(path);
+
+        //Then
+        assertThat(s3Path.requestedPath()).isEqualTo(path);
+        assertThat(s3Path.bucket()).isEqualTo(bucket);
+        assertThat(s3Path.prefix()).isEqualTo(prefix);
+    }
+
+    @Test
+    public void shouldHandlePathWithPrefixAndEndSlash() {
+        final String bucket = "bucket";
+        final String prefix = "prefix";
+        final String path = bucket + '/' + prefix + '/';
 
         //When
         S3Path s3Path = S3Path.parse(path);

--- a/java/configuration/src/test/java/sleeper/configuration/utils/S3PathTest.java
+++ b/java/configuration/src/test/java/sleeper/configuration/utils/S3PathTest.java
@@ -24,7 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class S3PathTest {
 
     @Test
-    public void shouldhandleMakingS3PathPathWithoutPrefix() {
+    public void shouldHandlePathWithoutPrefix() {
+        //Given
         String path = "justBucket";
 
         //When
@@ -37,7 +38,8 @@ public class S3PathTest {
     }
 
     @Test
-    public void shouldhandleMakingS3PathPathWithPrefix() {
+    public void shouldHandlePathWithPrefix() {
+        //Given
         String path = "bucket/prefix";
 
         //When
@@ -50,7 +52,8 @@ public class S3PathTest {
     }
 
     @Test
-    public void shouldhandleMakingS3PathPathWithPrefixAndDoubleSlash() {
+    public void shouldHandlePathWithPrefixAndDoubleSlash() {
+        //Given
         String path = "bucket//prefix";
 
         //When
@@ -64,7 +67,7 @@ public class S3PathTest {
 
     @ParameterizedTest
     @CsvSource({"s3://bucket/prefix", "s3a://bucket/prefix"})
-    public void shouldhandleMakingS3PathPathWithScheme(String path) {
+    public void shouldHandlePathWithScheme(String path) {
         //When
         S3Path s3Path = S3Path.parse(path);
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following issues and references them in the PR title. For example, "Issue 1234 - My Sleeper
  PR"
    - Resolves https://github.com/gchq/sleeper/issues/5368

### Tests

- [x] My PR adds the following tests based on [our test strategy](../docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - S3PathTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](../docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
