### PR TITLE
Issue 6206 - Set version number from SystemTestStandaloneProperties

### DIFF
--- a/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestStandaloneProperties.java
+++ b/java/system-test/system-test-configuration/src/main/java/sleeper/systemtest/configuration/SystemTestStandaloneProperties.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import sleeper.configuration.properties.S3InstanceProperties;
+import sleeper.core.SleeperVersion;
 import sleeper.core.properties.SleeperProperties;
 import sleeper.core.properties.SleeperPropertiesPrettyPrinter;
 import sleeper.core.properties.SleeperPropertyIndex;
@@ -40,6 +41,7 @@ import java.util.Properties;
 
 import static sleeper.core.properties.PropertiesUtils.loadProperties;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.CONFIG_BUCKET;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.VERSION;
 import static sleeper.core.properties.instance.CommonProperty.ID;
 import static sleeper.core.properties.instance.CommonProperty.JARS_BUCKET;
 import static sleeper.core.properties.instance.CommonProperty.LAMBDA_DEPLOY_TYPE;
@@ -141,6 +143,7 @@ public class SystemTestStandaloneProperties
         instanceProperties.set(APACHE_LOGGING_LEVEL, "INFO");
         instanceProperties.set(PARQUET_LOGGING_LEVEL, "WARN");
         instanceProperties.set(AWS_LOGGING_LEVEL, "INFO");
+        instanceProperties.set(VERSION, SleeperVersion.getVersion());
         return instanceProperties;
     }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6206

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Tested in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
