### PR TITLE
6946 - made EMRServerless the default bulk import method for the Pyth…

### DIFF
--- a/python/src/sleeper/client.py
+++ b/python/src/sleeper/client.py
@@ -125,7 +125,7 @@ class SleeperClient:
         table_name: str,
         files: list,
         id: str = None,
-        platform: str = "EMR",
+        platform: str = "EMRServerless",
         platform_spec: dict = None,
         class_name: str = None,
     ):
@@ -139,7 +139,7 @@ class SleeperClient:
         :param table_name: the table name to write to
         :param files: list of the files containing the rows to ingest
         :param id: the id of the bulk import job - if one is not provided then a UUID will be assigned
-        :param platform: the platform to use - either "EMR" or "PersistentEMR" or "EKS"
+        :param platform: the platform to use - either "EMRServerless", "EMR", "PersistentEMR" or "EKS"
         :param platform_spec: a dict containing details of the platform to use - see docs/usage/python-api.md
         """
         _bulk_import(


### PR DESCRIPTION
…on API

Make sure you have checked _all_ steps below.

### Issue

 - Resolves https://github.com/gchq/sleeper/issues/6946

### Tests

- [X] Default change only
