### PR TITLE
Issue 5763 - Improve realism of state store commit request JSON tests

### DIFF
--- a/java/core/src/test/java/sleeper/core/statestore/FileReferenceFactory.java
+++ b/java/core/src/test/java/sleeper/core/statestore/FileReferenceFactory.java
@@ -130,6 +130,20 @@ public class FileReferenceFactory {
      * Creates a factory to create files in the given partition tree. Sets a fixed last updated date for any references
      * created by the factory.
      *
+     * @param  instanceProperties   the instance properties
+     * @param  tableProperties      the table properties
+     * @param  tree                 the tree
+     * @param  lastStateStoreUpdate the time created references should be marked as having last been updated
+     * @return                      the factory
+     */
+    public static FileReferenceFactory fromUpdatedAt(InstanceProperties instanceProperties, TableProperties tableProperties, PartitionTree tree, Instant lastStateStoreUpdate) {
+        return new FileReferenceFactory(tree, lastStateStoreUpdate, FilePathGenerator.fromProperties(instanceProperties, tableProperties));
+    }
+
+    /**
+     * Creates a factory to create files in the given partition tree. Sets a fixed last updated date for any references
+     * created by the factory.
+     *
      * @param  partitions           the partitions in the tree
      * @param  lastStateStoreUpdate the time created references should be marked as having last been updated
      * @return                      the factory

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.java
@@ -17,43 +17,55 @@ package sleeper.core.statestore.commit;
 
 import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import sleeper.core.partition.PartitionTree;
 import sleeper.core.partition.PartitionsBuilder;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.table.TableProperties;
 import sleeper.core.properties.testutils.FixedTablePropertiesProvider;
 import sleeper.core.schema.Schema;
 import sleeper.core.schema.type.LongType;
-import sleeper.core.statestore.testutils.InMemoryTransactionBodyStore;
+import sleeper.core.statestore.FileReferenceFactory;
 import sleeper.core.statestore.transactionlog.log.TransactionBodyStore;
+import sleeper.core.statestore.transactionlog.transaction.FileReferenceTransaction;
 import sleeper.core.statestore.transactionlog.transaction.PartitionTransaction;
+import sleeper.core.statestore.transactionlog.transaction.StateStoreTransaction;
 import sleeper.core.statestore.transactionlog.transaction.TransactionType;
+import sleeper.core.statestore.transactionlog.transaction.impl.AddFilesTransaction;
 import sleeper.core.statestore.transactionlog.transaction.impl.ClearFilesTransaction;
 import sleeper.core.statestore.transactionlog.transaction.impl.InitialisePartitionsTransaction;
 
 import java.time.Instant;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.core.properties.table.TableProperty.TABLE_ID;
 import static sleeper.core.properties.table.TableProperty.TABLE_NAME;
-import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
+import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstancePropertiesWithId;
 import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.core.schema.SchemaTestHelper.createSchemaWithKey;
 
 public class StateStoreCommitRequestSerDeTest {
 
     Schema schema = createSchemaWithKey("key", new LongType());
-    TableProperties tableProperties = createTableProperties(schema);
-    StateStoreCommitRequestSerDe serDe = new StateStoreCommitRequestSerDe(new FixedTablePropertiesProvider(tableProperties));
-    TransactionBodyStore bodyStore = new InMemoryTransactionBodyStore();
+    InstanceProperties instanceProperties = createTestInstancePropertiesWithId("instanceid");
+    TableProperties tableProperties = createTestTableProperties(instanceProperties, schema);
+    StateStoreCommitRequestSerDe serDe;
+
+    @BeforeEach
+    void setUp() {
+        tableProperties.set(TABLE_ID, "933cd595");
+        tableProperties.set(TABLE_NAME, "test.table");
+        serDe = new StateStoreCommitRequestSerDe(new FixedTablePropertiesProvider(tableProperties));
+    }
 
     @Test
     void shouldSerialiseCompactionCommitInS3() {
         // Given
-        String key = TransactionBodyStore.createObjectKey("test-table", Instant.parse("2025-01-14T15:30:00Z"), "test-transaction");
-        StateStoreCommitRequest commitRequest = StateStoreCommitRequest.create(
-                "test-table", key, TransactionType.REPLACE_FILE_REFERENCES);
+        String key = createTransactionObjectKey(Instant.parse("2025-01-14T15:30:00Z"), "test-transaction");
+        StateStoreCommitRequest commitRequest = createCommitRequestInS3(key, TransactionType.REPLACE_FILE_REFERENCES);
 
         // When
         String json = serDe.toJsonPrettyPrint(commitRequest);
@@ -66,9 +78,8 @@ public class StateStoreCommitRequestSerDeTest {
     @Test
     void shouldSerialiseInitialisePartitionsInS3() {
         // Given
-        String key = TransactionBodyStore.createObjectKey("test-table", Instant.parse("2025-01-14T15:30:00Z"), "test-transaction");
-        StateStoreCommitRequest commitRequest = StateStoreCommitRequest.create(
-                "test-table", key, TransactionType.INITIALISE_PARTITIONS);
+        String key = createTransactionObjectKey(Instant.parse("2025-01-14T15:30:00Z"), "test-transaction");
+        StateStoreCommitRequest commitRequest = createCommitRequestInS3(key, TransactionType.INITIALISE_PARTITIONS);
 
         // When
         String json = serDe.toJsonPrettyPrint(commitRequest);
@@ -85,7 +96,24 @@ public class StateStoreCommitRequestSerDeTest {
                 .rootFirst("root")
                 .splitToNewChildren("root", "L", "R", 50L)
                 .buildList());
-        StateStoreCommitRequest commitRequest = StateStoreCommitRequest.create("test-table", transaction);
+        StateStoreCommitRequest commitRequest = createDirectCommitRequest(transaction);
+
+        // When
+        String json = serDe.toJsonPrettyPrint(commitRequest);
+
+        // Then
+        assertThat(serDe.fromJson(json)).isEqualTo(commitRequest);
+        Approvals.verify(json, new Options().forFile().withExtension(".json"));
+    }
+
+    @Test
+    void shouldSerialiseAddFilesDirectly() {
+        // Given
+        PartitionTree partitions = new PartitionsBuilder(schema).singlePartition("root").buildTree();
+        FileReferenceTransaction transaction = AddFilesTransaction.fromReferences(List.of(
+                fileFactory(partitions).rootFile("file1", 100),
+                fileFactory(partitions).rootFile("file2", 200)));
+        StateStoreCommitRequest commitRequest = createDirectCommitRequest(transaction);
 
         // When
         String json = serDe.toJsonPrettyPrint(commitRequest);
@@ -108,12 +136,20 @@ public class StateStoreCommitRequestSerDeTest {
         assertThat(serDe.fromJson(json)).isEqualTo(commitRequest);
     }
 
-    private TableProperties createTableProperties(Schema schema) {
-        InstanceProperties instanceProperties = createTestInstanceProperties();
-        TableProperties tableProperties = createTestTableProperties(instanceProperties, schema);
-        tableProperties.set(TABLE_ID, "test-table");
-        tableProperties.set(TABLE_NAME, "test.table");
-        return tableProperties;
+    private String createTransactionObjectKey(Instant now, String uuid) {
+        return TransactionBodyStore.createObjectKey(tableProperties.get(TABLE_ID), now, uuid);
+    }
+
+    private StateStoreCommitRequest createCommitRequestInS3(String objectKey, TransactionType transactionType) {
+        return StateStoreCommitRequest.create(tableProperties.get(TABLE_ID), objectKey, transactionType);
+    }
+
+    private StateStoreCommitRequest createDirectCommitRequest(StateStoreTransaction<?> transaction) {
+        return StateStoreCommitRequest.create(tableProperties.get(TABLE_ID), transaction);
+    }
+
+    private FileReferenceFactory fileFactory(PartitionTree partitions) {
+        return FileReferenceFactory.from(instanceProperties, tableProperties, partitions);
     }
 
 }

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseAddFilesDirectly.approved.json
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseAddFilesDirectly.approved.json
@@ -1,0 +1,30 @@
+{
+  "tableId": "933cd595",
+  "transactionType": "ADD_FILES",
+  "transaction": {
+    "files": [
+      {
+        "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
+        "references": [
+          {
+            "partitionId": "root",
+            "numberOfRows": 100,
+            "countApproximate": false,
+            "onlyContainsDataForThisPartition": true
+          }
+        ]
+      },
+      {
+        "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file2.parquet",
+        "references": [
+          {
+            "partitionId": "root",
+            "numberOfRows": 200,
+            "countApproximate": false,
+            "onlyContainsDataForThisPartition": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseCompactionCommitInS3.approved.json
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseCompactionCommitInS3.approved.json
@@ -1,5 +1,5 @@
 {
-  "tableId": "test-table",
+  "tableId": "933cd595",
   "transactionType": "REPLACE_FILE_REFERENCES",
-  "bodyKey": "test-table/statestore/transactions/2025-01-14T15:30:00Z-test-transaction.json"
+  "bodyKey": "933cd595/statestore/transactions/2025-01-14T15:30:00Z-test-transaction.json"
 }

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseInitialisePartitionsDirectly.approved.json
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseInitialisePartitionsDirectly.approved.json
@@ -1,5 +1,5 @@
 {
-  "tableId": "test-table",
+  "tableId": "933cd595",
   "transactionType": "INITIALISE_PARTITIONS",
   "transaction": {
     "partitions": [

--- a/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseInitialisePartitionsInS3.approved.json
+++ b/java/core/src/test/java/sleeper/core/statestore/commit/StateStoreCommitRequestSerDeTest.shouldSerialiseInitialisePartitionsInS3.approved.json
@@ -1,5 +1,5 @@
 {
-  "tableId": "test-table",
+  "tableId": "933cd595",
   "transactionType": "INITIALISE_PARTITIONS",
-  "bodyKey": "test-table/statestore/transactions/2025-01-14T15:30:00Z-test-transaction.json"
+  "bodyKey": "933cd595/statestore/transactions/2025-01-14T15:30:00Z-test-transaction.json"
 }

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeAddFiles.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeAddFiles.approved.txt
@@ -1,7 +1,7 @@
 {
   "files": [
     {
-      "filename": "file1.parquet",
+      "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
       "references": [
         {
           "partitionId": "root",
@@ -12,7 +12,7 @@
       ]
     },
     {
-      "filename": "file2.parquet",
+      "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file2.parquet",
       "references": [
         {
           "partitionId": "root",

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeAddSplitFile.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeAddSplitFile.approved.txt
@@ -1,7 +1,7 @@
 {
   "files": [
     {
-      "filename": "file.parquet",
+      "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file.parquet",
       "references": [
         {
           "partitionId": "L",

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeAssignJobIds.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeAssignJobIds.approved.txt
@@ -4,16 +4,16 @@
       "jobId": "job1",
       "partitionId": "root",
       "filenames": [
-        "file1.parquet",
-        "file2.parquet"
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file2.parquet"
       ]
     },
     {
       "jobId": "job2",
       "partitionId": "L",
       "filenames": [
-        "file3.parquet",
-        "file4.parquet"
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_L/file3.parquet",
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_L/file4.parquet"
       ]
     }
   ]

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeDeleteFiles.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeDeleteFiles.approved.txt
@@ -1,6 +1,6 @@
 {
   "filenames": [
-    "file1.parquet",
-    "file2.parquet"
+    "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
+    "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file2.parquet"
   ]
 }

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeReplaceFileReferences.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeReplaceFileReferences.approved.txt
@@ -3,11 +3,11 @@
     {
       "jobId": "job",
       "inputFiles": [
-        "file1.parquet",
-        "file2.parquet"
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file2.parquet"
       ],
       "newReference": {
-        "filename": "file3.parquet",
+        "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file3.parquet",
         "partitionId": "root",
         "numberOfRows": 100,
         "countApproximate": false,

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeReplaceFileReferencesWithTrackingIds.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeReplaceFileReferencesWithTrackingIds.approved.txt
@@ -5,11 +5,11 @@
       "taskId": "task",
       "jobRunId": "run",
       "inputFiles": [
-        "file1.parquet",
-        "file2.parquet"
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
+        "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file2.parquet"
       ],
       "newReference": {
-        "filename": "file3.parquet",
+        "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file3.parquet",
         "partitionId": "root",
         "numberOfRows": 100,
         "countApproximate": false,

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeSplitFileReferences.approved.txt
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/transaction/TransactionSerDeTest.shouldSerDeSplitFileReferences.approved.txt
@@ -2,7 +2,7 @@
   "requests": [
     {
       "oldReference": {
-        "filename": "file1.parquet",
+        "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
         "partitionId": "root",
         "numberOfRows": 100,
         "countApproximate": false,
@@ -10,14 +10,14 @@
       },
       "newReferences": [
         {
-          "filename": "file1.parquet",
+          "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
           "partitionId": "L",
           "numberOfRows": 50,
           "countApproximate": true,
           "onlyContainsDataForThisPartition": false
         },
         {
-          "filename": "file1.parquet",
+          "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_root/file1.parquet",
           "partitionId": "R",
           "numberOfRows": 50,
           "countApproximate": true,
@@ -27,7 +27,7 @@
     },
     {
       "oldReference": {
-        "filename": "file2.parquet",
+        "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_L/file2.parquet",
         "partitionId": "L",
         "numberOfRows": 200,
         "countApproximate": false,
@@ -35,14 +35,14 @@
       },
       "newReferences": [
         {
-          "filename": "file2.parquet",
+          "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_L/file2.parquet",
           "partitionId": "LL",
           "numberOfRows": 100,
           "countApproximate": true,
           "onlyContainsDataForThisPartition": false
         },
         {
-          "filename": "file2.parquet",
+          "filename": "s3a://sleeper-instanceid-table-data/933cd595/data/partition_L/file2.parquet",
           "partitionId": "LR",
           "numberOfRows": 100,
           "countApproximate": true,


### PR DESCRIPTION
This is intended to illustrate the JSON you would submit to the state store commit queue, if you want to manually add files to the state store. Here's a potential application:
1. Ingest a small file to a Sleeper table
2. Make a lot of copies of it in S3
3. Hand write some JSON for a state store commit request to add the copies to the table
4. Submit that to the state store commit queue
5. Your table now has a lot more data without needing to generate any more

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5763

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated TransactionSerDeTest, StateStoreCommitRequestSerDeTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
