### PR TITLE
fix: remove fragile log-based success detection in EKS bulk import state machine

### DIFF
--- a/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
@@ -41,11 +41,8 @@ import software.amazon.awscdk.services.lambda.eventsources.SqsEventSource;
 import software.amazon.awscdk.services.logs.ILogGroup;
 import software.amazon.awscdk.services.sqs.DeadLetterQueue;
 import software.amazon.awscdk.services.sqs.Queue;
-import software.amazon.awscdk.services.stepfunctions.Choice;
-import software.amazon.awscdk.services.stepfunctions.Condition;
 import software.amazon.awscdk.services.stepfunctions.CustomState;
 import software.amazon.awscdk.services.stepfunctions.DefinitionBody;
-import software.amazon.awscdk.services.stepfunctions.Fail;
 import software.amazon.awscdk.services.stepfunctions.Pass;
 import software.amazon.awscdk.services.stepfunctions.StateMachine;
 import software.amazon.awscdk.services.stepfunctions.TaskInput;
@@ -232,14 +229,10 @@ public final class EksBulkImportStack extends NestedStack {
         return StateMachine.Builder.create(this, "EksBulkImportStateMachine")
                 .definitionBody(DefinitionBody.fromChainable(
                         CustomState.Builder.create(this, "RunSparkJob").stateJson(runJobState).build()
-                                .next(Choice.Builder.create(this, "SuccessDecision").build()
-                                        .when(Condition.stringMatches("$.output.logs[0]", "*exit code: 0*"),
-                                                CustomState.Builder.create(this, "DeleteDriverPod")
-                                                        .stateJson(deleteDriverPodState).build()
-                                                        .next(CustomState.Builder.create(this, "DeleteJob")
-                                                                .stateJson(deleteJobState).build()))
-                                        .otherwise(createErrorMessage.next(publishError).next(Fail.Builder
-                                                .create(this, "FailedJobState").cause("Spark job failed").build())))))
+                                .next(CustomState.Builder.create(this, "DeleteDriverPod")
+                                        .stateJson(deleteDriverPodState).build()
+                                        .next(CustomState.Builder.create(this, "DeleteJob")
+                                                .stateJson(deleteJobState).build())))
                 .logs(createStateMachineLogOptions(coreStacks.getLogGroup(LogGroupRef.BULK_IMPORT_EKS_STATE_MACHINE)))
                 .build();
     }


### PR DESCRIPTION
## Problem

The EKS Bulk Import state machine always fails even when the Spark job completes successfully ([#7015](https://github.com/gchq/sleeper/issues/7015)).

**Root cause:** The `SuccessDecision` choice state checks for the string `"exit code: 0"` in pod logs (`$.output.logs[0]`) to determine if the job succeeded. This is unreliable because:

1. SLF4J may not be configured (defaults to no-op logger), so **no application logs are emitted at all**
2. Parsing free-text log output for success detection is inherently fragile

## Fix

The `run-job.json` step function uses `arn:aws:states:::eks:runJob.sync` which **already throws `States.ALL` on failure** — this is caught by the existing `Catch` block that routes to `CreateErrorMessage`. Therefore, if execution reaches the state after `RunSparkJob`, the job has **already succeeded**.

This PR removes the redundant `Choice`/`SuccessDecision` state and replaces it with a direct transition chain:

```
Before: RunSparkJob → SuccessChoice → [if "exit code: 0" in logs] → DeleteDriverPod → DeleteJob
                                              └→ otherwise → CreateErrorMessage → Fail ❌

After:  RunSparkJob → DeleteDriverPod → DeleteJob ✅
```

Error handling for actual job failures is preserved via the existing Catch block on `RunSparkJob`.

## Changes

- **EksBulkImportStack.java**: Remove `SuccessDecision` Choice state, go directly to cleanup states
- Remove unused imports (`Choice`, `Condition`, `Fail`)