### PR TITLE
6355: Include EMR Serverless in the ingest job reporting queue message counts

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/report/ingest/job/IngestQueueMessages.java
+++ b/java/clients/src/main/java/sleeper/clients/report/ingest/job/IngestQueueMessages.java
@@ -97,7 +97,7 @@ public class IngestQueueMessages {
         if (eksMessages != null) {
             out.printf("Jobs waiting in EKS queue (excluded from report): %s%n", eksMessages);
         }
-        if (eksMessages != null) {
+        if (emrServerlessMessages != null) {
             out.printf("Jobs waiting in EMR serverless queue (excluded from report): %s%n", emrServerlessMessages);
         }
         out.printf("Total jobs waiting across all queues: %s%n", getTotalMessages());


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6355

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated IngestQueueMessagesTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
