### PR TITLE
Issue 6903 - Make FFI byte arrays explicit in FFI interface

### DIFF
--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
@@ -66,7 +66,7 @@ public class FFIBytes {
      * The internal data buffer pointer is taken from the given location. It is the callers
      * responsibility to ensure it remains valid for the life of this object.
      *
-     * @param  location
+     * @param  location memory to read from
      * @return          an FFIBytes deserialised from the given memory location.
      */
     public static FFIBytes readFrom(jnr.ffi.Pointer location) {

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
@@ -18,14 +18,12 @@ package sleeper.foreign;
 import jnr.ffi.Struct;
 import jnr.ffi.TypeAlias;
 
+import java.util.Objects;
+
 /**
  * A Java implementation of FFIBytes. Whilst this class is not a JNR-FFI {@link Struct} instance, it is used
  * to write compatible data at a given memory location. Memory is dynamically allocated for the internal buffer which
  * will be automatically freed when its owning instance is garbage collected.
- *
- * <strong>THIS IS A C COMPATIBLE FFI STRUCT!</strong> If you updated this struct (field ordering, types, etc.),
- * you MUST update the corresponding Rust definition in rust/sleeper_df/src/objects.rs. The order and types of
- * the fields must match exactly.
  */
 @SuppressWarnings(value = {"checkstyle:membername"})
 public class FFIBytes {
@@ -37,6 +35,7 @@ public class FFIBytes {
     private final jnr.ffi.Pointer data;
 
     public FFIBytes(jnr.ffi.Runtime runtime, byte[] data) {
+        Objects.requireNonNull(data, "data");
         // Allocate some memory for the data
         this.data = runtime.getMemoryManager().allocateDirect(data.length);
         this.data.put(0, data, 0, data.length);
@@ -94,5 +93,25 @@ public class FFIBytes {
      */
     public static int size(jnr.ffi.Runtime r) {
         return r.addressSize() + r.findType(TypeAlias.size_t).size();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(length, data);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("FFIBytes{length=%d, data=0x%x}", length, data.address());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof FFIBytes))
+            return false;
+        FFIBytes other = (FFIBytes) obj;
+        return length == other.length && data.address() == other.data.address();
     }
 }

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.foreign;
+
+import jnr.ffi.Struct;
+import jnr.ffi.TypeAlias;
+
+/**
+ * A Java implementation of FFIBytes. Whilst this class is not a JNR-FFI {@link Struct} instance, it is used
+ * to write compatible data at a given memory location. Memory is dynamically allocated for the internal buffer which
+ * will be automatically freed when its owning instance is garbage collected.
+ *
+ * <strong>THIS IS A C COMPATIBLE FFI STRUCT!</strong> If you updated this struct (field ordering, types, etc.),
+ * you MUST update the corresponding Rust definition in rust/sleeper_df/src/objects.rs. The order and types of
+ * the fields must match exactly.
+ */
+@SuppressWarnings(value = {"checkstyle:membername"})
+public class FFIBytes {
+    /** Length of stored data. */
+    private final int length;
+    /**
+     * Memory address of byte array in memory.
+     */
+    private final jnr.ffi.Pointer data;
+
+    public FFIBytes(jnr.ffi.Runtime runtime, byte[] data) {
+        // Allocate some memory for the data
+        this.data = runtime.getMemoryManager().allocateDirect(data.length);
+        this.data.put(0, data, 0, data.length);
+        this.length = data.length;
+    }
+
+    private FFIBytes(int length, jnr.ffi.Pointer data) {
+        this.length = length;
+        this.data = data;
+    }
+
+    /**
+     * Writes this struct to the given memory address.
+     *
+     * The memory address must point to a valid location.
+     *
+     * @param location memory address to write to
+     */
+    public void writeTo(jnr.ffi.Pointer location) {
+        location.putLongLong(0, length);
+        location.putPointer(data.getRuntime().findType(TypeAlias.size_t).size(), data);
+    }
+
+    /**
+     * Read an instance from the given location.
+     *
+     * The internal data buffer pointer is taken from the given location. It is the callers
+     * responsibility to ensure it remains valid for the life of this object.
+     *
+     * @param  location
+     * @return          an FFIBytes deserialised from the given memory location.
+     */
+    public static FFIBytes readFrom(jnr.ffi.Pointer location) {
+        int length = (int) location.getLongLong(0);
+        jnr.ffi.Pointer data = location.getPointer(location.getRuntime().findType(TypeAlias.size_t).size());
+        return new FFIBytes(length, data);
+    }
+
+    /**
+     * Retrieve a Java copy of the internal data buffer. This is a snapshot of the data.
+     *
+     * @return copy of internal byte array
+     */
+    public byte[] getData() {
+        byte[] result = new byte[length];
+        data.get(0, result, 0, length);
+        return result;
+    }
+
+    /**
+     * Get the native size of this struct.
+     *
+     * @param  r the JNR FFI runtime to use
+     * @return   struct size in bytes
+     */
+    public static int size(jnr.ffi.Runtime r) {
+        return r.addressSize() + r.findType(TypeAlias.size_t).size();
+    }
+}

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java
@@ -107,10 +107,13 @@ public class FFIBytes {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (!(obj instanceof FFIBytes))
+        }
+        if (!(obj instanceof FFIBytes)) {
             return false;
+        }
+
         FFIBytes other = (FFIBytes) obj;
         return length == other.length && data.address() == other.data.address();
     }

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/bridge/FFIArray.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/bridge/FFIArray.java
@@ -23,8 +23,11 @@ import sleeper.core.schema.type.IntType;
 import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.PrimitiveType;
 import sleeper.core.schema.type.StringType;
+import sleeper.foreign.FFIBytes;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -46,10 +49,15 @@ public class FFIArray<T> {
      */
     private jnr.ffi.Pointer basePtr;
     /**
-     * Reference to dynamically allocated items to prevent GC until Array instance
+     * Reference to dynamically allocated items to prevent GC until FFIArray instance
      * is collected. These pointers will NOT be transferred across FFI boundary.
      */
     private jnr.ffi.Pointer[] items;
+    /**
+     * References to inserted FFIBytes objects. Needed to prevent GC whilst this FFIArray
+     * is alive.
+     */
+    private List<FFIBytes> bytesObjects = new ArrayList<>();
 
     public FFIArray(Struct enclosing) {
         this.len = enclosing.new size_t();
@@ -186,23 +194,11 @@ public class FFIArray<T> {
             long e = (long) item;
             this.items[idx] = r.getMemoryManager().allocateDirect(r.findType(NativeType.SLONGLONG).size());
             this.items[idx].putLong(0, e);
-        } else if (item instanceof java.lang.String) {
-            // Strings are encoded as 4 byte length then value
-            java.lang.String e = (java.lang.String) item;
-            byte[] utf8string = e.getBytes(StandardCharsets.UTF_8);
-            // Add four for length
-            int stringSize = utf8string.length + 4;
-            // Allocate memory for string and write length then the string
-            this.items[idx] = r.getMemoryManager().allocateDirect(stringSize);
-            this.items[idx].putInt(0, utf8string.length);
-            this.items[idx].put(4, utf8string, 0, utf8string.length);
-        } else if (item instanceof byte[]) {
-            // Byte arrays are encoded as 4 byte length then value
-            byte[] e = (byte[]) item;
-            int byteSize = e.length + 4;
-            this.items[idx] = r.getMemoryManager().allocateDirect(byteSize);
-            this.items[idx].putInt(0, e.length);
-            this.items[idx].put(4, e, 0, e.length);
+        } else if (item instanceof FFIBytes) {
+            FFIBytes e = (FFIBytes) item;
+            bytesObjects.add(e);
+            this.items[idx] = r.getMemoryManager().allocateDirect(FFIBytes.size(r));
+            e.writeTo(this.items[idx]);
         } else if (item instanceof Boolean) {
             boolean e = (boolean) item;
             this.items[idx] = r.getMemoryManager().allocateDirect(1);
@@ -229,9 +225,9 @@ public class FFIArray<T> {
         } else if (type instanceof IntType) {
             return getValue(index, Integer.class, nullsAllowed, runtime);
         } else if (type instanceof StringType) {
-            return getValue(index, String.class, nullsAllowed, runtime);
+            return new String((byte[]) getValue(index, FFIBytes.class, nullsAllowed, runtime), StandardCharsets.UTF_8);
         } else if (type instanceof ByteArrayType) {
-            return getValue(index, byte[].class, nullsAllowed, runtime);
+            return getValue(index, FFIBytes.class, nullsAllowed, runtime);
         } else {
             throw new IllegalArgumentException("Unsupported primitive type: " + type);
         }
@@ -276,26 +272,9 @@ public class FFIArray<T> {
             return (T) Long.valueOf(this.items[idx].getLong(0));
         } else if (clazz.equals(Boolean.TYPE) || clazz.equals(Boolean.class)) {
             return (T) Boolean.valueOf(this.items[idx].getByte(0) == 1);
-        } else if (clazz.equals(String.class)) {
-            // Read string length
-            int length = this.items[idx].getInt(0);
-            if (length < 0) {
-                throw new IllegalStateException(String.format("Read string length of %d at index %d", length, idx));
-            }
-            // Decode the bytes as UTF-8
-            byte[] utf8String = new byte[length];
-            this.items[idx].get(4, utf8String, 0, length);
-            return (T) new String(utf8String, StandardCharsets.UTF_8);
-        } else if (clazz.equals(byte.class.arrayType())) {
-            // Read the length of the byte array
-            int length = this.items[idx].getInt(0);
-            if (length < 0) {
-                throw new IllegalStateException(String.format("Read byte[] length of %d at index %d", length, idx));
-            }
-            // Grab the actual bytes into the new array
-            byte[] bytes = new byte[length];
-            this.items[idx].get(4, bytes, 0, length);
-            return (T) bytes;
+        } else if (clazz.equals(FFIBytes.class)) {
+            FFIBytes bytes = FFIBytes.readFrom(this.items[idx]);
+            return (T) bytes.getData();
         } else {
             throw new ClassCastException("Can't cast " + clazz + " to a valid Sleeper row key type");
         }

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/bridge/FFIArray.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/bridge/FFIArray.java
@@ -233,9 +233,9 @@ public class FFIArray<T> {
         } else if (type instanceof IntType) {
             return getValue(index, Integer.class, nullsAllowed, runtime);
         } else if (type instanceof StringType) {
-            return new String((byte[]) getValue(index, FFIBytes.class, nullsAllowed, runtime), StandardCharsets.UTF_8);
+            return getValue(index, String.class, nullsAllowed, runtime);
         } else if (type instanceof ByteArrayType) {
-            return getValue(index, FFIBytes.class, nullsAllowed, runtime);
+            return getValue(index, byte.class.arrayType(), nullsAllowed, runtime);
         } else {
             throw new IllegalArgumentException("Unsupported primitive type: " + type);
         }
@@ -280,7 +280,10 @@ public class FFIArray<T> {
             return (T) Long.valueOf(this.items[idx].getLong(0));
         } else if (clazz.equals(Boolean.TYPE) || clazz.equals(Boolean.class)) {
             return (T) Boolean.valueOf(this.items[idx].getByte(0) == 1);
-        } else if (clazz.equals(FFIBytes.class)) {
+        } else if (clazz.equals(String.class)) {
+            FFIBytes bytes = FFIBytes.readFrom(this.items[idx]);
+            return (T) new String(bytes.getData(), StandardCharsets.UTF_8);
+        } else if (clazz.equals(byte.class.arrayType())) {
             FFIBytes bytes = FFIBytes.readFrom(this.items[idx]);
             return (T) bytes.getData();
         } else {

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/bridge/FFIArray.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/bridge/FFIArray.java
@@ -194,11 +194,19 @@ public class FFIArray<T> {
             long e = (long) item;
             this.items[idx] = r.getMemoryManager().allocateDirect(r.findType(NativeType.SLONGLONG).size());
             this.items[idx].putLong(0, e);
-        } else if (item instanceof FFIBytes) {
-            FFIBytes e = (FFIBytes) item;
-            bytesObjects.add(e);
+        } else if (item instanceof String) {
+            String e = (String) item;
+            byte[] utf8Data = e.getBytes(StandardCharsets.UTF_8);
+            FFIBytes bytes = new FFIBytes(r, utf8Data);
+            bytesObjects.add(bytes);
             this.items[idx] = r.getMemoryManager().allocateDirect(FFIBytes.size(r));
-            e.writeTo(this.items[idx]);
+            bytes.writeTo(this.items[idx]);
+        } else if (item instanceof byte[]) {
+            byte[] e = (byte[]) item;
+            FFIBytes bytes = new FFIBytes(r, e);
+            bytesObjects.add(bytes);
+            this.items[idx] = r.getMemoryManager().allocateDirect(FFIBytes.size(r));
+            bytes.writeTo(this.items[idx]);
         } else if (item instanceof Boolean) {
             boolean e = (boolean) item;
             this.items[idx] = r.getMemoryManager().allocateDirect(1);

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/datafusion/FFICommonConfig.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/datafusion/FFICommonConfig.java
@@ -23,7 +23,6 @@ import sleeper.core.schema.type.IntType;
 import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.PrimitiveType;
 import sleeper.core.schema.type.StringType;
-import sleeper.foreign.FFIBytes;
 import sleeper.foreign.FFISleeperRegion;
 import sleeper.foreign.bridge.FFIArray;
 
@@ -45,7 +44,7 @@ public class FFICommonConfig extends Struct {
     /** Optional AWS configuration. */
     public final Struct.StructRef<FFIAwsConfig> aws_config = new Struct.StructRef<>(FFIAwsConfig.class);
     /** Array of input files to compact. */
-    public final FFIArray<FFIBytes> input_files = new FFIArray<>(this);
+    public final FFIArray<java.lang.String> input_files = new FFIArray<>(this);
     /** Whether the input files are individually sorted by the row and sort key fields. */
     public final Struct.Boolean input_files_sorted = new Struct.Boolean();
     /** Whether we should use readahead when reading from S3. */
@@ -57,11 +56,11 @@ public class FFICommonConfig extends Struct {
     /** Specifies if sketch output is enabled. Can only be used with file output. */
     public final Struct.Boolean write_sketch_file = new Struct.Boolean();
     /** Names of Sleeper row key fields from schema. */
-    public final FFIArray<FFIBytes> row_key_cols = new FFIArray<>(this);
+    public final FFIArray<java.lang.String> row_key_cols = new FFIArray<>(this);
     /** Types for region schema 1 = Int, 2 = Long, 3 = String, 4 = Byte array. */
     public final FFIArray<java.lang.Integer> row_key_schema = new FFIArray<>(this);
     /** Names of Sleeper sort key fields from schema. */
-    public final FFIArray<FFIBytes> sort_key_cols = new FFIArray<>(this);
+    public final FFIArray<java.lang.String> sort_key_cols = new FFIArray<>(this);
     /** Maximum size of output Parquet row group in rows. */
     public final Struct.size_t max_row_group_size = new Struct.size_t();
     /** Maximum size of output Parquet page size in bytes. */

--- a/java/common/foreign-bridge/src/main/java/sleeper/foreign/datafusion/FFICommonConfig.java
+++ b/java/common/foreign-bridge/src/main/java/sleeper/foreign/datafusion/FFICommonConfig.java
@@ -23,6 +23,7 @@ import sleeper.core.schema.type.IntType;
 import sleeper.core.schema.type.LongType;
 import sleeper.core.schema.type.PrimitiveType;
 import sleeper.core.schema.type.StringType;
+import sleeper.foreign.FFIBytes;
 import sleeper.foreign.FFISleeperRegion;
 import sleeper.foreign.bridge.FFIArray;
 
@@ -44,7 +45,7 @@ public class FFICommonConfig extends Struct {
     /** Optional AWS configuration. */
     public final Struct.StructRef<FFIAwsConfig> aws_config = new Struct.StructRef<>(FFIAwsConfig.class);
     /** Array of input files to compact. */
-    public final FFIArray<java.lang.String> input_files = new FFIArray<>(this);
+    public final FFIArray<FFIBytes> input_files = new FFIArray<>(this);
     /** Whether the input files are individually sorted by the row and sort key fields. */
     public final Struct.Boolean input_files_sorted = new Struct.Boolean();
     /** Whether we should use readahead when reading from S3. */
@@ -56,11 +57,11 @@ public class FFICommonConfig extends Struct {
     /** Specifies if sketch output is enabled. Can only be used with file output. */
     public final Struct.Boolean write_sketch_file = new Struct.Boolean();
     /** Names of Sleeper row key fields from schema. */
-    public final FFIArray<java.lang.String> row_key_cols = new FFIArray<>(this);
+    public final FFIArray<FFIBytes> row_key_cols = new FFIArray<>(this);
     /** Types for region schema 1 = Int, 2 = Long, 3 = String, 4 = Byte array. */
     public final FFIArray<java.lang.Integer> row_key_schema = new FFIArray<>(this);
     /** Names of Sleeper sort key fields from schema. */
-    public final FFIArray<java.lang.String> sort_key_cols = new FFIArray<>(this);
+    public final FFIArray<FFIBytes> sort_key_cols = new FFIArray<>(this);
     /** Maximum size of output Parquet row group in rows. */
     public final Struct.size_t max_row_group_size = new Struct.size_t();
     /** Maximum size of output Parquet page size in bytes. */
@@ -150,7 +151,6 @@ public class FFICommonConfig extends Struct {
             } else {
                 throw new IllegalStateException("Unsupported field type found " + type.getClass());
             }
-        }).boxed()
-                .toArray(Integer[]::new);
+        }).boxed().toArray(Integer[]::new);
     }
 }

--- a/java/common/foreign-bridge/src/test/java/sleeper/foreign/FFIBytesTest.java
+++ b/java/common/foreign-bridge/src/test/java/sleeper/foreign/FFIBytesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.foreign;
+
+import jnr.ffi.Pointer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+public class FFIBytesTest {
+    private final static jnr.ffi.Runtime RUNTIME = jnr.ffi.Runtime.getSystemRuntime();
+
+    @Test
+    void shouldThrowOnNullBytes() {
+        // When - Then
+        assertThatNullPointerException().isThrownBy(() -> new FFIBytes(RUNTIME, null)).withMessage("data");
+    }
+
+    @Test
+    void shouldAcceptAndGetZeroBytes() {
+        // Given
+        FFIBytes zero = new FFIBytes(RUNTIME, new byte[0]);
+
+        // When
+        byte[] returned = zero.getData();
+
+        // Then
+        assertThat(returned).hasSize(0);
+    }
+
+    @Test
+    void shouldAcceptAndGetSomeBytes() {
+        // Given
+        byte[] expected = {0, 1, 2, 3, 4, 5, 6};
+        FFIBytes data = new FFIBytes(RUNTIME, expected);
+
+        // When
+        byte[] returned = data.getData();
+
+        // Then
+        assertThat(returned).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldWriteToReadFromMemoryZeroBytes() {
+        // Given
+        FFIBytes zero = new FFIBytes(RUNTIME, new byte[0]);
+        Pointer memoryBuffer = RUNTIME.getMemoryManager().allocateTemporary(FFIBytes.size(RUNTIME), true);
+        zero.writeTo(memoryBuffer);
+
+        // When
+        FFIBytes returned = FFIBytes.readFrom(memoryBuffer);
+
+        // Then
+        assertThat(zero).isEqualTo(returned);
+    }
+
+    @Test
+    void shouldWriteToReadFromMemoryManyBytes() {
+        // Given
+        FFIBytes data = new FFIBytes(RUNTIME, new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+        Pointer memoryBuffer = RUNTIME.getMemoryManager().allocateTemporary(FFIBytes.size(RUNTIME), true);
+        data.writeTo(memoryBuffer);
+
+        // When
+        FFIBytes returned = FFIBytes.readFrom(memoryBuffer);
+
+        // Then
+        assertThat(data).isEqualTo(returned);
+    }
+}

--- a/java/common/foreign-bridge/src/test/java/sleeper/foreign/FFIBytesTest.java
+++ b/java/common/foreign-bridge/src/test/java/sleeper/foreign/FFIBytesTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 public class FFIBytesTest {
-    private final static jnr.ffi.Runtime RUNTIME = jnr.ffi.Runtime.getSystemRuntime();
+    private static final jnr.ffi.Runtime RUNTIME = jnr.ffi.Runtime.getSystemRuntime();
 
     @Test
     void shouldThrowOnNullBytes() {

--- a/java/common/foreign-bridge/src/test/java/sleeper/foreign/bridge/FFIArrayTest.java
+++ b/java/common/foreign-bridge/src/test/java/sleeper/foreign/bridge/FFIArrayTest.java
@@ -129,6 +129,23 @@ class FFIArrayTest {
     }
 
     @Test
+    void shouldPopulateAndReadBackWithStringsWithEmbeddedNulls() {
+        // Given
+        Struct struct = new Struct(Runtime.getSystemRuntime()) {
+        };
+        FFIArray<String> array = new FFIArray<>(struct);
+        String[] input = {"te\0st", "", "str\0\0\0ing", null, "test string\0", "\0", "\0hello"};
+
+        // When
+        array.populate(input, true);
+        array.validate();
+        String[] output = (String[]) array.readBack(String.class, true);
+
+        // Then
+        assertArrayEquals(input, output);
+    }
+
+    @Test
     void shouldPopulateAndReadBackWithByteArrays() {
         // Given
         Struct struct = new Struct(Runtime.getSystemRuntime()) {
@@ -137,7 +154,8 @@ class FFIArrayTest {
         byte[] a = {1, 2, 3};
         byte[] b = {};
         byte[] c = {127, -128, 0};
-        byte[][] input = {a, b, c, null};
+        byte[] d = {0, 0};
+        byte[][] input = {a, b, c, d, null};
 
         // When
         array.populate(input, true);

--- a/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
+++ b/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
@@ -30,6 +30,7 @@ import sleeper.core.range.Region;
 import sleeper.core.row.Row;
 import sleeper.core.schema.Schema;
 import sleeper.core.tracker.job.run.RowsProcessed;
+import sleeper.foreign.FFIBytes;
 import sleeper.foreign.FFIFileResult;
 import sleeper.foreign.FFISleeperRegion;
 import sleeper.foreign.bridge.FFIContext;
@@ -38,7 +39,9 @@ import sleeper.foreign.datafusion.FFICommonConfig;
 import sleeper.parquet.row.ParquetRowWriterFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static sleeper.core.properties.table.TableProperty.COLUMN_INDEX_TRUNCATE_LENGTH;
 import static sleeper.core.properties.table.TableProperty.COMPRESSION_CODEC;
@@ -108,7 +111,7 @@ public class DataFusionCompactionRunner implements CompactionRunner {
             Region region, DataFusionAwsConfig awsConfig, jnr.ffi.Runtime runtime) {
         Schema schema = tableProperties.getSchema();
         FFICommonConfig params = new FFICommonConfig(runtime, awsConfig);
-        params.input_files.populate(job.getInputFiles().toArray(String[]::new), false);
+        params.input_files.populate(makeFFIBytes(runtime, job.getInputFiles()), false);
         // Files are always sorted for compactions
         params.input_files_sorted.set(true);
         params.use_readahead_store.set(tableProperties.getBoolean(DATAFUSION_S3_READAHEAD_ENABLED));
@@ -116,9 +119,9 @@ public class DataFusionCompactionRunner implements CompactionRunner {
         params.read_page_indexes.set(false);
         params.output_file.set(job.getOutputFile());
         params.write_sketch_file.set(true);
-        params.row_key_cols.populate(schema.getRowKeyFieldNames().toArray(String[]::new), false);
+        params.row_key_cols.populate(makeFFIBytes(runtime, schema.getRowKeyFieldNames()), false);
         params.row_key_schema.populate(FFICommonConfig.getKeyTypes(schema.getRowKeyTypes()), false);
-        params.sort_key_cols.populate(schema.getSortKeyFieldNames().toArray(String[]::new), false);
+        params.sort_key_cols.populate(makeFFIBytes(runtime, schema.getSortKeyFieldNames()), false);
         params.max_row_group_size.set(tableProperties.getInt(PARQUET_ROW_GROUP_SIZE_ROWS));
         params.max_page_size.set(tableProperties.getInt(PAGE_SIZE));
         params.compression.set(tableProperties.get(COMPRESSION_CODEC));
@@ -134,6 +137,17 @@ public class DataFusionCompactionRunner implements CompactionRunner {
         params.validate();
 
         return params;
+    }
+
+    /**
+     * Converts strings into an array of {@link FFIBytes}.
+     *
+     * @param  runtime JNR runtime to use
+     * @param  strings strings to convert
+     * @return         byte objects for FFI
+     */
+    private static FFIBytes[] makeFFIBytes(jnr.ffi.Runtime runtime, List<String> strings) {
+        return strings.stream().map(s -> new FFIBytes(runtime, s.getBytes(StandardCharsets.UTF_8))).toArray(FFIBytes[]::new);
     }
 
     /**

--- a/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
+++ b/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
@@ -30,7 +30,6 @@ import sleeper.core.range.Region;
 import sleeper.core.row.Row;
 import sleeper.core.schema.Schema;
 import sleeper.core.tracker.job.run.RowsProcessed;
-import sleeper.foreign.FFIBytes;
 import sleeper.foreign.FFIFileResult;
 import sleeper.foreign.FFISleeperRegion;
 import sleeper.foreign.bridge.FFIContext;
@@ -39,9 +38,7 @@ import sleeper.foreign.datafusion.FFICommonConfig;
 import sleeper.parquet.row.ParquetRowWriterFactory;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static sleeper.core.properties.table.TableProperty.COLUMN_INDEX_TRUNCATE_LENGTH;
 import static sleeper.core.properties.table.TableProperty.COMPRESSION_CODEC;
@@ -111,7 +108,7 @@ public class DataFusionCompactionRunner implements CompactionRunner {
             Region region, DataFusionAwsConfig awsConfig, jnr.ffi.Runtime runtime) {
         Schema schema = tableProperties.getSchema();
         FFICommonConfig params = new FFICommonConfig(runtime, awsConfig);
-        params.input_files.populate(makeFFIBytes(runtime, job.getInputFiles()), false);
+        params.input_files.populate(job.getInputFiles().toArray(String[]::new), false);
         // Files are always sorted for compactions
         params.input_files_sorted.set(true);
         params.use_readahead_store.set(tableProperties.getBoolean(DATAFUSION_S3_READAHEAD_ENABLED));
@@ -119,9 +116,9 @@ public class DataFusionCompactionRunner implements CompactionRunner {
         params.read_page_indexes.set(false);
         params.output_file.set(job.getOutputFile());
         params.write_sketch_file.set(true);
-        params.row_key_cols.populate(makeFFIBytes(runtime, schema.getRowKeyFieldNames()), false);
+        params.row_key_cols.populate(schema.getRowKeyFieldNames().toArray(String[]::new), false);
         params.row_key_schema.populate(FFICommonConfig.getKeyTypes(schema.getRowKeyTypes()), false);
-        params.sort_key_cols.populate(makeFFIBytes(runtime, schema.getSortKeyFieldNames()), false);
+        params.sort_key_cols.populate(schema.getSortKeyFieldNames().toArray(String[]::new), false);
         params.max_row_group_size.set(tableProperties.getInt(PARQUET_ROW_GROUP_SIZE_ROWS));
         params.max_page_size.set(tableProperties.getInt(PAGE_SIZE));
         params.compression.set(tableProperties.get(COMPRESSION_CODEC));
@@ -137,17 +134,6 @@ public class DataFusionCompactionRunner implements CompactionRunner {
         params.validate();
 
         return params;
-    }
-
-    /**
-     * Converts strings into an array of {@link FFIBytes}.
-     *
-     * @param  runtime JNR runtime to use
-     * @param  strings strings to convert
-     * @return         byte objects for FFI
-     */
-    private static FFIBytes[] makeFFIBytes(jnr.ffi.Runtime runtime, List<String> strings) {
-        return strings.stream().map(s -> new FFIBytes(runtime, s.getBytes(StandardCharsets.UTF_8))).toArray(FFIBytes[]::new);
     }
 
     /**

--- a/java/compaction/compaction-datafusion/src/test/java/sleeper/compaction/datafusion/DataFusionCompactionRunnerIT.java
+++ b/java/compaction/compaction-datafusion/src/test/java/sleeper/compaction/datafusion/DataFusionCompactionRunnerIT.java
@@ -42,6 +42,7 @@ import sleeper.core.schema.type.MapType;
 import sleeper.core.schema.type.StringType;
 import sleeper.core.statestore.FileReference;
 import sleeper.core.statestore.FileReferenceFactory;
+import sleeper.core.statestore.SplitFileReferences;
 import sleeper.core.statestore.StateStore;
 import sleeper.core.statestore.testutils.FixedStateStoreProvider;
 import sleeper.core.statestore.testutils.InMemoryTransactionLogStateStore;
@@ -222,6 +223,36 @@ public class DataFusionCompactionRunnerIT {
                     .containsExactly(row1, row2);
             assertThat(SketchesDeciles.from(readSketches(job.getOutputFile())))
                     .isEqualTo(SketchesDeciles.from(tableProperties, List.of(row1, row2)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Handle data types in split points")
+    class HandleDataTypesInSplitPoints {
+
+        @Test
+        void shouldFilterDataByStringKey() throws Exception {
+            // Given
+            tableProperties.setSchema(createSchemaWithKey("key", new StringType()));
+            update(stateStore).initialise(new PartitionsBuilder(tableProperties)
+                    .rootFirst("root")
+                    .splitToNewChildren("root", "L", "R", "abc\0def")
+                    .buildList());
+            Row row1 = new Row(Map.of("key", "abc\0abc"));
+            Row row2 = new Row(Map.of("key", "abc\0ghi"));
+            String input = writeFileForPartition("root", List.of(row1, row2));
+            SplitFileReferences.from(stateStore).split();
+            CompactionJob job = createCompactionForPartition("test-job", "L", List.of(input));
+
+            // When
+            runTask(job);
+
+            // Then
+            assertThat(getRowsProcessed(job)).isEqualTo(new RowsProcessed(1, 1));
+            assertThat(readDataFile(job.getOutputFile()))
+                    .containsExactly(row1);
+            assertThat(SketchesDeciles.from(readSketches(job.getOutputFile())))
+                    .isEqualTo(SketchesDeciles.from(tableProperties, List.of(row1)));
         }
     }
 

--- a/rust/sleeper_df/src/objects.rs
+++ b/rust/sleeper_df/src/objects.rs
@@ -1,4 +1,6 @@
 //! All Foreign Function Interface compatible structs are here.
+use std::{ffi::c_uchar, slice};
+
 /*
  * Copyright 2022-2025 Crown Copyright
  *
@@ -14,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use color_eyre::eyre::eyre;
+use color_eyre::{Report, eyre::eyre};
 
 pub mod aws_config;
 pub mod ffi_common_config;
@@ -55,5 +57,33 @@ impl TryFrom<&usize> for RowKeySchemaType {
             4 => Ok(RowKeySchemaType::ByteArray),
             _ => Err(eyre!("Invalid FFIRowKeySchemaType ordinal value")),
         }
+    }
+}
+
+/// Represents an array of bytes (unsigned char in C, u8 in Rust) with a length.
+///
+/// This can be converted to a byte array slice or a string slice (assuming it is valid UTF-8).
+///
+/// *THIS IS A C COMPATIBLE FFI STRUCT!* If you updated this struct (field ordering, types, etc.),
+/// you MUST update the corresponding Java definition in java/common/foreign-bridge/src/main/java/sleeper/foreign/datafusion/FFICommonConfig.java.
+/// The order and types of the fields must match exactly.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct FFIBytes {
+    pub length: usize,
+    pub buffer: *const c_uchar,
+}
+
+impl TryFrom<&FFIBytes> for &str {
+    type Error = Report;
+
+    fn try_from(value: &FFIBytes) -> Result<Self, Self::Error> {
+        Ok(std::str::from_utf8(<&[u8]>::from(value))?)
+    }
+}
+
+impl From<&FFIBytes> for &[u8] {
+    fn from(value: &FFIBytes) -> Self {
+        unsafe { slice::from_raw_parts(value.buffer, value.length) }
     }
 }

--- a/rust/sleeper_df/src/objects.rs
+++ b/rust/sleeper_df/src/objects.rs
@@ -64,9 +64,9 @@ impl TryFrom<&usize> for RowKeySchemaType {
 ///
 /// This can be converted to a byte array slice or a string slice (assuming it is valid UTF-8).
 ///
-/// *THIS IS A C COMPATIBLE FFI STRUCT!* If you updated this struct (field ordering, types, etc.),
-/// you MUST update the corresponding Java definition in java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java.
-/// The order and types of the fields must match exactly.
+/// Whilst this is a C compatible FFI struct. It has a pure Java definition in
+/// java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java. If you change the ordering or types
+/// of fields in this struct, you MUST update the writeTo/readFrom methods in that class!
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct FFIBytes {

--- a/rust/sleeper_df/src/objects.rs
+++ b/rust/sleeper_df/src/objects.rs
@@ -65,7 +65,7 @@ impl TryFrom<&usize> for RowKeySchemaType {
 /// This can be converted to a byte array slice or a string slice (assuming it is valid UTF-8).
 ///
 /// *THIS IS A C COMPATIBLE FFI STRUCT!* If you updated this struct (field ordering, types, etc.),
-/// you MUST update the corresponding Java definition in java/common/foreign-bridge/src/main/java/sleeper/foreign/datafusion/FFICommonConfig.java.
+/// you MUST update the corresponding Java definition in java/common/foreign-bridge/src/main/java/sleeper/foreign/FFIBytes.java.
 /// The order and types of the fields must match exactly.
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/rust/sleeper_df/src/objects/ffi_common_config.rs
+++ b/rust/sleeper_df/src/objects/ffi_common_config.rs
@@ -16,13 +16,13 @@
 */
 use crate::{
     objects::{
-        RowKeySchemaType,
+        FFIBytes, RowKeySchemaType,
         aws_config::{FFIAwsConfig, unpack_aws_config},
         sleeper_region::FFISleeperRegion,
     },
-    unpack::{unpack_str, unpack_string, unpack_string_array, unpack_typed_array},
+    unpack::{unpack_str, unpack_string, unpack_typed_array},
 };
-use color_eyre::eyre::bail;
+use color_eyre::eyre::{Result, bail};
 use sleeper_core::{
     CommonConfig, CommonConfigBuilder, OutputType, SleeperParquetOptions,
     filter_aggregation_config::{aggregate::Aggregate, filter::Filter},
@@ -40,18 +40,18 @@ pub struct FFICommonConfig {
     pub override_aws_config: bool,
     pub aws_config: *const FFIAwsConfig,
     pub input_files_len: usize,
-    pub input_files: *const *const c_char,
+    pub input_files: *const *const FFIBytes,
     pub input_files_sorted: bool,
     pub use_readahead_store: bool,
     pub read_page_indexes: bool,
     pub output_file: *const c_char,
     pub write_sketch_file: bool,
     pub row_key_cols_len: usize,
-    pub row_key_cols: *const *const c_char,
+    pub row_key_cols: *const *const FFIBytes,
     pub row_key_schema_len: usize,
     pub row_key_schema: *const *const usize,
     pub sort_key_cols_len: usize,
-    pub sort_key_cols: *const *const c_char,
+    pub sort_key_cols: *const *const FFIBytes,
     pub max_row_group_size: usize,
     pub max_page_size: usize,
     pub compression: *const c_char,
@@ -80,12 +80,10 @@ impl FFICommonConfig {
 
     /// Get row key field names.
     pub fn row_key_cols(&self) -> Result<Vec<String>, color_eyre::Report> {
-        Ok(
-            unpack_string_array(self.row_key_cols, self.row_key_cols_len)?
-                .into_iter()
-                .map(String::from)
-                .collect::<Vec<_>>(),
-        )
+        unpack_typed_array(self.row_key_cols, self.row_key_cols_len)?
+            .iter()
+            .map(|bytes| Ok(String::from(TryInto::<&str>::try_into(bytes)?)))
+            .collect()
     }
 
     /// Convert to a Rust native struct.
@@ -148,9 +146,12 @@ impl FFICommonConfig {
         CommonConfigBuilder::new()
             .aws_config(unpack_aws_config(self)?)
             .input_files(
-                unpack_string_array(self.input_files, self.input_files_len)?
-                    .into_iter()
-                    .map(Url::parse)
+                unpack_typed_array(self.input_files, self.input_files_len)?
+                    .iter()
+                    .map(|bytes| {
+                        Url::parse(TryInto::<&str>::try_into(bytes)?)
+                            .map_err(color_eyre::Report::from)
+                    })
                     .collect::<Result<Vec<_>, _>>()?,
             )
             .input_files_sorted(self.input_files_sorted)
@@ -158,10 +159,12 @@ impl FFICommonConfig {
             .use_readahead_store(self.use_readahead_store)
             .row_key_cols(row_key_cols)
             .sort_key_cols(
-                unpack_string_array(self.sort_key_cols, self.sort_key_cols_len)?
-                    .into_iter()
-                    .map(String::from)
-                    .collect(),
+                unpack_typed_array(self.sort_key_cols, self.sort_key_cols_len)?
+                    .iter()
+                    .map(|bytes| {
+                        Ok::<_, color_eyre::Report>(String::from(TryInto::<&str>::try_into(bytes)?))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
             )
             .region(region)
             .output(output)

--- a/rust/sleeper_df/src/objects/query.rs
+++ b/rust/sleeper_df/src/objects/query.rs
@@ -15,13 +15,13 @@
 * limitations under the License.
 */
 use crate::{
-    objects::{ffi_common_config::FFICommonConfig, sleeper_region::FFISleeperRegion},
-    unpack::unpack_string_array,
+    objects::{FFIBytes, ffi_common_config::FFICommonConfig, sleeper_region::FFISleeperRegion},
+    unpack::unpack_typed_array,
 };
 use arrow::ffi_stream::FFI_ArrowArrayStream;
 use color_eyre::eyre::bail;
 use sleeper_core::LeafPartitionQueryConfig;
-use std::{ffi::c_char, slice};
+use std::slice;
 
 /// Contains all information needed for a Sleeper leaf partition query from a foreign function.
 ///
@@ -41,7 +41,7 @@ pub struct FFILeafPartitionQueryConfig {
     /// Length of requested value fields
     pub requested_value_fields_len: usize,
     /// Requested value fields.
-    pub requested_value_fields: *const *const c_char,
+    pub requested_value_fields: *const *const FFIBytes,
     /// Should logical and physical query plans be written to logging output?
     pub explain_plans: bool,
 }
@@ -76,12 +76,13 @@ impl FFILeafPartitionQueryConfig {
             .collect::<Result<Vec<_>, _>>()?;
 
         let requested_value_columns = if self.requested_value_fields_set {
-            Some(
-                unpack_string_array(self.requested_value_fields, self.requested_value_fields_len)?
-                    .into_iter()
-                    .map(String::from)
-                    .collect(),
-            )
+            let t =
+                unpack_typed_array(self.requested_value_fields, self.requested_value_fields_len)?
+                    .iter()
+                    .map(|bytes| Ok(String::from(TryInto::<&str>::try_into(bytes)?)))
+                    .collect::<Result<Vec<_>, color_eyre::Report>>()?;
+
+            Some(t)
         } else {
             None
         };

--- a/rust/sleeper_df/src/unpack.rs
+++ b/rust/sleeper_df/src/unpack.rs
@@ -35,9 +35,13 @@ pub fn unpack_string(pointer: *const c_char) -> Result<String> {
 /// # Errors
 /// If the array length is invalid, then behaviour is undefined.
 pub fn unpack_typed_array<T: Copy>(array_base: *const *const T, len: usize) -> Result<Vec<T>> {
+    if len == 0 {
+        return Ok(Vec::new());
+    }
     if array_base.is_null() {
         bail!("NULL pointer for array_base in generic typed array");
     }
+
     unsafe { slice::from_raw_parts(array_base, len) }
         .iter()
         .map(|p| {

--- a/rust/sleeper_df/src/unpack.rs
+++ b/rust/sleeper_df/src/unpack.rs
@@ -14,11 +14,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-use crate::objects::RowKeySchemaType;
-use color_eyre::{
-    Report,
-    eyre::{Result, bail, eyre},
-};
+use crate::objects::{FFIBytes, RowKeySchemaType};
+use color_eyre::eyre::{Result, bail, eyre};
 use sleeper_core::PartitionBound;
 use std::{
     ffi::{CStr, c_char, c_void},
@@ -31,49 +28,6 @@ pub fn unpack_str<'a>(pointer: *const c_char) -> Result<&'a str> {
 
 pub fn unpack_string(pointer: *const c_char) -> Result<String> {
     unpack_str(pointer).map(ToOwned::to_owned)
-}
-
-/// Create a vector from a C pointer to an array of strings.
-///
-/// # Errors
-/// If the array length is invalid, then behaviour is undefined.
-pub fn unpack_string_array(
-    array_base: *const *const c_char,
-    len: usize,
-) -> Result<Vec<&'static str>> {
-    if len == 0 {
-        return Ok(Vec::new());
-    }
-    if array_base.is_null() {
-        bail!("NULL pointer for array_base in string array");
-    }
-    unsafe {
-        // create a slice from the pointer
-        slice::from_raw_parts(array_base, len)
-    }
-    .iter()
-    // transform pointer to a non-owned string
-    .map(|s| {
-        if s.is_null() {
-            Err(eyre!("Found NULL pointer in string array"))
-        } else {
-            //unpack length (signed because it's from Java)
-            // This will have been allocated in Java so alignment will be ok
-            #[allow(clippy::cast_ptr_alignment)]
-            let str_len = unsafe { *(*s).cast::<i32>() };
-            if str_len < 0 {
-                bail!("Illegal string length in FFI array: {str_len}");
-            }
-            // convert to string and check it's valid
-            std::str::from_utf8(unsafe {
-                #[allow(clippy::cast_sign_loss)]
-                slice::from_raw_parts(s.byte_add(4).cast::<u8>(), str_len as usize)
-            })
-            .map_err(Into::into)
-        }
-    })
-    // now convert to a vector if all strings OK, else Err
-    .collect()
 }
 
 /// Create a vector of a generic type.
@@ -138,42 +92,16 @@ pub fn unpack_variant_array<'a>(
                         None => PartitionBound::Unbounded,
                     }),
                     RowKeySchemaType::String => {
-                        match unsafe { bptr.cast::<i32>().as_ref() } {
+                        match unsafe { bptr.cast::<FFIBytes>().as_ref() } {
                             //unpack length (signed because it's from Java)
-                            Some(str_len) => {
-                                if *str_len < 0 {
-                                    bail!("Illegal string variant length in FFI array: {str_len}");
-                                }
-                                std::str::from_utf8(unsafe {
-                                    #[allow(clippy::cast_sign_loss)]
-                                    slice::from_raw_parts(
-                                        bptr.byte_add(4).cast::<u8>(),
-                                        *str_len as usize,
-                                    )
-                                })
-                                .map_err(Report::from)
-                                .map(PartitionBound::String)
-                            }
+                            Some(bytes) => Ok(PartitionBound::String(bytes.try_into()?)),
                             None => Ok(PartitionBound::Unbounded),
                         }
                     }
                     RowKeySchemaType::ByteArray => {
-                        match unsafe { bptr.cast::<i32>().as_ref() } {
+                        match unsafe { bptr.cast::<FFIBytes>().as_ref() } {
                             //unpack length (signed because it's from Java)
-                            Some(byte_len) => {
-                                if *byte_len < 0 {
-                                    bail!(
-                                        "Illegal byte array variant length in FFI array: {byte_len}"
-                                    );
-                                }
-                                Ok(PartitionBound::ByteArray(unsafe {
-                                    #[allow(clippy::cast_sign_loss)]
-                                    slice::from_raw_parts(
-                                        bptr.byte_add(4).cast::<u8>(),
-                                        *byte_len as usize,
-                                    )
-                                }))
-                            }
+                            Some(bytes) => Ok(PartitionBound::ByteArray(bytes.into())),
                             None => Ok(PartitionBound::Unbounded),
                         }
                     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6903

### Tests

- [X] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - FFIBytesTest

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
