### PR TITLE
6457 Thread safe use of providers in multi threaded state store

### DIFF
--- a/java/statestore-committer/src/main/java/sleeper/statestore/committer/MultiThreadedStateStoreCommitter.java
+++ b/java/statestore-committer/src/main/java/sleeper/statestore/committer/MultiThreadedStateStoreCommitter.java
@@ -169,8 +169,8 @@ public class MultiThreadedStateStoreCommitter {
 
                 commitRequestsByTableId.entrySet().forEach(tableCommitRequests -> {
                     String tableId = tableCommitRequests.getKey();
-                    List<StateStoreCommitRequestWithSqsReceipt> requestsWithHandle = tableCommitRequests.getValue();
-                    LOGGER.info("Received {} requests for table: {}", requestsWithHandle.size(), tableId);
+                    List<StateStoreCommitRequestWithSqsReceipt> requests = tableCommitRequests.getValue();
+                    LOGGER.info("Received {} requests for table: {}", requests.size(), tableId);
 
                     // Wait until processing of previous commits for this table has finished
                     if (tableFutures.containsKey(tableId)) {
@@ -186,7 +186,7 @@ public class MultiThreadedStateStoreCommitter {
 
                     // Apply the commits for each table on a separate thread
                     CompletableFuture<Instant> task = CompletableFuture.supplyAsync(() -> {
-                        processCommitRequestsForTable(tableId, stateStore, requestsWithHandle);
+                        processCommitRequestsForTable(tableId, stateStore, requests);
                         return Instant.now();
                     });
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6457

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
