### PR TITLE
Issue 5991 - Reduce number of parallel compaction tasks in test

### DIFF
--- a/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
+++ b/java/system-test/system-test-suite/src/main/java/sleeper/systemtest/suite/fixtures/SystemTestInstance.java
@@ -251,7 +251,7 @@ public class SystemTestInstance {
         properties.setEnumList(OPTIONAL_STACKS,
                 // Enable GC to reduce the number of files needing deletion during teardown
                 List.of(OptionalStack.CompactionStack, OptionalStack.GarbageCollectorStack));
-        properties.set(MAXIMUM_CONCURRENT_COMPACTION_TASKS, "300");
+        properties.set(MAXIMUM_CONCURRENT_COMPACTION_TASKS, "200");
         properties.unset(COMPACTION_COMMIT_BATCHING_WINDOW_IN_SECONDS); // Use default
         setSystemTestTags(properties, "compactionInParallel", "Sleeper Maven system test compaction in parallel");
         return createInstanceConfiguration(properties);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5991

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated ParallelCompactionsST

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
