### PR TITLE
Issue 6771 - Allow creating SleeperClient with no web socket deployed

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketClient.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketClient.java
@@ -53,12 +53,12 @@ public class QueryWebSocketClient {
         this.tablePropertiesProvider = tablePropertiesProvider;
         this.adapter = adapter;
         this.timeoutMs = timeoutMs;
-        if (!instanceProperties.isSet(QUERY_WEBSOCKET_API_URL)) {
-            throw new IllegalArgumentException("Use of this query client requires the WebSocket API to have been deployed as part of your Sleeper instance.");
-        }
     }
 
     public CompletableFuture<List<Row>> submitQuery(Query query) throws InterruptedException {
+        if (!instanceProperties.isSet(QUERY_WEBSOCKET_API_URL)) {
+            throw new IllegalArgumentException("Use of this query client requires the WebSocket API to have been deployed as part of your Sleeper instance.");
+        }
         TableProperties tableProperties = tablePropertiesProvider.getByName(query.getTableName());
         QueryWebSocketFuture<List<Row>> future = new QueryWebSocketFuture<>();
         QueryWebSocketListener listener = new QueryWebSocketListener(tableProperties.getSchema(), query, future);

--- a/java/clients/src/test/java/sleeper/clients/query/QueryWebSocketClientTest.java
+++ b/java/clients/src/test/java/sleeper/clients/query/QueryWebSocketClientTest.java
@@ -33,6 +33,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.QUERY_WEBSOCKET_API_URL;
 
 public class QueryWebSocketClientTest extends QueryWebSocketClientTestBase {
 
@@ -314,11 +316,27 @@ public class QueryWebSocketClientTest extends QueryWebSocketClientTestBase {
             assertThat(connection.getSentMessages())
                     .containsExactly(querySerDe.toJson(query));
         }
+
+        @Test
+        void shouldFailToSendQueryWithNoWebSocketDeployed() {
+            // Given
+            instanceProperties.unset(QUERY_WEBSOCKET_API_URL);
+            QueryWebSocketClient client = createClient();
+            Query query = exactQuery("test-query", 100);
+
+            // When / Then
+            assertThatThrownBy(() -> client.submitQuery(query))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Use of this query client requires the WebSocket API to have been deployed as part of your Sleeper instance.");
+        }
     }
 
     protected CompletableFuture<List<Row>> runQueryFuture(Query query) throws Exception {
-        QueryWebSocketClient realClient = new QueryWebSocketClient(
+        return createClient().submitQuery(query);
+    }
+
+    private QueryWebSocketClient createClient() {
+        return new QueryWebSocketClient(
                 instanceProperties, tablePropertiesProvider, connection.createAdapter(), 0);
-        return realClient.submitQuery(query);
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/query/QueryWebSocketClientTest.java
+++ b/java/clients/src/test/java/sleeper/clients/query/QueryWebSocketClientTest.java
@@ -319,8 +319,9 @@ public class QueryWebSocketClientTest extends QueryWebSocketClientTestBase {
 
         @Test
         void shouldFailToSendQueryWithNoWebSocketDeployed() {
-            // Given
+            // Given no web socket is deployed
             instanceProperties.unset(QUERY_WEBSOCKET_API_URL);
+            // And we create the client (which we should be able to do)
             QueryWebSocketClient client = createClient();
             Query query = exactQuery("test-query", 100);
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6771

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated QueryWebSocketClientTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
