### PR TITLE
6688: Override set on table properties to set schema correctly

### DIFF
--- a/java/core/src/main/java/sleeper/core/properties/table/TableProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/table/TableProperties.java
@@ -130,11 +130,22 @@ public class TableProperties extends SleeperProperties<TableProperty> {
      */
     public void setSchema(Schema schema) {
         this.schema = schema;
-        set(TableProperty.SCHEMA, new SchemaSerDe().toJson(schema));
+        super.set(TableProperty.SCHEMA, new SchemaSerDe().toJson(schema));
     }
 
     public InstanceProperties getInstanceProperties() {
         return instanceProperties;
+    }
+
+    @Override
+    public void set(TableProperty property, String value) {
+        if (value != null) {
+            if (property == SCHEMA) {
+                setSchema(Schema.loadFromString(value));
+            } else {
+                super.set(property, value);
+            }
+        }
     }
 
     @Override

--- a/java/core/src/test/java/sleeper/core/properties/table/TablePropertiesSchemaTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/table/TablePropertiesSchemaTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.schema.Field;
 import sleeper.core.schema.Schema;
+import sleeper.core.schema.SchemaSerDe;
 import sleeper.core.schema.type.StringType;
 
 import java.util.Properties;
@@ -27,6 +28,7 @@ import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.properties.PropertiesUtils.loadProperties;
+import static sleeper.core.properties.table.TableProperty.SCHEMA;
 import static sleeper.core.properties.table.TableProperty.TABLE_NAME;
 
 class TablePropertiesSchemaTest {
@@ -117,5 +119,18 @@ class TablePropertiesSchemaTest {
         // Then
         assertThatThrownBy(() -> TableProperties.createAndValidate(instanceProperties, properties))
                 .hasMessage("Property sleeper.table.name was invalid. It was unset.");
+    }
+
+    @Test
+    void shouldSetSchemaCorrectlyWhenSetCalled() {
+        //Given
+        TableProperties tableProperties = new TableProperties(new InstanceProperties());
+        Schema schema = Schema.builder().rowKeyFields(new Field("key", new StringType())).build();
+
+        //When
+        tableProperties.set(SCHEMA, new SchemaSerDe().toJson(schema));
+
+        //Then
+        assertThat(tableProperties.getSchema()).isEqualTo(schema);
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6688

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - TablePropertiesSchemaTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
