### PR TITLE
Issue 5782 - Ingest batcher permissions for table data bucket

### DIFF
--- a/java/cdk/src/main/java/sleeper/cdk/stack/core/CoreStacks.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/core/CoreStacks.java
@@ -86,6 +86,10 @@ public class CoreStacks {
         tableIndexStack.grantRead(grantee);
     }
 
+    public void grantReadTableDataBucket(IGrantable grantee) {
+        dataStack.grantRead(grantee);
+    }
+
     public void grantReadTablesAndData(IGrantable grantee) {
         configBucketStack.grantRead(grantee);
         tableIndexStack.grantRead(grantee);

--- a/java/cdk/src/main/java/sleeper/cdk/stack/ingest/IngestBatcherStack.java
+++ b/java/cdk/src/main/java/sleeper/cdk/stack/ingest/IngestBatcherStack.java
@@ -153,6 +153,7 @@ public class IngestBatcherStack extends NestedStack {
         submitQueue.grantConsumeMessages(submitterLambda);
         submitDLQ.grantSendMessages(submitterLambda);
         coreStacks.grantReadTablesConfig(submitterLambda);
+        coreStacks.grantReadTableDataBucket(submitterLambda);
         coreStacks.grantReadIngestSources(submitterLambda.getRole());
 
         IFunction jobCreatorLambda = lambdaCode.buildFunction(this, LambdaHandler.INGEST_BATCHER_JOB_CREATOR, "IngestBatcherJobCreationLambda", builder -> builder


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5782

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - IngestBatcherST.shouldIngestFileFromTableDataBucket

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
