### PR TITLE
Issue 5876 - Increase timeout waiting for tasks in ParallelCompactionsST

### DIFF
--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/SystemTestCompaction.java
@@ -116,9 +116,12 @@ public class SystemTestCompaction {
     }
 
     public SystemTestCompaction waitForTasks(int expectedTasks) {
+        return waitForTasks(expectedTasks, pollDriver.pollWithIntervalAndTimeout(Duration.ofSeconds(10), Duration.ofMinutes(6)));
+    }
+
+    public SystemTestCompaction waitForTasks(int expectedTasks, PollWithRetries poll) {
         new WaitForTasks(driver.getJobTracker())
-                .waitUntilNumTasksStartedAJob(expectedTasks, lastJobIds,
-                        pollDriver.pollWithIntervalAndTimeout(Duration.ofSeconds(10), Duration.ofMinutes(6)));
+                .waitUntilNumTasksStartedAJob(expectedTasks, lastJobIds, pollDriver.poll(poll));
         return this;
     }
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
@@ -73,7 +73,9 @@ public class ParallelCompactionsST {
                 .putTableOnlineWaitForJobCreation(40960,
                         PollWithRetries.intervalAndPollingTimeout(
                                 Duration.ofSeconds(10), Duration.ofMinutes(5)))
-                .waitForTasks(300)
+                .waitForTasks(300,
+                        PollWithRetries.intervalAndPollingTimeout(
+                                Duration.ofSeconds(10), Duration.ofMinutes(10)))
                 .waitForJobsToFinishThenCommit(
                         PollWithRetries.intervalAndPollingTimeout(
                                 Duration.ofSeconds(10), Duration.ofMinutes(5)),


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5876

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated ParallelCompactionsST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
