### PR TITLE
Issue 5355: Remove use of deprecated methods in ParquetRowReader

### DIFF
--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/BulkImportJobDriverIT.java
@@ -413,7 +413,7 @@ class BulkImportJobDriverIT extends LocalStackTestBase {
     }
 
     private static List<Row> readRows(String filename, Schema schema) {
-        try (ParquetRowReader reader = new ParquetRowReader(filename, schema)) {
+        try (ParquetRowReader reader = new ParquetRowReader(new Path(filename), schema)) {
             List<Row> readRows = new ArrayList<>();
             Row row = reader.read();
             while (null != row) {

--- a/java/parquet/src/main/java/sleeper/parquet/row/ParquetRowReader.java
+++ b/java/parquet/src/main/java/sleeper/parquet/row/ParquetRowReader.java
@@ -29,10 +29,6 @@ import java.io.IOException;
  */
 public class ParquetRowReader extends ParquetReader<Row> {
 
-    public ParquetRowReader(String file, Schema schema) throws IOException {
-        super(new Path(file), new RowReadSupport(schema));
-    }
-
     public ParquetRowReader(Path path, Schema schema) throws IOException {
         super(path, new RowReadSupport(schema));
     }

--- a/java/query/query-runner/src/test/java/sleeper/query/runner/output/S3ResultsOutputIT.java
+++ b/java/query/query-runner/src/test/java/sleeper/query/runner/output/S3ResultsOutputIT.java
@@ -164,7 +164,7 @@ class S3ResultsOutputIT {
     private List<Row> getRowsFromOutput(String path) {
         List<Row> rows = new ArrayList<>();
         try {
-            ParquetRowReader reader = new ParquetRowReader(path, schema);
+            ParquetRowReader reader = new ParquetRowReader(new org.apache.hadoop.fs.Path(path), schema);
 
             Row row = reader.read();
             while (null != row) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5355
### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
