### PR TITLE
Issue 6348 - Stop reading environment variables in tests

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditor.java
+++ b/java/clients/src/main/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditor.java
@@ -39,7 +39,7 @@ public class UpdatePropertiesWithTextEditor {
 
     private final Path tempDirectory;
     private final CommandRunner runCommand;
-    private final UpdatePropertiesTextEditorCommand editorCommand = new UpdatePropertiesTextEditorCommand();
+    private final UpdatePropertiesTextEditorCommand editorCommand;
 
     public UpdatePropertiesWithTextEditor(Path tempDirectory) {
         this(tempDirectory, CommandUtils::runCommandInheritIO, System::getenv);
@@ -48,6 +48,7 @@ public class UpdatePropertiesWithTextEditor {
     public UpdatePropertiesWithTextEditor(Path tempDirectory, CommandRunner runCommand, Function<String, String> readEnvironmentVariable) {
         this.tempDirectory = tempDirectory;
         this.runCommand = runCommand;
+        this.editorCommand = new UpdatePropertiesTextEditorCommand(readEnvironmentVariable);
     }
 
     public UpdatePropertiesRequest<InstanceProperties> openPropertiesFile(InstanceProperties properties) throws IOException, InterruptedException {

--- a/java/clients/src/test/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditorIT.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditorIT.java
@@ -66,15 +66,11 @@ class UpdatePropertiesWithTextEditorIT {
         void shouldInvokeEditorOnInstancePropertiesFile() throws Exception {
             // Given
             InstanceProperties properties = createTestInstanceProperties();
-
-            String editor = System.getenv("EDITOR");
-            if (editor == null || editor.isBlank()) {
-                editor = "nano";
-            }
+            helper.setEnvironmentVariable("EDITOR", "myeditor");
 
             // When / Then
             assertThat(helper.openInstancePropertiesGetCommandRun(properties))
-                    .containsExactly(editor, tempDir.resolve("sleeper/admin/temp.properties").toString());
+                    .containsExactly("myeditor", tempDir.resolve("sleeper/admin/temp.properties").toString());
         }
 
         @Test

--- a/java/clients/src/test/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditorTestHelper.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/properties/UpdatePropertiesWithTextEditorTestHelper.java
@@ -107,6 +107,10 @@ public class UpdatePropertiesWithTextEditorTestHelper {
         return expectedPropertiesFile;
     }
 
+    public void setEnvironmentVariable(String name, String value) {
+        environmentVariables.put(name, value);
+    }
+
     private UpdatePropertiesWithTextEditor updaterSavingProperties(SleeperProperties<?> after) {
         return updaterWithCommandHandler(command -> {
             after.save(expectedPropertiesFile);


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6348

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated UpdatePropertiesWithTextEditorIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
