### PR TITLE
Issue 5990 - Stop pausing instance during teardown

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/teardown/TearDownInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/teardown/TearDownInstance.java
@@ -18,7 +18,6 @@ package sleeper.clients.teardown;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sleeper.clients.deploy.AwsScheduleRules;
 import sleeper.clients.util.ClientUtils;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.local.LoadLocalProperties;
@@ -66,7 +65,6 @@ public class TearDownInstance {
         LOGGER.info("scriptsDir: {}", scriptsDir);
         LOGGER.info("{}: {}", ID.getPropertyName(), instanceId);
 
-        shutdownSystemProcesses();
         deleteStack();
         waitForStackToDelete();
         deleteArtefactsStack();
@@ -74,10 +72,6 @@ public class TearDownInstance {
         removeGeneratedDir(scriptsDir);
 
         LOGGER.info("Finished tear down");
-    }
-
-    public void shutdownSystemProcesses() throws InterruptedException {
-        new AwsScheduleRules(clients.getCloudWatch()).pauseInstance(instanceId);
     }
 
     public void deleteStack() {

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/cdk/TearDownMavenSystemTest.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/cdk/TearDownMavenSystemTest.java
@@ -63,7 +63,6 @@ public class TearDownMavenSystemTest {
         List<TearDownInstance> tearDownAllInstances = Stream.concat(tearDownMavenInstances.stream(), tearDownStandaloneInstances.stream()).collect(toUnmodifiableList());
 
         for (TearDownInstance instance : tearDownAllInstances) {
-            instance.shutdownSystemProcesses();
             instance.deleteStack();
         }
         for (TearDownInstance instance : tearDownMavenInstances) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/5990

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
