### PR TITLE
6422 - Fix issue with EMR cluster unable to change capacity

### DIFF
--- a/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/PersistentEmrBulkImportStack.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/PersistentEmrBulkImportStack.java
@@ -121,11 +121,13 @@ public class PersistentEmrBulkImportStack extends NestedStack {
                 .name("Driver")
                 .instanceTypeConfigs(readMasterInstanceTypes(instanceProperties, ebsConf))
                 .targetOnDemandCapacity(1)
+                .targetSpotCapacity(0)
                 .build();
         CfnCluster.InstanceFleetConfigProperty coreInstanceFleetConfigProperty = CfnCluster.InstanceFleetConfigProperty.builder()
                 .name("Executors")
                 .instanceTypeConfigs(readExecutorInstanceTypes(instanceProperties, ebsConf))
                 .targetOnDemandCapacity(instanceProperties.getInt(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY))
+                .targetSpotCapacity(0)
                 .build();
 
         JobFlowInstancesConfigProperty.Builder jobFlowInstancesConfigPropertyBuilder = JobFlowInstancesConfigProperty.builder()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6422

### Tests

Manual testing on a real instance showed that: scaling now works from managed scaling with min of 1 to min of 2, from managed scaling on to managed scaling off, and from managed scaling off to managed scaling on with a min of 3.
