### PR TITLE
Issue 5435: ParquetReader.useColumnIndexFilter setting is not applied consistently

### DIFF
--- a/java/athena/src/test/java/sleeper/athena/record/SimpleRecordHandlerIT.java
+++ b/java/athena/src/test/java/sleeper/athena/record/SimpleRecordHandlerIT.java
@@ -263,7 +263,7 @@ public class SimpleRecordHandlerIT extends RecordHandlerITBase {
 
         // Then
         ParquetReaderIterator parquetReaderIterator = new ParquetReaderIterator(
-                ParquetRowReaderFactory.createParquetRowReader(new Path(file), SCHEMA));
+                ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(file), SCHEMA).build());
         while (parquetReaderIterator.hasNext()) {
             parquetReaderIterator.next();
         }

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/BulkImportJobDriverIT.java
@@ -308,7 +308,7 @@ class BulkImportJobDriverIT extends LocalStackTestBase {
             relevantFiles.stream()
                     .map(af -> {
                         try {
-                            return ParquetRowReaderFactory.createParquetRowReader(new Path(af.getFilename()), schema);
+                            return ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(af.getFilename()), schema).build();
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -414,7 +414,7 @@ class BulkImportJobDriverIT extends LocalStackTestBase {
     }
 
     private static List<Row> readRows(String filename, Schema schema) {
-        try (ParquetReader<Row> reader = ParquetRowReaderFactory.createParquetRowReader(new Path(filename), schema)) {
+        try (ParquetReader<Row> reader = ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(filename), schema).build()) {
             List<Row> readRows = new ArrayList<>();
             Row row = reader.read();
             while (null != row) {

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/dataframe/FileWritingIteratorIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/dataframe/FileWritingIteratorIT.java
@@ -221,7 +221,7 @@ class FileWritingIteratorIT {
     }
 
     private List<sleeper.core.row.Row> readRows(String path) {
-        try (ParquetReader<sleeper.core.row.Row> reader = ParquetRowReaderFactory.createParquetRowReader(new Path(path), createSchema())) {
+        try (ParquetReader<sleeper.core.row.Row> reader = ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(path), createSchema()).build()) {
             List<sleeper.core.row.Row> rows = new ArrayList<>();
             sleeper.core.row.Row row = reader.read();
             while (null != row) {

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/dataframe/WriteParquetFilesIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/dataframe/WriteParquetFilesIT.java
@@ -155,7 +155,7 @@ class WriteParquetFilesIT {
     }
 
     private List<sleeper.core.row.Row> readRows(String filename, Schema schema) {
-        try (ParquetReader<sleeper.core.row.Row> reader = ParquetRowReaderFactory.createParquetRowReader(new Path(filename), schema)) {
+        try (ParquetReader<sleeper.core.row.Row> reader = ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(filename), schema).build()) {
             List<sleeper.core.row.Row> rows = new ArrayList<>();
             for (sleeper.core.row.Row row = reader.read(); row != null; row = reader.read()) {
                 rows.add(new sleeper.core.row.Row(row));

--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/rdd/SingleFileWritingIteratorIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/rdd/SingleFileWritingIteratorIT.java
@@ -233,7 +233,7 @@ class SingleFileWritingIteratorIT {
     }
 
     private List<sleeper.core.row.Row> readRows(String path) {
-        try (ParquetReader<sleeper.core.row.Row> reader = ParquetRowReaderFactory.createParquetRowReader(new Path(path), schema)) {
+        try (ParquetReader<sleeper.core.row.Row> reader = ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(path), schema).build()) {
             List<sleeper.core.row.Row> rows = new ArrayList<>();
             sleeper.core.row.Row row = reader.read();
             while (null != row) {

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/ECSCompactionTaskRunnerLocalStackIT.java
@@ -549,7 +549,7 @@ public class ECSCompactionTaskRunnerLocalStackIT extends LocalStackTestBase {
     }
 
     private List<Row> readRows(String filename, Schema schema) {
-        try (ParquetReader<Row> reader = ParquetRowReaderFactory.createParquetRowReader(new Path(filename), schema)) {
+        try (ParquetReader<Row> reader = ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(filename), schema).build()) {
             List<Row> rows = new ArrayList<>();
             for (Row row = reader.read(); row != null; row = reader.read()) {
                 rows.add(new Row(row));

--- a/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/testutils/CompactionRunnerTestData.java
+++ b/java/compaction/compaction-job-execution/src/test/java/sleeper/compaction/job/execution/testutils/CompactionRunnerTestData.java
@@ -169,7 +169,7 @@ public class CompactionRunnerTestData {
     public static List<Row> readDataFile(Schema schema, String filename) throws IOException {
         List<Row> results = new ArrayList<>();
         try (ParquetReaderIterator reader = new ParquetReaderIterator(
-                ParquetRowReaderFactory.createParquetRowReader(new Path(filename), schema))) {
+                ParquetRowReaderFactory.parquetRowReaderBuilder(new Path(filename), schema).build())) {
             while (reader.hasNext()) {
                 results.add(new Row(reader.next()));
             }

--- a/java/parquet/src/main/java/sleeper/parquet/row/ParquetRowReaderFactory.java
+++ b/java/parquet/src/main/java/sleeper/parquet/row/ParquetRowReaderFactory.java
@@ -21,19 +21,12 @@ import org.apache.parquet.hadoop.ParquetReader;
 import sleeper.core.row.Row;
 import sleeper.core.schema.Schema;
 
-import java.io.IOException;
-
 /**
  * Factory to create parquet reader for sleeper rows. Uses {@link RowReadSupport}.
  */
 public class ParquetRowReaderFactory {
 
     private ParquetRowReaderFactory() {
-    }
-
-    public static ParquetReader<Row> createParquetRowReader(Path path, Schema schema) throws IOException {
-        return ParquetReader.builder(new RowReadSupport(schema), path).build();
-
     }
 
     public static ParquetReader.Builder<Row> parquetRowReaderBuilder(Path path, Schema schema) {

--- a/java/query/query-runner/src/test/java/sleeper/query/runner/output/S3ResultsOutputIT.java
+++ b/java/query/query-runner/src/test/java/sleeper/query/runner/output/S3ResultsOutputIT.java
@@ -165,7 +165,7 @@ class S3ResultsOutputIT {
     private List<Row> getRowsFromOutput(String path) {
         List<Row> rows = new ArrayList<>();
         try {
-            ParquetReader<Row> reader = ParquetRowReaderFactory.createParquetRowReader(new org.apache.hadoop.fs.Path(path), schema);
+            ParquetReader<Row> reader = ParquetRowReaderFactory.parquetRowReaderBuilder(new org.apache.hadoop.fs.Path(path), schema).build();
 
             Row row = reader.read();
             while (null != row) {

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonQueryDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/python/PythonQueryDriver.java
@@ -81,8 +81,8 @@ public class PythonQueryDriver implements PythonQueryTypesDriver {
         String path = "file://" + outputDir.resolve(queryId + ".txt");
         List<Row> rows = new ArrayList<>();
         try {
-            ParquetReader<Row> reader = ParquetRowReaderFactory.createParquetRowReader(new org.apache.hadoop.fs.Path(path),
-                    instance.getTableProperties().getSchema());
+            ParquetReader<Row> reader = ParquetRowReaderFactory.parquetRowReaderBuilder(new org.apache.hadoop.fs.Path(path),
+                    instance.getTableProperties().getSchema()).build();
 
             Row row = reader.read();
             while (null != row) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5435

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Execution of existing test suite

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
