### PR TITLE
Issue 6213 - Remove ssl-cert-snakeoil.key from CLI

### DIFF
--- a/scripts/cli/dependencies/Dockerfile
+++ b/scripts/cli/dependencies/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     unminimize \
     && yes | unminimize \
     && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /etc/ssl/private/ssl-cert-snakeoil.key \
     && userdel -r ubuntu \
     && groupdel systemd-journal
 # The deleted user and group are added either by one of the above packages, or by unminimize. They are deleted to avoid


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6213

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Re-ran Trivy manually

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
