### PR TITLE
Issue 5522: DefaultCompactionRunnerFactory doesn't allow java compactions with aggregators specified

### DIFF
--- a/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/job/execution/DefaultCompactionRunnerFactory.java
+++ b/java/compaction/compaction-job-execution/src/main/java/sleeper/compaction/job/execution/DefaultCompactionRunnerFactory.java
@@ -51,14 +51,6 @@ public class DefaultCompactionRunnerFactory implements CompactionRunnerFactory {
     public CompactionRunner createCompactor(CompactionJob job, TableProperties tableProperties) {
         DataEngine engine = tableProperties.getEnumValue(DATA_ENGINE, DataEngine.class);
         CompactionRunner runner = createRunnerForEngine(engine);
-
-        // Has an experimental DataFusion only iterator been specified? If so, make sure
-        // we are using the DataFusion compactor
-        if (DataEngine.AGGREGATION_ITERATOR_NAME.equals(job.getIteratorClassName()) && !(runner instanceof DataFusionCompactionRunner)) {
-            throw new IllegalStateException("DataFusion-only iterator specified, but DataFusion compactor not selected for job ID "
-                    + job.getId() + " table ID " + job.getTableId());
-        }
-
         LOGGER.info("Selecting {} compactor (language {}) for job ID {} table ID {}", runner.getClass().getSimpleName(), runner.implementationLanguage(), job.getId(), job.getTableId());
         return runner;
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5522

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Existing test suite execution

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
