### PR TITLE
Issue 6168 - Stop Python virtual environment conflicting in nightly tests

### DIFF
--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -18,8 +18,9 @@ unset CDPATH
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 SCRIPTS_DIR=$(cd "$THIS_DIR" && cd ../.. && pwd)
-MAVEN_DIR=$(cd "$SCRIPTS_DIR" && cd ../java && pwd)
-REPO_PARENT_DIR=$(cd "$SCRIPTS_DIR" && cd ../.. && pwd)
+REPO_DIR=$(cd "$SCRIPTS_DIR" && cd .. && pwd)
+MAVEN_DIR=$(cd "$REPO_DIR" && cd java && pwd)
+REPO_PARENT_DIR=$(cd "$REPO_DIR" && cd .. && pwd)
 
 pushd "$SCRIPTS_DIR/test"
 
@@ -54,13 +55,15 @@ echo "SUITE_PARAMS=(${SUITE_PARAMS[*]})"
 
 source "$SCRIPTS_DIR/functions/timeUtils.sh"
 source "$SCRIPTS_DIR/functions/systemTestUtils.sh"
+source "$SCRIPTS_DIR/functions/sedInPlace.sh"
 START_TIMESTAMP=$(record_time)
 START_TIME=$(recorded_time_str "$START_TIMESTAMP" "%Y%m%d-%H%M%S")
 START_TIME_SHORT=$(recorded_time_str "$START_TIMESTAMP" "%m%d%H%M")
 OUTPUT_DIR="$REPO_PARENT_DIR/logs/$START_TIME-$MAIN_SUITE_NAME"
 
 mkdir -p "$OUTPUT_DIR"
-../build/buildForTest.sh
+"$SCRIPTS_DIR/build/buildForTest.sh"
+"$SCRIPTS_DIR/build/buildPython.sh"
 VERSION=$(cat "$SCRIPTS_DIR/templates/version.txt")
 SYSTEM_TEST_JAR="$SCRIPTS_DIR/jars/system-test-${VERSION}-utility.jar"
 
@@ -74,11 +77,16 @@ docker buildx create --name sleeper --use
 set +e
 
 copyFolderForParallelRun() {
-    echo "Making folder $1 for parallel build"
+    COPY_DIR=$1
+    echo "Making folder $COPY_DIR for parallel build"
     pushd $REPO_PARENT_DIR
-    sudo rm -rf $1
-    mkdir $1
-    sudo rsync -a --exclude=".*" sleeper/ $1
+    sudo rm -rf $COPY_DIR
+    mkdir $COPY_DIR
+    sudo rsync -a --exclude=".*" sleeper/ $COPY_DIR
+    # A Python virtual environment includes an absolute path reference to itself, so update it
+    sed_in_place \
+      -e "s|sleeper/python|$COPY_DIR/python|" \
+      "$COPY_DIR/python/env/bin/activate"
     popd
 }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6168

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Tested manually

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
