### PR TITLE
6789: Only validate emr capacity min less than max when scalling enabled

### DIFF
--- a/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
@@ -83,7 +83,10 @@ public class InstanceProperties extends SleeperProperties<InstanceProperty> {
         // Validate EMR managed scaling max is greater than min
         int minEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY);
         int maxEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
-        if (getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING) && maxEmrCapacity <= minEmrCapacity) {
+        boolean managedScalling = getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING);
+        if (managedScalling && maxEmrCapacity <= minEmrCapacity) {
+            reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, String.valueOf(managedScalling));
+            reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, String.valueOf(minEmrCapacity));
             reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, String.valueOf(maxEmrCapacity));
         }
     }

--- a/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
@@ -34,6 +34,7 @@ import static sleeper.core.properties.PropertiesUtils.loadProperties;
 import static sleeper.core.properties.instance.CommonProperty.TAGS;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY;
+import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING;
 
 /**
  * Contains values of the properties to configure an instance of Sleeper.
@@ -82,7 +83,7 @@ public class InstanceProperties extends SleeperProperties<InstanceProperty> {
         // Validate EMR managed scaling max is greater than min
         int minEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY);
         int maxEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
-        if (maxEmrCapacity <= minEmrCapacity) {
+        if (getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING) && maxEmrCapacity <= minEmrCapacity) {
             reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, String.valueOf(maxEmrCapacity));
         }
     }

--- a/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
@@ -83,9 +83,9 @@ public class InstanceProperties extends SleeperProperties<InstanceProperty> {
         // Validate EMR managed scaling max is greater than min
         int minEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY);
         int maxEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
-        boolean managedScalling = getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING);
-        if (managedScalling && maxEmrCapacity <= minEmrCapacity) {
-            reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, String.valueOf(managedScalling));
+        boolean managedScaling = getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING);
+        if (managedScaling && maxEmrCapacity <= minEmrCapacity) {
+            reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, String.valueOf(managedScaling));
             reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, String.valueOf(minEmrCapacity));
             reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, String.valueOf(maxEmrCapacity));
         }

--- a/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import sleeper.core.properties.SleeperPropertiesInvalidException;
-import sleeper.core.properties.SleeperProperty;
 
 import java.io.File;
 import java.io.IOException;
@@ -292,29 +291,6 @@ class InstancePropertiesTest {
 
         // When / Then
         properties.validate(); //Will throw if invalid
-    }
-
-    @Test
-    public void shouldFailValidationForInvalidEMRManagedScalingBoundsWhenEmrScalingTrue() {
-        // Given
-        InstanceProperties properties = createTestInstanceProperties();
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "15");
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "10");
-
-        // When / Then
-        assertThatThrownBy(() -> properties.validate())
-                .isInstanceOf(SleeperPropertiesInvalidException.class)
-                .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
-                        BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
-                .extracting("invalidValues")
-                .satisfies(invalidValues -> {
-                    assertThat(invalidValues).isNotNull();
-                    Map<SleeperProperty, String> values = (Map) invalidValues;
-                    assertThat(values.keySet()).contains(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING,
-                            BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY,
-                            BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
-                });
     }
 
     private static InstanceProperties getSleeperProperties() {

--- a/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import sleeper.core.properties.SleeperPropertiesInvalidException;
+import sleeper.core.properties.SleeperProperty;
 
 import java.io.File;
 import java.io.IOException;
@@ -302,8 +303,18 @@ class InstancePropertiesTest {
         properties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "10");
 
         // When / Then
-        assertThatThrownBy(() -> properties.validate()).isInstanceOf(SleeperPropertiesInvalidException.class)
-                .hasMessageContaining(String.format("%s was invalid", BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY.getPropertyName()));
+        assertThatThrownBy(() -> properties.validate())
+                .isInstanceOf(SleeperPropertiesInvalidException.class)
+                .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
+                        BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
+                .extracting("invalidValues")
+                .satisfies(invalidValues -> {
+                    assertThat(invalidValues).isNotNull();
+                    Map<SleeperProperty, String> values = (Map) invalidValues;
+                    assertThat(values.keySet()).contains(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING,
+                            BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY,
+                            BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
+                });
     }
 
     private static InstanceProperties getSleeperProperties() {

--- a/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
@@ -94,6 +94,7 @@ import static sleeper.core.properties.instance.PartitionSplittingProperty.SPLIT_
 import static sleeper.core.properties.instance.PartitionSplittingProperty.SPLIT_PARTITIONS_TIMEOUT_IN_SECONDS;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY;
+import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSING_LAMBDA_RESULTS_BATCH_SIZE;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSING_LAMBDA_STATE_REFRESHING_PERIOD_IN_SECONDS;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSOR_LAMBDA_MEMORY_IN_MB;
@@ -281,13 +282,41 @@ class InstancePropertiesTest {
     }
 
     @Test
-    public void shouldFailValidationForInvalidEMRManagedScalingBounds() {
+    public void shouldPassValidationForInvalidEMRManagedScalingBoundsWhenEmrScalingFalse() {
         // Given
         InstanceProperties properties = createTestInstanceProperties();
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
         properties.set(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "15");
         properties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "10");
 
         // When / Then
+        properties.validate(); //Will throw if invalid
+    }
+
+    @Test
+    public void shouldFailValidationForInvalidEMRManagedScalingBoundsWhenEmrScalingTrue() {
+        // Given
+        InstanceProperties properties = createTestInstanceProperties();
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "15");
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "10");
+
+        // When / Then
+        assertThatThrownBy(() -> properties.validate()).isInstanceOf(SleeperPropertiesInvalidException.class)
+                .hasMessageContaining(String.format("%s was invalid", BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY.getPropertyName()));
+    }
+
+    @Test
+    public void shouldFailValidationForInvalidEMRManagedScalingBoundsWhenEmrScalingSetTrue() {
+        // Given
+        InstanceProperties properties = createTestInstanceProperties();
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "15");
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "10");
+        properties.validate();
+
+        // When / Then
+        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
         assertThatThrownBy(() -> properties.validate()).isInstanceOf(SleeperPropertiesInvalidException.class)
                 .hasMessageContaining(String.format("%s was invalid", BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY.getPropertyName()));
     }

--- a/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
@@ -306,21 +306,6 @@ class InstancePropertiesTest {
                 .hasMessageContaining(String.format("%s was invalid", BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY.getPropertyName()));
     }
 
-    @Test
-    public void shouldFailValidationForInvalidEMRManagedScalingBoundsWhenEmrScalingSetTrue() {
-        // Given
-        InstanceProperties properties = createTestInstanceProperties();
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "15");
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "10");
-        properties.validate();
-
-        // When / Then
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
-        assertThatThrownBy(() -> properties.validate()).isInstanceOf(SleeperPropertiesInvalidException.class)
-                .hasMessageContaining(String.format("%s was invalid", BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY.getPropertyName()));
-    }
-
     private static InstanceProperties getSleeperProperties() {
         InstanceProperties instanceProperties = new InstanceProperties();
         instanceProperties.set(ACCOUNT, "1234567890");

--- a/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/instance/InstancePropertiesTest.java
@@ -94,7 +94,6 @@ import static sleeper.core.properties.instance.PartitionSplittingProperty.SPLIT_
 import static sleeper.core.properties.instance.PartitionSplittingProperty.SPLIT_PARTITIONS_TIMEOUT_IN_SECONDS;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY;
-import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSING_LAMBDA_RESULTS_BATCH_SIZE;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSING_LAMBDA_STATE_REFRESHING_PERIOD_IN_SECONDS;
 import static sleeper.core.properties.instance.QueryProperty.QUERY_PROCESSOR_LAMBDA_MEMORY_IN_MB;
@@ -279,18 +278,6 @@ class InstancePropertiesTest {
         assertThatThrownBy(() -> properties.validate())
                 .isInstanceOf(SleeperPropertiesInvalidException.class)
                 .hasMessage("Property sleeper.tags was invalid. It was \"" + tags + "\".");
-    }
-
-    @Test
-    public void shouldPassValidationForInvalidEMRManagedScalingBoundsWhenEmrScalingFalse() {
-        // Given
-        InstanceProperties properties = createTestInstanceProperties();
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "15");
-        properties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "10");
-
-        // When / Then
-        properties.validate(); //Will throw if invalid
     }
 
     private static InstanceProperties getSleeperProperties() {

--- a/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
@@ -88,7 +88,7 @@ public class PersistentEMRManagedScalingBoundsTest {
 
     @Nested
     @DisplayName("Use managed scaling")
-    class ManagedScalingTests {
+    class ManagedScaling {
         @Test
         public void shouldValidateFalseWhenMinGreaterMaxAndManagedScalingTrue() {
             // Given
@@ -102,7 +102,7 @@ public class PersistentEMRManagedScalingBoundsTest {
                     .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
                             BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
                     .extracting("invalidValues", as(InstanceOfAssertFactories.MAP))
-                    .containsAllEntriesOf(Map.of(
+                    .isEqualTo(Map.of(
                             BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true",
                             BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "10",
                             BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "5"));

--- a/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
@@ -15,15 +15,17 @@
  */
 package sleeper.core.properties.model;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.properties.SleeperPropertiesInvalidException;
-import sleeper.core.properties.SleeperProperty;
 import sleeper.core.properties.instance.InstanceProperties;
 
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY;
@@ -83,7 +85,7 @@ public class PersistentEMRManagedScalingBoundsTest {
     }
 
     @Test
-    public void shouldValidateFalseMinGreaterMax() {
+    public void shouldValidateFalseWhenMinGreaterMaxAndManagedScalingTrue() {
         // Given
         instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
         instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 10);
@@ -94,25 +96,33 @@ public class PersistentEMRManagedScalingBoundsTest {
                 .isInstanceOf(SleeperPropertiesInvalidException.class)
                 .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
                         BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
-                .extracting("invalidValues")
-                .satisfies(invalidValues -> {
-                    assertThat(invalidValues).isNotNull();
-                    Map<SleeperProperty, String> values = (Map) invalidValues;
-                    assertThat(values.keySet()).contains(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING,
-                            BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY,
-                            BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
-                });
+                .extracting("invalidValues", as(InstanceOfAssertFactories.MAP))
+                .containsAllEntriesOf(Map.of(
+                        BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true",
+                        BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "10",
+                        BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "5"));
     }
 
     @Test
-    public void shouldValidateTrue() {
+    public void shouldValidateTrueWhenMinLowerThanMaxAndManagedScalingTrue() {
         // Given
-        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
+        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
         instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 1);
         instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
 
         // When / Then
-        instanceProperties.validate();
+        assertThatCode(() -> instanceProperties.validate()).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void shouldValidateTrueWhenManagedScalingFalse() {
+        // Given
+        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
+        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 5);
+        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
+
+        // When / Then
+        assertThatCode(() -> instanceProperties.validate()).doesNotThrowAnyException();
     }
 
     @Test

--- a/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
@@ -18,13 +18,17 @@ package sleeper.core.properties.model;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.properties.SleeperPropertiesInvalidException;
+import sleeper.core.properties.SleeperProperty;
 import sleeper.core.properties.instance.InstanceProperties;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY;
+import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING;
 import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
 
 public class PersistentEMRManagedScalingBoundsTest {
@@ -81,18 +85,29 @@ public class PersistentEMRManagedScalingBoundsTest {
     @Test
     public void shouldValidateFalseMinGreaterMax() {
         // Given
+        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
         instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 10);
         instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
 
         // When / Then
         assertThatThrownBy(() -> instanceProperties.validate())
                 .isInstanceOf(SleeperPropertiesInvalidException.class)
-                .hasMessageContaining("5");
+                .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
+                        BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
+                .extracting("invalidValues")
+                .satisfies(invalidValues -> {
+                    assertThat(invalidValues).isNotNull();
+                    Map<SleeperProperty, String> values = (Map) invalidValues;
+                    assertThat(values.keySet()).contains(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING,
+                            BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY,
+                            BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
+                });
     }
 
     @Test
     public void shouldValidateTrue() {
         // Given
+        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
         instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 1);
         instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
 

--- a/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
@@ -16,6 +16,8 @@
 package sleeper.core.properties.model;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import sleeper.core.properties.SleeperPropertiesInvalidException;
@@ -84,45 +86,49 @@ public class PersistentEMRManagedScalingBoundsTest {
                 .hasMessageContaining("2005");
     }
 
-    @Test
-    public void shouldValidateFalseWhenMinGreaterMaxAndManagedScalingTrue() {
-        // Given
-        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
-        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 10);
-        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
+    @Nested
+    @DisplayName("Use managed scaling")
+    class ManagedScalingTests {
+        @Test
+        public void shouldValidateFalseWhenMinGreaterMaxAndManagedScalingTrue() {
+            // Given
+            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 10);
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
 
-        // When / Then
-        assertThatThrownBy(() -> instanceProperties.validate())
-                .isInstanceOf(SleeperPropertiesInvalidException.class)
-                .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
-                        BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
-                .extracting("invalidValues", as(InstanceOfAssertFactories.MAP))
-                .containsAllEntriesOf(Map.of(
-                        BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true",
-                        BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "10",
-                        BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "5"));
-    }
+            // When / Then
+            assertThatThrownBy(() -> instanceProperties.validate())
+                    .isInstanceOf(SleeperPropertiesInvalidException.class)
+                    .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
+                            BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
+                    .extracting("invalidValues", as(InstanceOfAssertFactories.MAP))
+                    .containsAllEntriesOf(Map.of(
+                            BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true",
+                            BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "10",
+                            BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "5"));
+        }
 
-    @Test
-    public void shouldValidateTrueWhenMinLowerThanMaxAndManagedScalingTrue() {
-        // Given
-        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
-        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 1);
-        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
+        @Test
+        public void shouldValidateTrueWhenMinLowerThanMaxAndManagedScalingTrue() {
+            // Given
+            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 1);
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
 
-        // When / Then
-        assertThatCode(() -> instanceProperties.validate()).doesNotThrowAnyException();
-    }
+            // When / Then
+            assertThatCode(() -> instanceProperties.validate()).doesNotThrowAnyException();
+        }
 
-    @Test
-    public void shouldValidateTrueWhenManagedScalingFalse() {
-        // Given
-        instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
-        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 5);
-        instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
+        @Test
+        public void shouldValidateTrueWhenManagedScalingFalse() {
+            // Given
+            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 5);
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
 
-        // When / Then
-        assertThatCode(() -> instanceProperties.validate()).doesNotThrowAnyException();
+            // When / Then
+            assertThatCode(() -> instanceProperties.validate()).doesNotThrowAnyException();
+        }
     }
 
     @Test


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6789

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - InstancePropertiesTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
