### PR TITLE
Issue 6414 - Trigger workflow when autogenerated files are edited directly

### DIFF
--- a/.github/workflows/java-status.yaml
+++ b/.github/workflows/java-status.yaml
@@ -5,6 +5,10 @@ on:
       - '.github/workflows/java-status.yaml'
       - '.github/config/chunks.yaml'
       - 'java/**'
+      # Check generated files are not edited directly
+      - 'examples/**'
+      - 'scripts/templates/**'
+      - 'docs/usage/properties/**'
   push:
     branches:
       - develop
@@ -52,7 +56,7 @@ jobs:
           mvn compile exec:java -q -e -Dexec.mainClass=sleeper.build.notices.CheckNotices \
             -Dmaven.repo.local=${{ runner.temp }}/.m2/repository \
             -Dexec.args="$NOTICES_FILE $MAVEN_PROJECT"
-      - name: Validate properties templates are up to date
+      - name: Validate generated files and documentation are up to date
         working-directory: ./java
         run: |
           PROJECT_ROOT=$(cd .. && pwd)


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6414

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Running in GitHub Actions

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
