### PR TITLE
Issue 6823 - Add caching of HEAD requests objectmeta to readahead store

### DIFF
--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -1276,7 +1276,7 @@ mod tests {
         // When 2 - request data again
         let meta2 = ps.head(&"test_file".into()).await?;
 
-        // Then
+        // Then 2
         assert_eq!(meta, meta2);
         // No extra HEAD request should have occurred
         assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 1);
@@ -1294,7 +1294,7 @@ mod tests {
         // When
         let _ = ps.head(&"test_file".into()).await?;
 
-        // Then - no specific HEAD should have occurred
+        // Then - no HEAD request should have occurred
         assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 0);
 
         Ok(())
@@ -1354,6 +1354,7 @@ mod tests {
                 },
             )
             .await?;
+
         // Then
         // check file in cache
         assert_eq!(
@@ -1392,6 +1393,7 @@ mod tests {
                 },
             )
             .await?;
+
         // Then
         // check file in cache
         assert_eq!(

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -2,6 +2,8 @@
 //! but delegates to a custom GET implementation. This allows it to implement a readahead mechanism
 //! to reduce the number of GET calls.
 //!
+//! It also caches [`ObjectMeta`]s retrieved from GET/HEAD requests and returns them on future HEAD requests.
+//!
 //! When a ranged get request is made, [`ReadaheadStore`] will convert the [`GetRange::Bounded`] range to a
 //! [`GetRange::Offset`] range when the request is made to the underlying store so that we can read beyond the
 //! original range requested. A [`PositionedStream`] is returned which honours the original bounded range. The returned

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -411,11 +411,33 @@ impl<T: ObjectStore> ReadaheadStore<T> {
     /// # Panics
     /// If the mutex lock that guards the cache has become poisoned.
     pub fn clean_cache(&self) -> usize {
+        self.clean_cache_with_remove(false)
+    }
+
+    /// Purge all cache entries that are too old or too numerous across all files.
+    /// A lock will be obtained for the cache object and all streams that are too old
+    /// will be purged as well as the lowest position streams if there are too many.
+    ///
+    /// If `stream_removed' is true, then the maximum number of live streams per location
+    /// discounts for a cache item having just been removed. This is used internally by
+    /// [`get_opts`] to allow for a cached stream to be removed, whilst correctly preserving
+    /// the maximum live streams invariant.
+    ///
+    /// Returns the total number of live streams still in the cache.
+    ///
+    /// # Panics
+    /// If the mutex lock that guards the cache has become poisoned.
+    fn clean_cache_with_remove(&self, stream_removed: bool) -> usize {
         let now = Instant::now();
+        let max_streams = if stream_removed {
+            self.max_live_streams.saturating_sub(1)
+        } else {
+            self.max_live_streams
+        };
         debug!(
             "Purging cache of streams older than {}s or when more than {} streams per location",
             self.max_age.as_secs().to_formatted_string(&Locale::en),
-            self.max_live_streams.to_formatted_string(&Locale::en)
+            max_streams.to_formatted_string(&Locale::en)
         );
         let mut cache = self
             .cache
@@ -428,11 +450,11 @@ impl<T: ObjectStore> ReadaheadStore<T> {
                 .streams
                 .retain(|_, c| now.duration_since(c.last_use) < self.max_age);
             // Evict least recently used streams until we are under size
-            if cache_ob.streams.len() > self.max_live_streams {
-                let streams_to_evict = cache_ob.streams.len() - self.max_live_streams;
+            if cache_ob.streams.len() > max_streams {
+                let streams_to_evict = cache_ob.streams.len() - max_streams;
                 debug!(
                     "Need to evict {streams_to_evict} for {path} max {}",
-                    self.max_live_streams
+                    max_streams
                 );
                 // Get stream of entries ordered by oldest first (LRU)
                 let mut removal_queue = cache_ob
@@ -590,12 +612,13 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
             return Ok(result);
         }
 
-        self.clean_cache();
-
         let start_pos = get_start_pos(options.range.as_ref());
         let cached = self
             .get_cached_stream(location, options.range.as_ref())
             .await?;
+
+        // Clean cache, but record that one cacheable stream has just been removed
+        self.clean_cache_with_remove(true);
 
         // If cache hit
         match cached {

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -352,14 +352,7 @@ impl<T: ObjectStore> ReadaheadStore<T> {
         let payload = match payload {
             GetResultPayload::Stream(stream) => {
                 // Retrieve data from cache or insert it if needed
-                let mut cache = self.cache.lock().unwrap();
-                cache
-                    .entry(location.to_owned())
-                    .or_insert_with(|| CacheObject {
-                        meta: meta.clone(),
-                        attrs: attributes.clone(),
-                        streams: BTreeMap::new(),
-                    });
+                self.create_cache_location(location, meta.clone(), attributes.clone());
 
                 let inserter = CacheInserter {
                     cache_ptr: Arc::downgrade(&self.cache),
@@ -384,6 +377,21 @@ impl<T: ObjectStore> ReadaheadStore<T> {
             meta,
             attributes,
         })
+    }
+
+    /// Creates an empty cache object for the given location.
+    fn create_cache_location(&self, location: &Path, meta: ObjectMeta, attributes: Attributes) {
+        let mut cache = self
+            .cache
+            .lock()
+            .expect("ReadaheadStore cache lock poisoned");
+        cache
+            .entry(location.to_owned())
+            .or_insert_with(|| CacheObject {
+                meta,
+                attrs: attributes,
+                streams: BTreeMap::new(),
+            });
     }
 
     /// Purge all cache entries that are too old or too numerous across all files.
@@ -530,10 +538,15 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        debug!("READAHEAD GET CALLED");
         // If this an options head or full request (no range) or a suffix range, then pass it through, don't try
         // to do anything with it
         if should_skip_readahead(&options) {
-            return self.inner.get_opts(location, options).await;
+            let result = self.inner.get_opts(location, options).await?;
+            // Create an empty cache entry for the ObjectMeta, in case it's wanted for future HEAD requests
+            debug!("Creating HEAD based cache entry for {location}");
+            self.create_cache_location(location, result.meta.clone(), result.attributes.clone());
+            return Ok(result);
         }
 
         let start_pos = get_start_pos(options.range.as_ref());
@@ -580,6 +593,33 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
         self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        let cached_meta = {
+            let cache = self
+                .cache
+                .lock()
+                .expect("ReadaheadStore cache lock poisoned");
+            cache.get(location).map(|cache_ob| {
+                debug!("Readahead cached retrieval for HEAD {location}");
+                cache_ob.meta.clone()
+            })
+        };
+
+        // If we retrieved something from the cache, return it
+        // otherwise re-direct to GET which will call inner get_opts
+        // and cache result
+        Ok(if let Some(meta) = cached_meta {
+            meta
+        } else {
+            debug!("Readahead cache miss for HEAD {location}");
+            let options = GetOptions {
+                head: true,
+                ..Default::default()
+            };
+            self.get_opts(location, options).await?.meta
+        })
     }
 }
 

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -453,7 +453,9 @@ impl<T: ObjectStore> ReadaheadStore<T> {
             };
             if cache_ob.streams.len() > max_streams_for_location {
                 let streams_to_evict = cache_ob.streams.len() - max_streams_for_location;
-                debug!("Need to evict {streams_to_evict} for {path}",);
+                debug!(
+                    "Need to evict {streams_to_evict} for {path} max for location {max_streams_for_location}"
+                );
                 // Get stream of entries ordered by oldest first (LRU)
                 let mut removal_queue = cache_ob
                     .streams

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -1316,6 +1316,7 @@ mod tests {
                 },
             )
             .await?;
+
         // Then
         // check file in cache
         assert_eq!(

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -449,6 +449,18 @@ impl<T: ObjectStore> ReadaheadStore<T> {
             .expect("ReadaheadStore cache lock poisoned")
             .clear();
     }
+
+    /// Remove all cache entries for given location.
+    ///
+    /// # Panics
+    /// If the mutex lock that guards the cache has become poisoned.
+    pub fn remove_cache_for(&self, location: &Path) {
+        let mut cache = self
+            .cache
+            .lock()
+            .expect("ReadaheadStore cache lock poisoned");
+        cache.remove(location);
+    }
 }
 
 impl<T: ObjectStore> Drop for ReadaheadStore<T> {
@@ -534,6 +546,7 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
         payload: PutPayload,
         opts: PutOptions,
     ) -> Result<PutResult> {
+        self.remove_cache_for(location);
         self.inner.put_opts(location, payload, opts).await
     }
 
@@ -542,6 +555,7 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
         location: &Path,
         opts: PutMultipartOptions,
     ) -> Result<Box<dyn MultipartUpload>> {
+        self.remove_cache_for(location);
         self.inner.put_multipart_opts(location, opts).await
     }
 
@@ -586,6 +600,7 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
     }
 
     async fn delete(&self, location: &Path) -> Result<()> {
+        self.remove_cache_for(location);
         self.inner.delete(location).await
     }
 
@@ -1236,6 +1251,36 @@ mod tests {
         let ps = make_store();
         ps.put(&"test_file".into(), "some data".into()).await?;
 
+        // When
+        let meta = ps.head(&"test_file".into()).await?;
+
+        // Then
+        assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 1);
+
+        // When 2 - request data again
+        let meta2 = ps.head(&"test_file".into()).await?;
+
+        // Then
+        assert_eq!(meta, meta2);
+        // No extra HEAD request should have occurred
+        assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_cache_objectmeta_on_get() -> Result<()> {
+        // Given
+        let ps = make_store();
+        ps.put(&"test_file".into(), "some data".into()).await?;
+        let _ = ps.get(&"test_file".into()).await?;
+
+        // When
+        let _ = ps.head(&"test_file".into()).await?;
+
+        // Then - no specific HEAD should have occurred
+        assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 0);
+
         Ok(())
     }
 
@@ -1272,16 +1317,7 @@ mod tests {
         ps.delete(&"test_file".into()).await?;
 
         // Then 2 - cache should be empty
-        assert_eq!(
-            ps.cache
-                .lock()
-                .unwrap()
-                .get(&"test_file".into())
-                .unwrap()
-                .streams
-                .len(),
-            0
-        );
+        assert!(ps.cache.lock().unwrap().get(&"test_file".into()).is_none());
 
         Ok(())
     }
@@ -1319,16 +1355,7 @@ mod tests {
         ps.put(&"test_file".into(), "some data".into()).await?;
 
         // Then 2 - cache should be empty
-        assert_eq!(
-            ps.cache
-                .lock()
-                .unwrap()
-                .get(&"test_file".into())
-                .unwrap()
-                .streams
-                .len(),
-            0
-        );
+        assert!(ps.cache.lock().unwrap().get(&"test_file".into()).is_none());
 
         Ok(())
     }
@@ -1367,16 +1394,7 @@ mod tests {
         p.complete().await?;
 
         // Then 2 - cache should be empty
-        assert_eq!(
-            ps.cache
-                .lock()
-                .unwrap()
-                .get(&"test_file".into())
-                .unwrap()
-                .streams
-                .len(),
-            0
-        );
+        assert!(ps.cache.lock().unwrap().get(&"test_file".into()).is_none());
 
         Ok(())
     }

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -443,18 +443,17 @@ impl<T: ObjectStore> ReadaheadStore<T> {
             cache_ob
                 .streams
                 .retain(|_, c| now.duration_since(c.last_use) < self.max_age);
-            // Evict least recently used streams until we are under size
-            if cache_ob.streams.len() > self.max_live_streams {
-                let mut streams_to_evict = cache_ob.streams.len() - self.max_live_streams;
-                if let Some(removed_location) = retrieved_location
-                    && removed_location == path
-                {
-                    streams_to_evict = streams_to_evict.saturating_sub(1);
-                }
-                debug!(
-                    "Need to evict {streams_to_evict} for {path} max {}",
-                    self.max_live_streams
-                );
+            // Max streams for this location depends on if a stream has just been removed for it
+            let max_streams_for_location = if let Some(retrieved) = retrieved_location
+                && retrieved == path
+            {
+                self.max_live_streams.saturating_sub(1)
+            } else {
+                self.max_live_streams
+            };
+            if cache_ob.streams.len() > max_streams_for_location {
+                let streams_to_evict = cache_ob.streams.len() - max_streams_for_location;
+                debug!("Need to evict {streams_to_evict} for {path}",);
                 // Get stream of entries ordered by oldest first (LRU)
                 let mut removal_queue = cache_ob
                     .streams
@@ -2010,6 +2009,7 @@ mod tests {
         ps.put(&"test_file2".into(), "some data".into()).await?;
 
         // When
+        // Get a cached stream and drop it, causing it to insert into cache
         ps.get_range(&"test_file2".into(), 1..2).await?;
 
         // Then
@@ -2028,6 +2028,30 @@ mod tests {
                 .0,
             1
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_opts_should_purge_location_when_stream_retrieved() -> Result<()> {
+        // Given
+        let ps = make_store()
+            .with_max_live_streams(1)
+            .with_max_stream_age(Duration::from_secs(10));
+
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        // When
+        // Get a cached stream and drop it, causing it to insert into cache
+        ps.get_range(&"test_file".into(), 4..5).await?;
+        // Get a second cached stream and drop it, this should cause above stream to be evicted.
+        ps.get_range(&"test_file".into(), 2..4).await?;
+
+        // Then
+        // test_file cache should have 1 entry
+        let cache = ps.cache.lock().unwrap();
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get(&"test_file".into()).unwrap().streams.len(), 1);
 
         Ok(())
     }

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -411,33 +411,27 @@ impl<T: ObjectStore> ReadaheadStore<T> {
     /// # Panics
     /// If the mutex lock that guards the cache has become poisoned.
     pub fn clean_cache(&self) -> usize {
-        self.clean_cache_with_remove(false)
+        self.clean_cache_with_remove(None)
     }
 
     /// Purge all cache entries that are too old or too numerous across all files.
     /// A lock will be obtained for the cache object and all streams that are too old
     /// will be purged as well as the lowest position streams if there are too many.
     ///
-    /// If `stream_removed' is true, then the maximum number of live streams per location
-    /// discounts for a cache item having just been removed. This is used internally by
-    /// [`get_opts`] to allow for a cached stream to be removed, whilst correctly preserving
-    /// the maximum live streams invariant.
+    /// If a `retrieved_location` is provided, then this indicates a cached stream was
+    /// just removed for that location, therefore we account for that stream when computing
+    /// the maximum number of cached streams at that location.
     ///
     /// Returns the total number of live streams still in the cache.
     ///
     /// # Panics
     /// If the mutex lock that guards the cache has become poisoned.
-    fn clean_cache_with_remove(&self, stream_removed: bool) -> usize {
+    fn clean_cache_with_remove(&self, retrieved_location: Option<&Path>) -> usize {
         let now = Instant::now();
-        let max_streams = if stream_removed {
-            self.max_live_streams.saturating_sub(1)
-        } else {
-            self.max_live_streams
-        };
         debug!(
             "Purging cache of streams older than {}s or when more than {} streams per location",
             self.max_age.as_secs().to_formatted_string(&Locale::en),
-            max_streams.to_formatted_string(&Locale::en)
+            self.max_live_streams.to_formatted_string(&Locale::en)
         );
         let mut cache = self
             .cache
@@ -450,11 +444,16 @@ impl<T: ObjectStore> ReadaheadStore<T> {
                 .streams
                 .retain(|_, c| now.duration_since(c.last_use) < self.max_age);
             // Evict least recently used streams until we are under size
-            if cache_ob.streams.len() > max_streams {
-                let streams_to_evict = cache_ob.streams.len() - max_streams;
+            if cache_ob.streams.len() > self.max_live_streams {
+                let mut streams_to_evict = cache_ob.streams.len() - self.max_live_streams;
+                if let Some(removed_location) = retrieved_location
+                    && removed_location == path
+                {
+                    streams_to_evict = streams_to_evict.saturating_sub(1);
+                }
                 debug!(
                     "Need to evict {streams_to_evict} for {path} max {}",
-                    max_streams
+                    self.max_live_streams
                 );
                 // Get stream of entries ordered by oldest first (LRU)
                 let mut removal_queue = cache_ob
@@ -618,7 +617,7 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
             .await?;
 
         // Clean cache, but record that one cacheable stream has just been removed
-        self.clean_cache_with_remove(true);
+        self.clean_cache_with_remove(Some(location));
 
         // If cache hit
         match cached {

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -71,8 +71,6 @@ use object_store::{
     ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
     path::Path,
 };
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::{Debug, Display},
@@ -1442,12 +1440,12 @@ mod tests {
         ps.put(&"test_file".into(), "some data".into()).await?;
 
         // When
-        assert_eq!(*ps.underlying_gets.lock().unwrap(), 0);
+        assert_eq!(ps.underlying_gets.load(Ordering::Relaxed), 0);
         assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 0);
         let _ = ps.head(&"test_file".into()).await?;
 
         // Then
-        assert_eq!(*ps.underlying_gets.lock().unwrap(), 0);
+        assert_eq!(ps.underlying_gets.load(Ordering::Relaxed), 0);
         assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 1);
 
         Ok(())

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -69,6 +69,8 @@ use object_store::{
     ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
     path::Path,
 };
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::{Debug, Display},
@@ -181,6 +183,8 @@ pub struct ReadaheadStore<T: ObjectStore> {
     max_live_streams: usize,
     /// Number of underlying GET requests
     underlying_gets: Arc<Mutex<usize>>,
+    /// Number of underlying HEAD requests
+    underlying_heads: AtomicUsize,
 }
 
 impl<T: ObjectStore> ReadaheadStore<T> {
@@ -195,6 +199,7 @@ impl<T: ObjectStore> ReadaheadStore<T> {
             max_age: DEFAULT_MAX_STREAM_AGE,
             max_live_streams: DEFAULT_MAX_STREAM_PER_LOCATION,
             underlying_gets: Arc::new(Mutex::new(0)),
+            underlying_heads: AtomicUsize::new(0),
         }
     }
 
@@ -344,7 +349,7 @@ impl<T: ObjectStore> ReadaheadStore<T> {
             .lock()
             .expect("ReadaheadStore lock poisoned") += 1;
         debug!(
-            "ReadaheadStore GET request to {}/{location}",
+            "ReadaheadStore cacheable GET request to {}/{location}",
             self.path_prefix
         );
 
@@ -449,10 +454,13 @@ impl<T: ObjectStore> ReadaheadStore<T> {
 impl<T: ObjectStore> Drop for ReadaheadStore<T> {
     fn drop(&mut self) {
         info!(
-            "ReadaheadStore made {} GET requests to underlying location {}",
+            "ReadaheadStore made {} GET and {} HEAD requests to underlying location {}",
             self.underlying_gets
                 .lock()
                 .expect("ReadaheadStore lock poisoned")
+                .to_formatted_string(&Locale::en),
+            self.underlying_heads
+                .load(Ordering::Relaxed)
                 .to_formatted_string(&Locale::en),
             self.path_prefix,
         );
@@ -538,13 +546,15 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
-        debug!("READAHEAD GET CALLED");
         // If this an options head or full request (no range) or a suffix range, then pass it through, don't try
         // to do anything with it
         if should_skip_readahead(&options) {
+            debug!(
+                "ReadaheadStore ObjectMeta-only-cache GET request to {}/{location}",
+                self.path_prefix
+            );
             let result = self.inner.get_opts(location, options).await?;
             // Create an empty cache entry for the ObjectMeta, in case it's wanted for future HEAD requests
-            debug!("Creating HEAD based cache entry for {location}");
             self.create_cache_location(location, result.meta.clone(), result.attributes.clone());
             return Ok(result);
         }
@@ -601,10 +611,7 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
                 .cache
                 .lock()
                 .expect("ReadaheadStore cache lock poisoned");
-            cache.get(location).map(|cache_ob| {
-                debug!("Readahead cached retrieval for HEAD {location}");
-                cache_ob.meta.clone()
-            })
+            cache.get(location).map(|cache_ob| cache_ob.meta.clone())
         };
 
         // If we retrieved something from the cache, return it
@@ -613,11 +620,12 @@ impl<T: ObjectStore> ObjectStore for ReadaheadStore<T> {
         Ok(if let Some(meta) = cached_meta {
             meta
         } else {
-            debug!("Readahead cache miss for HEAD {location}");
             let options = GetOptions {
                 head: true,
                 ..Default::default()
             };
+            self.underlying_heads
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             self.get_opts(location, options).await?.meta
         })
     }
@@ -1209,6 +1217,171 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn head_count_is_zero() -> Result<()> {
+        // Given
+        let ps = make_store();
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        // When - no op
+
+        // Then
+        assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_return_cached_head_objectmeta() -> Result<()> {
+        // Given
+        let ps = make_store();
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_remove_cache_on_delete() -> Result<()> {
+        // Given
+        let ps = make_store();
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        // When
+        let _ = ps
+            .make_get_request(
+                &"test_file".into(),
+                GetOptions {
+                    range: Some(GetRange::Bounded(4..7)),
+                    ..GetOptions::default()
+                },
+            )
+            .await?;
+        // Then
+        // check file in cache
+        assert_eq!(
+            ps.cache
+                .lock()
+                .unwrap()
+                .get(&"test_file".into())
+                .unwrap()
+                .streams
+                .len(),
+            1
+        );
+
+        // When 2 - delete file
+        ps.delete(&"test_file".into()).await?;
+
+        // Then 2 - cache should be empty
+        assert_eq!(
+            ps.cache
+                .lock()
+                .unwrap()
+                .get(&"test_file".into())
+                .unwrap()
+                .streams
+                .len(),
+            0
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_remove_cache_on_put() -> Result<()> {
+        // Given
+        let ps = make_store();
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        // When
+        let _ = ps
+            .make_get_request(
+                &"test_file".into(),
+                GetOptions {
+                    range: Some(GetRange::Bounded(4..7)),
+                    ..GetOptions::default()
+                },
+            )
+            .await?;
+        // Then
+        // check file in cache
+        assert_eq!(
+            ps.cache
+                .lock()
+                .unwrap()
+                .get(&"test_file".into())
+                .unwrap()
+                .streams
+                .len(),
+            1
+        );
+
+        // When 2 - PUT file
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        // Then 2 - cache should be empty
+        assert_eq!(
+            ps.cache
+                .lock()
+                .unwrap()
+                .get(&"test_file".into())
+                .unwrap()
+                .streams
+                .len(),
+            0
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_remove_cache_on_put_multipart() -> Result<()> {
+        // Given
+        let ps = make_store();
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        // When
+        let _ = ps
+            .make_get_request(
+                &"test_file".into(),
+                GetOptions {
+                    range: Some(GetRange::Bounded(4..7)),
+                    ..GetOptions::default()
+                },
+            )
+            .await?;
+        // Then
+        // check file in cache
+        assert_eq!(
+            ps.cache
+                .lock()
+                .unwrap()
+                .get(&"test_file".into())
+                .unwrap()
+                .streams
+                .len(),
+            1
+        );
+
+        // When 2 - PUT multipart on file
+        let mut p = ps.put_multipart(&"test_file".into()).await?;
+        p.complete().await?;
+
+        // Then 2 - cache should be empty
+        assert_eq!(
+            ps.cache
+                .lock()
+                .unwrap()
+                .get(&"test_file".into())
+                .unwrap()
+                .streams
+                .len(),
+            0
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn make_get_requests_increments_get_count() -> Result<()> {
         // Given
         let ps = make_store();
@@ -1222,6 +1395,24 @@ mod tests {
 
         // Then
         assert_eq!(*ps.underlying_gets.lock().unwrap(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn make_head_requests_increments_get_count() -> Result<()> {
+        // Given
+        let ps = make_store();
+        ps.put(&"test_file".into(), "some data".into()).await?;
+
+        // When
+        assert_eq!(*ps.underlying_gets.lock().unwrap(), 0);
+        assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 0);
+        let _ = ps.head(&"test_file".into()).await?;
+
+        // Then
+        assert_eq!(*ps.underlying_gets.lock().unwrap(), 0);
+        assert_eq!(ps.underlying_heads.load(Ordering::Relaxed), 1);
 
         Ok(())
     }

--- a/rust/objectstore_ext/src/readahead.rs
+++ b/rust/objectstore_ext/src/readahead.rs
@@ -1835,6 +1835,7 @@ mod tests {
 
     #[tokio::test]
     async fn purge_oldest_two_lru() {
+        // Test that of 3 streams, the 2 oldest get purged, leaving the most recent
         let instant_to_keep = Instant::now().checked_sub(Duration::from_secs(10)).unwrap();
         test_cache_purge_and_validate(
             1,

--- a/rust/objectstore_ext/src/store.rs
+++ b/rust/objectstore_ext/src/store.rs
@@ -31,6 +31,8 @@ use std::{pin::Pin, sync::Mutex};
 struct LoggingData {
     /// The number of GET requests logged.
     get_count: usize,
+    /// The number of HEAD requests logged.
+    head_count: usize,
     /// The total number of bytes read across all files.
     get_bytes_read: u64,
 }
@@ -72,6 +74,18 @@ impl<T: ObjectStore> LoggingObjectStore<T> {
             .get_count
     }
 
+    /// Gives the total number of HEAD requests made on this store.
+    ///
+    /// # Panics
+    /// If we are not able to acquire the lock for the store
+    /// stats.
+    pub fn head_count(&self) -> usize {
+        self.internal
+            .lock()
+            .expect("LoggingObjectStore stats lock poisoned")
+            .head_count
+    }
+
     /// Get the total number of bytes requested by this store in ranged requests.
     /// This is only a hint. The actual number of bytes read may be lower or higher.
     /// Only bytes requested via [`GetRange::Bounded`] requests are recorded. Further,
@@ -102,10 +116,11 @@ impl<T: ObjectStore> std::fmt::Display for LoggingObjectStore<T> {
 impl<T: ObjectStore> Drop for LoggingObjectStore<T> {
     fn drop(&mut self) {
         info!(
-            "LoggingObjectStore \"{}\" to \"{}\" made {} GET requests and requested a total of {} bytes (range bounded)",
+            "LoggingObjectStore \"{}\" to \"{}\" made {} GET and {} HEAD requests and requested a total of {} bytes (range bounded)",
             self.prefix,
             self.path_prefix,
             self.get_count().to_formatted_string(&Locale::en),
+            self.head_count().to_formatted_string(&Locale::en),
             self.get_bytes_read().to_formatted_string(&Locale::en)
         );
     }
@@ -167,6 +182,13 @@ impl<T: ObjectStore> ObjectStore for LoggingObjectStore<T> {
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        {
+            let stats = &mut *self
+                .internal
+                .lock()
+                .expect("LoggingObjectStore stats lock poisoned");
+            stats.head_count += 1;
+        }
         debug!(
             "{} HEAD request {}/{}",
             self.prefix, self.path_prefix, location
@@ -346,6 +368,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn single_heaq_request() -> Result<()> {
+        // Given
+        let store = make_store();
+        store.put(&"test_file".into(), "some_data".into()).await?;
+
+        // Then
+        assert_eq!(store.head_count(), 0);
+
+        // When
+        store.head(&"test_file".into()).await?;
+
+        // Then 2 - check HEAD incremented
+        assert_eq!(store.head_count(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn single_ranged_read_requests() -> Result<()> {
         // Given
         let store = make_store();
@@ -415,7 +455,7 @@ mod tests {
             assert_eq!(captured_logs[1].level, Level::Debug);
             assert_eq!(
                 captured_logs[2].body,
-                "LoggingObjectStore \"TEST\" to \"memory:/\" made 1 GET requests and requested a total of 4 bytes (range bounded)"
+                "LoggingObjectStore \"TEST\" to \"memory:/\" made 1 GET and 0 HEAD requests and requested a total of 4 bytes (range bounded)"
             );
             assert_eq!(captured_logs[2].level, Level::Info);
         });

--- a/rust/sleeper_core/src/datafusion/output.rs
+++ b/rust/sleeper_core/src/datafusion/output.rs
@@ -98,7 +98,7 @@ impl Default for SleeperParquetOptions {
 /// The result of executing a [`DataFrame`] with a [`Completer`].
 ///
 /// A completer will return a different variant depending on the
-/// [`CompletionOptions`] the plan was configured with.
+/// [`OutputType`] the plan was configured with.
 pub enum CompletedOutput {
     /// Results of plan are returned as a asynchronous stream
     /// of Arrow [`RecordBatch`]es.

--- a/rust/sleeper_core/src/datafusion/region.rs
+++ b/rust/sleeper_core/src/datafusion/region.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 /// Represents a Sleeper partition region.
 ///
-/// A [`SleeperPartitionRegion`] is multi-dimension key range over row-key fields in Sleeper.
+/// A multi-dimension key range over row-key fields in Sleeper.
 /// If a table has only on row-key field then a region is a single row range. A region in a
 /// table with two row-key fields would be a rectangle, etc.
 #[derive(Debug, Default)]

--- a/rust/sleeper_core/src/sleeper_context.rs
+++ b/rust/sleeper_core/src/sleeper_context.rs
@@ -15,6 +15,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+#[cfg(doc)]
+use datafusion::execution::object_store::ObjectStoreRegistry;
 use datafusion::{
     error::DataFusionError,
     execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder},

--- a/rust/sleeper_df/src/objects/ffi_common_config.rs
+++ b/rust/sleeper_df/src/objects/ffi_common_config.rs
@@ -70,7 +70,7 @@ impl FFICommonConfig {
     /// The schema types for the row key fields in this Sleeper schema.
     ///
     /// # Errors
-    /// If an invalid row key type is found, e.g. type ordinal number is outside range. See [`FFIRowKeySchemaType`].
+    /// If an invalid row key type is found, e.g. type ordinal number is outside range. See [`RowKeySchemaType`].
     pub fn schema_types(&self) -> Result<Vec<RowKeySchemaType>, color_eyre::Report> {
         unpack_typed_array(self.row_key_schema, self.row_key_schema_len)?
             .iter()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6823

### Tests

- [X] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    -rust/objectstore_ext/src/readahead.rs

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
