### PR TITLE
Issue 6889 - Stop ParallelCompactionsST failing when second round of compactions starts before first round is fully created

### DIFF
--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/CompactionDsl.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/CompactionDsl.java
@@ -77,36 +77,24 @@ public class CompactionDsl {
         return this;
     }
 
-    public CompactionDsl putTableOnlineUntilJobsAreCreated(int expectedJobs) {
-        putTablesOnlineWaitForJobCreation(expectedJobs);
+    public CompactionDsl putCurrentTablesOnlineUntilJobsAreCreated(int expectedJobs) {
+        putCurrentTablesOnlineWaitForJobCreation(expectedJobs);
         instance.updateTableProperties(Map.of(TABLE_ONLINE, "false"));
         return this;
     }
 
-    public CompactionDsl putTableOnlineWaitForJobCreation(int expectedJobs) {
-        return putTablesOnlineWaitForJobCreation(expectedJobs);
-    }
-
-    public CompactionDsl putTablesOnlineWaitForJobCreation(int expectedJobs) {
-        return putTablesOnlineWaitForJobCreation(expectedJobs,
+    public CompactionDsl putCurrentTablesOnlineWaitForJobCreation(int expectedJobs) {
+        return putCurrentTablesOnlineWaitForJobCreation(expectedJobs,
                 PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(15), Duration.ofMinutes(2)));
     }
 
-    public CompactionDsl putTableOnlineWaitForJobCreation(int expectedJobs, PollWithRetries poll) {
-        return putTablesOnlineWaitForJobCreation(expectedJobs, poll);
-    }
-
-    public CompactionDsl putTablesOnlineWaitForJobCreation(int expectedJobs, PollWithRetries poll) {
+    public CompactionDsl putCurrentTablesOnlineWaitForJobCreation(int expectedJobs, PollWithRetries poll) {
         lastJobIds = waitForJobCreation.createJobsGetIds(expectedJobs, pollDriver.poll(poll),
                 () -> instance.updateTableProperties(Map.of(TABLE_ONLINE, "true")));
         return this;
     }
 
-    public CompactionDsl putTableOnlineWaitForMinJobCreation(int expectedJobs, PollWithRetries poll) {
-        return putTablesOnlineWaitForMinJobCreation(expectedJobs, poll);
-    }
-
-    public CompactionDsl putTablesOnlineWaitForMinJobCreation(int expectedJobs, PollWithRetries poll) {
+    public CompactionDsl putCurrentTablesOnlineWaitForMinJobCreation(int expectedJobs, PollWithRetries poll) {
         lastJobIds = waitForJobCreation.createMinJobsGetIds(expectedJobs, pollDriver.poll(poll),
                 () -> instance.updateTableProperties(Map.of(TABLE_ONLINE, "true")));
         return this;

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/CompactionDsl.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/CompactionDsl.java
@@ -102,6 +102,16 @@ public class CompactionDsl {
         return this;
     }
 
+    public CompactionDsl putTableOnlineWaitForMinJobCreation(int expectedJobs, PollWithRetries poll) {
+        return putTablesOnlineWaitForMinJobCreation(expectedJobs, poll);
+    }
+
+    public CompactionDsl putTablesOnlineWaitForMinJobCreation(int expectedJobs, PollWithRetries poll) {
+        lastJobIds = waitForJobCreation.createMinJobsGetIds(expectedJobs, pollDriver.poll(poll),
+                () -> instance.updateTableProperties(Map.of(TABLE_ONLINE, "true")));
+        return this;
+    }
+
     public CompactionDsl forceCreateJobs(int expectedJobs) {
         lastJobIds = waitForJobCreation.createJobsGetIds(expectedJobs,
                 pollDriver.pollWithIntervalAndTimeout(Duration.ofSeconds(1), Duration.ofMinutes(1)),

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/TooManyCompactionsCreatedException.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/TooManyCompactionsCreatedException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022-2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.dsl.compaction;
+
+import java.util.List;
+
+public class TooManyCompactionsCreatedException extends RuntimeException {
+
+    public TooManyCompactionsCreatedException(int expectedJobs, List<String> foundJobIds) {
+        super("Expected " + expectedJobs + " new compaction jobs, found " + foundJobIds.size());
+    }
+
+}

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreation.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreation.java
@@ -18,6 +18,7 @@ package sleeper.systemtest.dsl.compaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import sleeper.core.properties.table.TableProperties;
 import sleeper.core.tracker.compaction.job.CompactionJobTracker;
 import sleeper.core.tracker.compaction.job.query.CompactionJobStatus;
 import sleeper.core.util.PollWithRetries;
@@ -26,6 +27,7 @@ import sleeper.systemtest.dsl.instance.SystemTestInstanceContext;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,22 +38,29 @@ import static sleeper.core.properties.table.TableProperty.TABLE_ID;
 public class WaitForCompactionJobCreation {
     public static final Logger LOGGER = LoggerFactory.getLogger(WaitForCompactionJobCreation.class);
 
-    private final SystemTestInstanceContext instance;
-    private final CompactionJobTracker store;
+    private final Supplier<Stream<TableProperties>> getTableProperties;
+    private final CompactionJobTracker jobTracker;
 
     public WaitForCompactionJobCreation(SystemTestInstanceContext instance, CompactionDriver driver) {
-        this.instance = instance;
-        this.store = driver.getJobTracker();
+        this(instance::streamTableProperties, driver.getJobTracker());
+    }
+
+    public WaitForCompactionJobCreation(Supplier<Stream<TableProperties>> getTableProperties, CompactionJobTracker jobTracker) {
+        this.getTableProperties = getTableProperties;
+        this.jobTracker = jobTracker;
     }
 
     public List<String> createJobsGetIds(int expectedJobs, PollWithRetries poll, Runnable createJobs) {
+        return createJobsGetIds(poll, createJobs, meetsExpectedJobs(expectedJobs));
+    }
+
+    public List<String> createJobsGetIds(PollWithRetries poll, Runnable createJobs, Predicate<List<String>> checkNewJobIds) {
         Set<String> jobsBefore = allJobIds()
                 .collect(Collectors.toSet());
         createJobs.run();
         try {
             List<String> newJobs = poll.queryUntil("compaction jobs were created",
-                    () -> newJobIds(jobsBefore),
-                    meetsExpectedJobs(expectedJobs));
+                    () -> newJobIds(jobsBefore), checkNewJobIds);
             LOGGER.info("Created {} new compaction jobs", newJobs.size());
             return newJobs;
         } catch (InterruptedException e) {
@@ -79,10 +88,10 @@ public class WaitForCompactionJobCreation {
     }
 
     private Stream<String> allJobIds() {
-        return instance.streamTableProperties()
+        return getTableProperties.get()
                 .map(properties -> properties.get(TABLE_ID))
                 .parallel()
-                .flatMap(tableId -> store.streamAllJobs(tableId)
+                .flatMap(tableId -> jobTracker.streamAllJobs(tableId)
                         .map(CompactionJobStatus::getJobId));
     }
 

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreation.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreation.java
@@ -54,6 +54,10 @@ public class WaitForCompactionJobCreation {
         return createJobsGetIds(poll, createJobs, meetsExpectedJobs(expectedJobs));
     }
 
+    public List<String> createMinJobsGetIds(int expectedJobs, PollWithRetries poll, Runnable createJobs) {
+        return createJobsGetIds(poll, createJobs, meetsExpectedMinJobs(expectedJobs));
+    }
+
     private List<String> createJobsGetIds(PollWithRetries poll, Runnable createJobs, Predicate<List<String>> checkNewJobIds) {
         Set<String> jobsBefore = allJobIds()
                 .collect(Collectors.toSet());
@@ -85,6 +89,10 @@ public class WaitForCompactionJobCreation {
                 return jobIds.size() == expectedJobs;
             }
         };
+    }
+
+    private static Predicate<List<String>> meetsExpectedMinJobs(int expectedJobs) {
+        return jobIds -> jobIds.size() >= expectedJobs;
     }
 
     private Stream<String> allJobIds() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreation.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreation.java
@@ -54,7 +54,7 @@ public class WaitForCompactionJobCreation {
         return createJobsGetIds(poll, createJobs, meetsExpectedJobs(expectedJobs));
     }
 
-    public List<String> createJobsGetIds(PollWithRetries poll, Runnable createJobs, Predicate<List<String>> checkNewJobIds) {
+    private List<String> createJobsGetIds(PollWithRetries poll, Runnable createJobs, Predicate<List<String>> checkNewJobIds) {
         Set<String> jobsBefore = allJobIds()
                 .collect(Collectors.toSet());
         createJobs.run();
@@ -80,7 +80,7 @@ public class WaitForCompactionJobCreation {
     private static Predicate<List<String>> meetsExpectedJobs(int expectedJobs) {
         return jobIds -> {
             if (jobIds.size() > expectedJobs) {
-                throw new IllegalStateException("Expected " + expectedJobs + " new compaction jobs, found " + jobIds.size());
+                throw new TooManyCompactionsCreatedException(expectedJobs, jobIds);
             } else {
                 return jobIds.size() == expectedJobs;
             }

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022-2025 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.systemtest.dsl.compaction;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.core.properties.instance.InstanceProperties;
+import sleeper.core.properties.table.TableProperties;
+import sleeper.core.tracker.compaction.job.InMemoryCompactionJobTracker;
+import sleeper.core.tracker.compaction.job.update.CompactionJobCreatedEvent;
+import sleeper.core.util.PollWithRetries;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static sleeper.core.properties.table.TableProperty.TABLE_ID;
+import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
+import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
+import static sleeper.core.schema.SchemaTestHelper.createSchemaWithKey;
+
+public class WaitForCompactionJobCreationTest {
+
+    InstanceProperties instanceProperties = createTestInstanceProperties();
+    List<TableProperties> tables = new ArrayList<>();
+    InMemoryCompactionJobTracker jobTracker = new InMemoryCompactionJobTracker();
+
+    @Test
+    void shouldFindJobsCreatedImmediately() {
+        // Given
+        TableProperties table = createTable();
+        Runnable createJobs = () -> {
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-1")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("L").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:01Z"));
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-2")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("R").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:02Z"));
+        };
+
+        // When
+        List<String> jobIds = createJobsGetIds(2, createJobs);
+
+        // Then
+        assertThat(jobIds).containsExactly("test-job-2", "test-job-1");
+    }
+
+    @Test
+    void shouldFindNotEnoughJobsCreated() {
+        // Given
+        TableProperties table = createTable();
+        Runnable createJobs = () -> {
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("L").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:01Z"));
+        };
+
+        // When / Then
+        assertThatThrownBy(() -> createJobsGetIds(2, createJobs))
+                .isInstanceOf(PollWithRetries.TimedOutException.class);
+    }
+
+    private TableProperties createTable() {
+        TableProperties properties = createTestTableProperties(instanceProperties, createSchemaWithKey("key"));
+        tables.add(properties);
+        return properties;
+    }
+
+    private List<String> createJobsGetIds(int expectedJobs, Runnable createJobs) {
+        return waitForJobs().createJobsGetIds(expectedJobs, PollWithRetries.immediateRetries(10), createJobs);
+    }
+
+    private WaitForCompactionJobCreation waitForJobs() {
+        return new WaitForCompactionJobCreation(tables::stream, jobTracker);
+    }
+
+}

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
@@ -100,7 +100,8 @@ public class WaitForCompactionJobCreationTest {
 
         // When / Then
         assertThatThrownBy(() -> createJobsGetIds(1, createJobs))
-                .isInstanceOf(TooManyCompactionsCreatedException.class);
+                .isInstanceOf(TooManyCompactionsCreatedException.class)
+                .hasMessage("Expected 1 new compaction jobs, found 2");
     }
 
     @Test

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
@@ -81,6 +81,28 @@ public class WaitForCompactionJobCreationTest {
                 .isInstanceOf(PollWithRetries.TimedOutException.class);
     }
 
+    @Test
+    void shouldFindMoreThanExpectedJobsCreated() {
+        // Given
+        TableProperties table = createTable();
+        Runnable createJobs = () -> {
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-1")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("L").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:01Z"));
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-2")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("R").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:02Z"));
+        };
+
+        // When / Then
+        assertThatThrownBy(() -> createJobsGetIds(1, createJobs))
+                .isInstanceOf(TooManyCompactionsCreatedException.class);
+    }
+
     private TableProperties createTable() {
         TableProperties properties = createTestTableProperties(instanceProperties, createSchemaWithKey("key"));
         tables.add(properties);

--- a/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
+++ b/java/system-test/system-test-dsl/src/test/java/sleeper/systemtest/dsl/compaction/WaitForCompactionJobCreationTest.java
@@ -103,6 +103,71 @@ public class WaitForCompactionJobCreationTest {
                 .isInstanceOf(TooManyCompactionsCreatedException.class);
     }
 
+    @Test
+    void shouldAllowExtraJobsCreatedByMin() {
+        // Given
+        TableProperties table = createTable();
+        Runnable createJobs = () -> {
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-1")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("L").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:01Z"));
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-2")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("R").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:02Z"));
+        };
+
+        // When
+        List<String> jobIds = createMinJobsGetIds(1, createJobs);
+
+        // Then
+        assertThat(jobIds).containsExactly("test-job-2", "test-job-1");
+    }
+
+    @Test
+    void shouldAllowExactJobsCreatedByMin() {
+        // Given
+        TableProperties table = createTable();
+        Runnable createJobs = () -> {
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-1")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("L").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:01Z"));
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job-2")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("R").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:02Z"));
+        };
+
+        // When
+        List<String> jobIds = createMinJobsGetIds(2, createJobs);
+
+        // Then
+        assertThat(jobIds).containsExactly("test-job-2", "test-job-1");
+    }
+
+    @Test
+    void shouldFindNotEnoughJobsCreatedByMin() {
+        // Given
+        TableProperties table = createTable();
+        Runnable createJobs = () -> {
+            jobTracker.jobCreated(CompactionJobCreatedEvent.builder()
+                    .jobId("test-job")
+                    .tableId(table.get(TABLE_ID))
+                    .partitionId("L").inputFilesCount(2)
+                    .build(), Instant.parse("2026-03-31T14:00:01Z"));
+        };
+
+        // When / Then
+        assertThatThrownBy(() -> createMinJobsGetIds(2, createJobs))
+                .isInstanceOf(PollWithRetries.TimedOutException.class);
+    }
+
     private TableProperties createTable() {
         TableProperties properties = createTestTableProperties(instanceProperties, createSchemaWithKey("key"));
         tables.add(properties);
@@ -111,6 +176,10 @@ public class WaitForCompactionJobCreationTest {
 
     private List<String> createJobsGetIds(int expectedJobs, Runnable createJobs) {
         return waitForJobs().createJobsGetIds(expectedJobs, PollWithRetries.immediateRetries(10), createJobs);
+    }
+
+    private List<String> createMinJobsGetIds(int expectedJobs, Runnable createJobs) {
+        return waitForJobs().createMinJobsGetIds(expectedJobs, PollWithRetries.immediateRetries(10), createJobs);
     }
 
     private WaitForCompactionJobCreation waitForJobs() {

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionCreationST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionCreationST.java
@@ -73,7 +73,7 @@ public class CompactionCreationST {
 
         // When
         FoundCompactionJobs jobs = sleeper.compaction()
-                .putTableOnlineWaitForJobCreation(65536,
+                .putCurrentTablesOnlineWaitForJobCreation(65536,
                         PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(10), Duration.ofMinutes(5)))
                 .drainJobsQueueForWholeInstance(65536);
 

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionDataFusionPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionDataFusionPerformanceST.java
@@ -68,7 +68,7 @@ public class CompactionDataFusionPerformanceST {
                 .waitForTotalFileReferences(110);
 
         // When
-        sleeper.compaction().putTableOnlineUntilJobsAreCreated(10).waitForTasks(10)
+        sleeper.compaction().putCurrentTablesOnlineUntilJobsAreCreated(10).waitForTasks(10)
                 .waitForJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofHours(1)));
 
         // Then

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/CompactionPerformanceST.java
@@ -65,7 +65,7 @@ public class CompactionPerformanceST {
                 .waitForTotalFileReferences(110);
 
         // When
-        sleeper.compaction().putTableOnlineUntilJobsAreCreated(10).waitForTasks(10)
+        sleeper.compaction().putCurrentTablesOnlineUntilJobsAreCreated(10).waitForTasks(10)
                 .waitForJobs(PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofHours(1)));
 
         // Then

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/MultipleTablesST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/MultipleTablesST.java
@@ -104,7 +104,8 @@ public class MultipleTablesST {
                 .waitForTask().waitForJobs();
 
         // When we run compaction and GC
-        sleeper.compaction().putTablesOnlineWaitForJobCreation(NUMBER_OF_TABLES).waitForTasks(1).waitForJobs();
+        sleeper.compaction().putCurrentTablesOnlineWaitForJobCreation(NUMBER_OF_TABLES)
+                .waitForTasks(1).waitForJobs();
         sleeper.garbageCollection().waitFor();
 
         // Then all tables should have one file reference with the expected rows, and none ready for GC

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
@@ -70,7 +70,7 @@ public class ParallelCompactionsST {
 
         // When we run compaction
         sleeper.compaction()
-                .putTableOnlineWaitForMinJobCreation(40960,
+                .putCurrentTablesOnlineWaitForMinJobCreation(40960,
                         PollWithRetries.intervalAndPollingTimeout(
                                 Duration.ofSeconds(10), Duration.ofMinutes(5)))
                 .waitForTasks(200,

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
@@ -70,7 +70,7 @@ public class ParallelCompactionsST {
 
         // When we run compaction
         sleeper.compaction()
-                .putTableOnlineWaitForJobCreation(40960,
+                .putTableOnlineWaitForMinJobCreation(40960,
                         PollWithRetries.intervalAndPollingTimeout(
                                 Duration.ofSeconds(10), Duration.ofMinutes(5)))
                 .waitForTasks(200,

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ParallelCompactionsST.java
@@ -110,7 +110,7 @@ public class ParallelCompactionsST {
         assertThat(sleeper.reporting().finishedCompactionTasks())
                 .allSatisfy(task -> assertThat(task.getJobRuns())
                         .describedAs("ran the expected distribution of jobs")
-                        .isBetween(0, 600));
+                        .isBetween(0, 700));
     }
 
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6889

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - WaitForCompactionJobCreationTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
