### PR TITLE
Issue 6155: Replace use of deprecated Maven systemProperties

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1905,17 +1905,17 @@
                     <configuration>
                         <argLine>@{argLine} ${module.access.args}</argLine>
                         <systemPropertyVariables>
-                            <propertyName>sleeper.system.test.short.id</propertyName>
-                            <propertyName>sleeper.system.test.vpc.id</propertyName>
-                            <propertyName>sleeper.system.test.subnet.ids</propertyName>
-                            <propertyName>sleeper.system.test.output.dir</propertyName>
-                            <propertyName>sleeper.system.test.cluster.enabled</propertyName>
-                            <propertyName>sleeper.system.test.force.redeploy</propertyName>
-                            <propertyName>sleeper.system.test.instances.force.redeploy</propertyName>
-                            <propertyName>sleeper.system.test.force.statestore.classname</propertyName>
-                            <propertyName>sleeper.system.test.create.multi.platform.builder</propertyName>
-                            <propertyName>sleeper.system.test.standalone.properties.template</propertyName>
-                            <propertyName>sleeper.system.test.instance.properties.overrides</propertyName>
+                            <sleeper.system.test.short.id>${sleeper.system.test.short.id}</sleeper.system.test.short.id>
+                            <sleeper.system.test.vpc.id>${sleeper.system.test.vpc.id}</sleeper.system.test.vpc.id>
+                            <sleeper.system.test.subnet.ids>${sleeper.system.test.subnet.ids}</sleeper.system.test.subnet.ids>
+                            <sleeper.system.test.output.dir>${sleeper.system.test.output.dir}</sleeper.system.test.output.dir>
+                            <sleeper.system.test.cluster.enabled>${sleeper.system.test.cluster.enabled}</sleeper.system.test.cluster.enabled>
+                            <sleeper.system.test.force.redeploy>${sleeper.system.test.force.redeploy}</sleeper.system.test.force.redeploy>
+                            <sleeper.system.test.instances.force.redeploy>${sleeper.system.test.instances.force.redeploy}</sleeper.system.test.instances.force.redeploy>
+                            <sleeper.system.test.force.statestore.classname>${sleeper.system.test.force.statestore.classname}</sleeper.system.test.force.statestore.classname>
+                            <sleeper.system.test.create.multi.platform.builder>${sleeper.system.test.create.multi.platform.builder}</sleeper.system.test.create.multi.platform.builder>
+                            <sleeper.system.test.standalone.properties.template>${sleeper.system.test.standalone.properties.template}</sleeper.system.test.standalone.properties.template>
+                            <sleeper.system.test.instance.properties.overrides>${sleeper.system.test.instance.properties.overrides}</sleeper.system.test.instance.properties.overrides>
                         </systemPropertyVariables>
                     </configuration>
                     <executions>


### PR DESCRIPTION
### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6155

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Execution of existing build

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
