### PR TITLE
Issue 6934 - Handle unreadable EMR managed scaling properties

### DIFF
--- a/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
@@ -95,6 +95,13 @@ public abstract class SleeperProperties<T extends SleeperProperty> implements Sl
                 reporter.invalidProperty(property, value);
             }
         });
+        getValidationCriteria().forEach(criteria -> {
+            if (!criteria.test(this)) {
+                for (T property : criteria.getPropertiesValidated()) {
+                    reporter.invalidProperty(property, get(property));
+                }
+            }
+        });
     }
 
     /**
@@ -115,6 +122,15 @@ public abstract class SleeperProperties<T extends SleeperProperty> implements Sl
      * @return the index
      */
     public abstract SleeperPropertyIndex<T> getPropertiesIndex();
+
+    /**
+     * Retrieves validation criteria to be checked against multiple properties.
+     *
+     * @return the validation criteria
+     */
+    protected List<SleeperPropertiesValidationCriteria<T>> getValidationCriteria() {
+        return List.of();
+    }
 
     /**
      * Retrieves a printer to output the property values in a human-readable string format.

--- a/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
@@ -96,6 +96,12 @@ public abstract class SleeperProperties<T extends SleeperProperty> implements Sl
             }
         });
         getValidationCriteria().forEach(criteria -> {
+            // If we've already found a value is invalid, don't check it again
+            for (T property : criteria.getPropertiesValidated()) {
+                if (!reporter.isValid(property)) {
+                    return;
+                }
+            }
             if (!criteria.test(this)) {
                 for (T property : criteria.getPropertiesValidated()) {
                     reporter.invalidProperty(property, get(property));

--- a/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
@@ -88,7 +88,7 @@ public abstract class SleeperProperties<T extends SleeperProperty> implements Sl
      *
      * @param reporter the reporter to receive failures
      */
-    public void validate(SleeperPropertiesValidationReporter reporter) {
+    public final void validate(SleeperPropertiesValidationReporter reporter) {
         getPropertiesIndex().getUserDefined().forEach(property -> {
             String value = get(property);
             if (!property.getValidationPredicate().test(value)) {

--- a/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationCriteria.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationCriteria.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.properties;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * A validation criteria for Sleeper configuration properties that compares multiple properties.
+ *
+ * @param <T> the type of property definitions
+ * @param <P> the type of property values
+ */
+public interface SleeperPropertiesValidationCriteria<T extends SleeperProperty> extends Predicate<SleeperProperties<T>> {
+
+    /**
+     * Reports which properties are validated by this criteria.
+     *
+     * @return the property definitions
+     */
+    List<T> getPropertiesValidated();
+
+    /**
+     * Creates a validation criteria based on the properties validated.
+     *
+     * @param  properties the properties validated
+     * @param  predicate  the predicate
+     * @return            the validation criteria
+     */
+    public static <T extends SleeperProperty> SleeperPropertiesValidationCriteria<T> forProperties(List<T> properties, Predicate<SleeperProperties<T>> predicate) {
+        return new SleeperPropertiesValidationCriteria<T>() {
+            @Override
+            public boolean test(SleeperProperties<T> properties) {
+                return predicate.test(properties);
+            }
+
+            @Override
+            public List<T> getPropertiesValidated() {
+                return properties;
+            }
+        };
+    }
+
+}

--- a/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationCriteria.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationCriteria.java
@@ -22,7 +22,6 @@ import java.util.function.Predicate;
  * A validation criteria for Sleeper configuration properties that compares multiple properties.
  *
  * @param <T> the type of property definitions
- * @param <P> the type of property values
  */
 public interface SleeperPropertiesValidationCriteria<T extends SleeperProperty> extends Predicate<SleeperProperties<T>> {
 
@@ -36,11 +35,12 @@ public interface SleeperPropertiesValidationCriteria<T extends SleeperProperty> 
     /**
      * Creates a validation criteria that will report a given set of properties as invalid.
      *
+     * @param  <T>        the type of property definitions
      * @param  properties the properties that are invalid if the criteria is not met
      * @param  predicate  the predicate
      * @return            the validation criteria
      */
-    public static <T extends SleeperProperty> SleeperPropertiesValidationCriteria<T> forProperties(List<T> properties, Predicate<SleeperProperties<T>> predicate) {
+    static <T extends SleeperProperty> SleeperPropertiesValidationCriteria<T> forProperties(List<T> properties, Predicate<SleeperProperties<T>> predicate) {
         return new SleeperPropertiesValidationCriteria<T>() {
             @Override
             public boolean test(SleeperProperties<T> properties) {

--- a/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationCriteria.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationCriteria.java
@@ -27,16 +27,16 @@ import java.util.function.Predicate;
 public interface SleeperPropertiesValidationCriteria<T extends SleeperProperty> extends Predicate<SleeperProperties<T>> {
 
     /**
-     * Reports which properties are validated by this criteria.
+     * Reports which properties are invalid if this criteria is not met.
      *
      * @return the property definitions
      */
     List<T> getPropertiesValidated();
 
     /**
-     * Creates a validation criteria based on the properties validated.
+     * Creates a validation criteria that will report a given set of properties as invalid.
      *
-     * @param  properties the properties validated
+     * @param  properties the properties that are invalid if the criteria is not met
      * @param  predicate  the predicate
      * @return            the validation criteria
      */

--- a/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationReporter.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationReporter.java
@@ -56,4 +56,14 @@ public class SleeperPropertiesValidationReporter {
         return invalidValues.isEmpty();
     }
 
+    /**
+     * Checks if a specific property value was valid.
+     *
+     * @param  property the property definition
+     * @return          true if the value was valid
+     */
+    public boolean isValid(SleeperProperty property) {
+        return invalidValues.containsKey(property);
+    }
+
 }

--- a/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationReporter.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperPropertiesValidationReporter.java
@@ -63,7 +63,7 @@ public class SleeperPropertiesValidationReporter {
      * @return          true if the value was valid
      */
     public boolean isValid(SleeperProperty property) {
-        return invalidValues.containsKey(property);
+        return !invalidValues.containsKey(property);
     }
 
 }

--- a/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/InstanceProperties.java
@@ -18,13 +18,15 @@ package sleeper.core.properties.instance;
 import sleeper.core.properties.PropertyGroup;
 import sleeper.core.properties.SleeperProperties;
 import sleeper.core.properties.SleeperPropertiesPrettyPrinter;
-import sleeper.core.properties.SleeperPropertiesValidationReporter;
+import sleeper.core.properties.SleeperPropertiesValidationCriteria;
 import sleeper.core.properties.SleeperPropertyIndex;
+import sleeper.core.properties.model.PersistentEMRManagedScalingBounds;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -32,9 +34,6 @@ import java.util.stream.Collectors;
 
 import static sleeper.core.properties.PropertiesUtils.loadProperties;
 import static sleeper.core.properties.instance.CommonProperty.TAGS;
-import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY;
-import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY;
-import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING;
 
 /**
  * Contains values of the properties to configure an instance of Sleeper.
@@ -74,21 +73,9 @@ public class InstanceProperties extends SleeperProperties<InstanceProperty> {
         return instanceProperties;
     }
 
-    /**
-     * Overridden to check EMR managed scaling bounds are correct.
-     */
     @Override
-    public void validate(SleeperPropertiesValidationReporter reporter) {
-        super.validate(reporter);
-        // Validate EMR managed scaling max is greater than min
-        int minEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY);
-        int maxEmrCapacity = getInt(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
-        boolean managedScaling = getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING);
-        if (managedScaling && maxEmrCapacity <= minEmrCapacity) {
-            reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, String.valueOf(managedScaling));
-            reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, String.valueOf(minEmrCapacity));
-            reporter.invalidProperty(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, String.valueOf(maxEmrCapacity));
-        }
+    protected List<SleeperPropertiesValidationCriteria<InstanceProperty>> getValidationCriteria() {
+        return List.of(PersistentEMRManagedScalingBounds.validationCriteria());
     }
 
     /**

--- a/java/core/src/main/java/sleeper/core/properties/model/PersistentEMRManagedScalingBounds.java
+++ b/java/core/src/main/java/sleeper/core/properties/model/PersistentEMRManagedScalingBounds.java
@@ -15,10 +15,15 @@
  */
 package sleeper.core.properties.model;
 
-import sleeper.core.properties.instance.InstanceProperties;
+import sleeper.core.properties.SleeperPropertiesValidationCriteria;
+import sleeper.core.properties.SleeperPropertyValues;
+import sleeper.core.properties.instance.InstanceProperty;
+
+import java.util.List;
 
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY;
 import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY;
+import static sleeper.core.properties.instance.PersistentEMRProperty.BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING;
 
 /**
  * Stores information about the EMR managed scaling parameters for persistent EMR bulk import stacks.
@@ -48,9 +53,21 @@ public record PersistentEMRManagedScalingBounds(int minCapacityUnits, int maxCap
      * @param  instanceProperties Sleeper instance properties
      * @return                    scaling bounds for EMR
      */
-    public static PersistentEMRManagedScalingBounds create(InstanceProperties instanceProperties) {
+    public static PersistentEMRManagedScalingBounds create(SleeperPropertyValues<InstanceProperty> instanceProperties) {
         int minEmrCapacity = instanceProperties.getInt(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY);
         int maxEmrCapacity = instanceProperties.getInt(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
         return new PersistentEMRManagedScalingBounds(minEmrCapacity, maxEmrCapacity);
+    }
+
+    public static SleeperPropertiesValidationCriteria<InstanceProperty> validationCriteria() {
+        return SleeperPropertiesValidationCriteria.forProperties(
+                List.of(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY),
+                properties -> {
+                    if (!properties.getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING)) {
+                        return true;
+                    }
+                    PersistentEMRManagedScalingBounds bounds = PersistentEMRManagedScalingBounds.create(properties);
+                    return bounds.maxCapacityUnits() > bounds.minCapacityUnits();
+                });
     }
 }

--- a/java/core/src/main/java/sleeper/core/properties/model/PersistentEMRManagedScalingBounds.java
+++ b/java/core/src/main/java/sleeper/core/properties/model/PersistentEMRManagedScalingBounds.java
@@ -59,6 +59,11 @@ public record PersistentEMRManagedScalingBounds(int minCapacityUnits, int maxCap
         return new PersistentEMRManagedScalingBounds(minEmrCapacity, maxEmrCapacity);
     }
 
+    /**
+     * Creates a validation criteria to compare the EMR managed scaling bounds against one another.
+     *
+     * @return a validation criteria that fails if the min and max capacity are not valid in relation to one another
+     */
     public static SleeperPropertiesValidationCriteria<InstanceProperty> validationCriteria() {
         return SleeperPropertiesValidationCriteria.forProperties(
                 List.of(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY),

--- a/java/core/src/main/java/sleeper/core/properties/model/PersistentEMRManagedScalingBounds.java
+++ b/java/core/src/main/java/sleeper/core/properties/model/PersistentEMRManagedScalingBounds.java
@@ -48,7 +48,7 @@ public record PersistentEMRManagedScalingBounds(int minCapacityUnits, int maxCap
      * @param  instanceProperties Sleeper instance properties
      * @return                    scaling bounds for EMR
      */
-    public static PersistentEMRManagedScalingBounds createManagedScalingBounds(InstanceProperties instanceProperties) {
+    public static PersistentEMRManagedScalingBounds create(InstanceProperties instanceProperties) {
         int minEmrCapacity = instanceProperties.getInt(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY);
         int maxEmrCapacity = instanceProperties.getInt(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY);
         return new PersistentEMRManagedScalingBounds(minEmrCapacity, maxEmrCapacity);

--- a/java/core/src/main/java/sleeper/core/properties/table/TableProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/table/TableProperties.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import sleeper.core.properties.PropertyGroup;
 import sleeper.core.properties.SleeperProperties;
 import sleeper.core.properties.SleeperPropertiesPrettyPrinter;
-import sleeper.core.properties.SleeperPropertiesValidationReporter;
 import sleeper.core.properties.SleeperPropertyIndex;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.schema.Schema;
@@ -97,11 +96,6 @@ public class TableProperties extends SleeperProperties<TableProperty> {
     protected void init() {
         setSchema(get(SCHEMA));
         super.init();
-    }
-
-    @Override
-    public void validate(SleeperPropertiesValidationReporter reporter) {
-        super.validate(reporter);
     }
 
     @Override

--- a/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
@@ -15,7 +15,6 @@
  */
 package sleeper.core.properties.model;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,7 +24,6 @@ import sleeper.core.properties.instance.InstanceProperties;
 
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -89,27 +87,9 @@ public class PersistentEMRManagedScalingBoundsTest {
     @Nested
     @DisplayName("Use managed scaling")
     class ManagedScaling {
-        @Test
-        public void shouldValidateFalseWhenMinGreaterMaxAndManagedScalingTrue() {
-            // Given
-            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
-            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 10);
-            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
-
-            // When / Then
-            assertThatThrownBy(() -> instanceProperties.validate())
-                    .isInstanceOf(SleeperPropertiesInvalidException.class)
-                    .hasMessage(String.format("Property %s was invalid. It was \"true\". Failure 1 of 3.",
-                            BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()))
-                    .extracting("invalidValues", as(InstanceOfAssertFactories.MAP))
-                    .isEqualTo(Map.of(
-                            BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true",
-                            BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "10",
-                            BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "5"));
-        }
 
         @Test
-        public void shouldValidateTrueWhenMinLowerThanMaxAndManagedScalingTrue() {
+        public void shouldValidateWhenMinLowerThanMaxAndManagedScalingTrue() {
             // Given
             instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
             instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 1);
@@ -120,7 +100,47 @@ public class PersistentEMRManagedScalingBoundsTest {
         }
 
         @Test
-        public void shouldValidateTrueWhenManagedScalingFalse() {
+        public void shouldNotValidateWhenMinGreaterMaxAndManagedScalingTrue() {
+            // Given
+            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 10);
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
+
+            // When / Then
+            assertThatThrownBy(() -> instanceProperties.validate())
+                    .isInstanceOfSatisfying(SleeperPropertiesInvalidException.class, e -> {
+                        assertThat(e.getInvalidValues()).isEqualTo(Map.of(
+                                BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true",
+                                BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "10",
+                                BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "5"));
+                        assertThat(e.getMessage()).isEqualTo(String.format(
+                                "Property %s was invalid. It was \"true\". Failure 1 of 3.",
+                                BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()));
+                    });
+        }
+
+        @Test
+        public void shouldNotValidateWhenMinEqualToMaxAndManagedScalingTrue() {
+            // Given
+            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 5);
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, 5);
+
+            // When / Then
+            assertThatThrownBy(() -> instanceProperties.validate())
+                    .isInstanceOfSatisfying(SleeperPropertiesInvalidException.class, e -> {
+                        assertThat(e.getInvalidValues()).isEqualTo(Map.of(
+                                BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true",
+                                BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, "5",
+                                BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "5"));
+                        assertThat(e.getMessage()).isEqualTo(String.format(
+                                "Property %s was invalid. It was \"true\". Failure 1 of 3.",
+                                BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING.getPropertyName()));
+                    });
+        }
+
+        @Test
+        public void shouldValidateWhenManagedScalingFalse() {
             // Given
             instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "false");
             instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 5);

--- a/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/model/PersistentEMRManagedScalingBoundsTest.java
@@ -149,6 +149,24 @@ public class PersistentEMRManagedScalingBoundsTest {
             // When / Then
             assertThatCode(() -> instanceProperties.validate()).doesNotThrowAnyException();
         }
+
+        @Test
+        void shouldNotValidateWhenMaxIsUnreadable() {
+            // Given
+            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING, "true");
+            instanceProperties.setNumber(BULK_IMPORT_PERSISTENT_EMR_MIN_CAPACITY, 5);
+            instanceProperties.set(BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "abc");
+
+            // When / Then
+            assertThatThrownBy(() -> instanceProperties.validate())
+                    .isInstanceOfSatisfying(SleeperPropertiesInvalidException.class, e -> {
+                        assertThat(e.getInvalidValues()).isEqualTo(Map.of(
+                                BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY, "abc"));
+                        assertThat(e.getMessage()).isEqualTo(String.format(
+                                "Property %s was invalid. It was \"abc\".",
+                                BULK_IMPORT_PERSISTENT_EMR_MAX_CAPACITY.getPropertyName()));
+                    });
+        }
     }
 
     @Test

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/PersistentEmrBulkImportStack.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/PersistentEmrBulkImportStack.java
@@ -166,7 +166,7 @@ public class PersistentEmrBulkImportStack extends NestedStack {
                         .collect(Collectors.toList()));
 
         if (instanceProperties.getBoolean(BULK_IMPORT_PERSISTENT_EMR_USE_MANAGED_SCALING)) {
-            PersistentEMRManagedScalingBounds bounds = PersistentEMRManagedScalingBounds.createManagedScalingBounds(instanceProperties);
+            PersistentEMRManagedScalingBounds bounds = PersistentEMRManagedScalingBounds.create(instanceProperties);
             ManagedScalingPolicyProperty scalingPolicy = ManagedScalingPolicyProperty.builder()
                     .computeLimits(CfnCluster.ComputeLimitsProperty.builder()
                             .unitType("InstanceFleetUnits")


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6934

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated PersistentEMRManagedScalingBoundsTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
