### PR TITLE
Issue 5405 - Remove line breaks in issue template for progress on another issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/progress.md
+++ b/.github/ISSUE_TEMPLATE/progress.md
@@ -7,34 +7,21 @@ assignees: ''
 
 ---
 
-You've done some work towards another issue but haven't finished it yet. You want to integrate your changes into the
-rest of the project with a pull request before you continue your work on the issue. This will mean other contributors
-can see your changes in their copy of the code, and can take your work into account in anything they're doing. This is
-great!
+You've done some work towards another issue but haven't finished it yet. You want to integrate your changes into the rest of the project with a pull request before you continue your work on the issue. This will mean other contributors can see your changes in their copy of the code, and can take your work into account in anything they're doing. This is great!
 
-Please complete the link below to link this to the issue you're working on. Give this new issue a name that describes
-the changes you will include in a pull request.
+Please complete the link below to link this to the issue you're working on. Give this new issue a name that describes the changes you will include in a pull request.
 
 Split from:
 - https://github.com/gchq/sleeper/issues/XXX
 
 #### Pull requests for unfinished changes
 
-Any changes you make must still pass all tests and linting. Your code in progress should still follow
-[our conventions](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md), and should
-still include automated test coverage following
-[our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md).
+Any changes you make must still pass all tests and linting. Your code in progress should still follow [our conventions](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md), and should still include automated test coverage following [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md).
 
-If your changes affect the behaviour of the system in incomplete ways, or may cause confusion over an incomplete
-feature, we may still be able to accommodate this. You could avoid connecting your new code to the rest of the system
-temporarily, or include configuration such that the new behaviour is disabled by default.
+If your changes affect the behaviour of the system in incomplete ways, or may cause confusion over an incomplete feature, we may still be able to accommodate this. You could avoid connecting your new code to the rest of the system temporarily, or include configuration such that the new behaviour is disabled by default.
 
 #### Explanation
 
-For tracking reasons, we want each pull request to be linked to an issue that it resolves. For an issue that's still in
-progress, please don't link a pull request to the original because that would trigger GitHub to close the original issue
-when the pull request is merged. Instead, you can link your pull request to a new issue that's split from the original.
+For tracking reasons, we want each pull request to be linked to an issue that it resolves. For an issue that's still in progress, please don't link a pull request to the original because that would trigger GitHub to close the original issue when the pull request is merged. Instead, you can link your pull request to a new issue that's split from the original.
 
-As an alternative to this template, you could consider raising a normal feature issue, with a link to the original in
-the background section. You can use a "Split from:" link as shown above. That gives you an opportunity to include more
-information about the intention and any analysis.
+As an alternative to this template, you could consider raising a normal feature issue, with a link to the original in the background section. You can use a "Split from:" link as shown above. That gives you an opportunity to include more information about the intention and any analysis.


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5405

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Just issue template

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
