### PR TITLE
Revert "Bump software.amazon.awscdk:aws-cdk-lib from 2.235.1 to 2.236.0 in /java"

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -183,7 +183,7 @@
         <!-- Facebook Collections brings in a vulnerable version of Guava, so we manage this -->
         <guava.version>33.5.0-jre</guava.version>
         <google.errorprone.version>2.46.0</google.errorprone.version>
-        <cdk.version>2.236.0</cdk.version>
+        <cdk.version>2.235.1</cdk.version>
         <cdk.kubectl.32.version>2.1.0</cdk.kubectl.32.version>
         <constructs.version>10.4.5</constructs.version>
         <jsii.version>1.125.0</jsii.version>


### PR DESCRIPTION
Reverts gchq/sleeper#6478