### PR TITLE
Issue 6465 - Confusing logs when table properties are read from a local configuration folder

### DIFF
--- a/java/core/src/main/java/sleeper/core/properties/local/LoadLocalProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/local/LoadLocalProperties.java
@@ -176,7 +176,7 @@ public class LoadLocalProperties {
      * @param  propertiesFile     the path to the table properties file
      * @return                    the table properties
      */
-    public static TableProperties loadOnlyTableFromPropertiesFileNoValidation(InstanceProperties instanceProperties, Path propertiesFile) {
+    public static TableProperties loadTablePropertiesFromFileNoValidation(InstanceProperties instanceProperties, Path propertiesFile) {
         Path folder = propertiesFile.getParent();
         if (folder == null) {
             throw new IllegalArgumentException("Properties file parameter has no parent directory, please pass in a file instead of a directory.");
@@ -203,7 +203,7 @@ public class LoadLocalProperties {
      * @return                    the table configuration
      */
     public static SleeperTableConfiguration loadTableFromPropertiesFileNoValidation(InstanceProperties instanceProperties, Path propertiesFile) {
-        TableProperties tableProperties = loadOnlyTableFromPropertiesFileNoValidation(instanceProperties, propertiesFile);
+        TableProperties tableProperties = loadTablePropertiesFromFileNoValidation(instanceProperties, propertiesFile);
         Path folder = propertiesFile.getParent();
         if (folder == null) {
             throw new IllegalArgumentException("Properties file parameter has no parent directory, please pass in a file instead of a directory.");
@@ -226,7 +226,7 @@ public class LoadLocalProperties {
         if (!Files.exists(propertiesPath)) {
             return null;
         }
-        return loadOnlyTableFromPropertiesFileNoValidation(instanceProperties, propertiesPath);
+        return loadTablePropertiesFromFileNoValidation(instanceProperties, propertiesPath);
     }
 
     private static Path directoryOf(Path filePath) {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6465

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Execution of existing test suite

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
