### PR TITLE
Issue 7034 - Stop removing BuildX builder

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
@@ -73,8 +73,8 @@ public class UploadDockerImages {
         if (deployConfig.dockerImageLocation() == DockerImageLocation.LOCAL_BUILD
                 && createMultiplatformBuilder
                 && imagesToUpload.stream().anyMatch(StackDockerImage::isMultiplatform)) {
-            commandRunner.run("docker", "buildx", "rm", "sleeper");
-            commandRunner.runOrThrow("docker", "buildx", "create", "--name", "sleeper", "--use");
+            commandRunner.run("docker", "buildx", "create", "--name", "sleeper");
+            commandRunner.runOrThrow("docker", "buildx", "use", "sleeper");
         }
 
         for (StackDockerImage image : imagesToUpload) {

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/DockerImageCommandTestData.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/DockerImageCommandTestData.java
@@ -88,8 +88,12 @@ public class DockerImageCommandTestData {
         return pipeline(command("docker", "buildx", "rm", "sleeper"));
     }
 
-    public static CommandPipeline createNewBuildxBuilderInstanceCommand() {
-        return pipeline(command("docker", "buildx", "create", "--name", "sleeper", "--use"));
+    public static CommandPipeline createBuildxBuilderInstanceCommand() {
+        return pipeline(command("docker", "buildx", "create", "--name", "sleeper"));
+    }
+
+    public static CommandPipeline useBuildxBuilderInstanceCommand() {
+        return pipeline(command("docker", "buildx", "use", "sleeper"));
     }
 
     public static CommandPipeline buildAndPushMultiplatformImageCommand(String tag, String dockerDirectory) {

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
@@ -39,12 +39,12 @@ import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildA
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildLambdaImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.commandsToLoginDockerAndPushImages;
-import static sleeper.clients.deploy.container.DockerImageCommandTestData.createNewBuildxBuilderInstanceCommand;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.createBuildxBuilderInstanceCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.dockerLoginToEcrCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.pullImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.pushImageCommand;
-import static sleeper.clients.deploy.container.DockerImageCommandTestData.removeOldBuildxBuilderInstanceCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.tagImageCommand;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.useBuildxBuilderInstanceCommand;
 import static sleeper.core.properties.instance.CommonProperty.ECR_REPOSITORY_PREFIX;
 import static sleeper.core.properties.instance.CommonProperty.LAMBDA_DEPLOY_TYPE;
 import static sleeper.core.properties.instance.CommonProperty.OPTIONAL_STACKS;
@@ -264,8 +264,8 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
             String expectedTag = "123.dkr.ecr.test-region.amazonaws.com/test-instance/compaction:1.0.0";
             assertThat(commandsThatRan).containsExactly(
                     dockerLoginToEcrCommand(),
-                    removeOldBuildxBuilderInstanceCommand(),
-                    createNewBuildxBuilderInstanceCommand(),
+                    createBuildxBuilderInstanceCommand(),
+                    useBuildxBuilderInstanceCommand(),
                     buildAndPushMultiplatformImageCommand(expectedTag, "./docker/compaction"));
         }
 
@@ -282,8 +282,8 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
             String expectedTag2 = "123.dkr.ecr.test-region.amazonaws.com/test-instance/compaction:1.0.0";
             assertThat(commandsThatRan).containsExactly(
                     dockerLoginToEcrCommand(),
-                    removeOldBuildxBuilderInstanceCommand(),
-                    createNewBuildxBuilderInstanceCommand(),
+                    createBuildxBuilderInstanceCommand(),
+                    useBuildxBuilderInstanceCommand(),
                     buildImageCommand(expectedTag1, "./docker/ingest"),
                     pushImageCommand(expectedTag1),
                     buildAndPushMultiplatformImageCommand(expectedTag2, "./docker/compaction"));
@@ -311,10 +311,10 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
         }
 
         @Test
-        void shouldNotFailWhenRemoveBuildxBuilderFailsForCompactionImage() throws Exception {
+        void shouldNotFailWhenCreateBuildxBuilderFailsForCompactionImage() throws Exception {
             // Given
             properties.setEnum(OPTIONAL_STACKS, OptionalStack.CompactionStack);
-            setReturnExitCodeForCommand(123, removeOldBuildxBuilderInstanceCommand());
+            setReturnExitCodeForCommand(123, createBuildxBuilderInstanceCommand());
 
             // When
             uploadForDeployment(dockerDeploymentImageConfig());
@@ -323,27 +323,27 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
             String expectedTag = "123.dkr.ecr.test-region.amazonaws.com/test-instance/compaction:1.0.0";
             assertThat(commandsThatRan).containsExactly(
                     dockerLoginToEcrCommand(),
-                    removeOldBuildxBuilderInstanceCommand(),
-                    createNewBuildxBuilderInstanceCommand(),
+                    createBuildxBuilderInstanceCommand(),
+                    useBuildxBuilderInstanceCommand(),
                     buildAndPushMultiplatformImageCommand(expectedTag, "./docker/compaction"));
         }
 
         @Test
-        void shouldFailWhenCreateBuildxBuilderFails() {
+        void shouldFailWhenUseBuildxBuilderFails() {
             // Given
             properties.setEnum(OPTIONAL_STACKS, OptionalStack.CompactionStack);
-            setReturnExitCodeForCommand(123, createNewBuildxBuilderInstanceCommand());
+            setReturnExitCodeForCommand(123, useBuildxBuilderInstanceCommand());
 
             // When / Then
             assertThatThrownBy(() -> uploadForDeployment(dockerDeploymentImageConfig()))
                     .isInstanceOfSatisfying(CommandFailedException.class, e -> {
-                        assertThat(e.getCommand()).isEqualTo(createNewBuildxBuilderInstanceCommand());
+                        assertThat(e.getCommand()).isEqualTo(useBuildxBuilderInstanceCommand());
                         assertThat(e.getExitCode()).isEqualTo(123);
                     });
             assertThat(commandsThatRan).containsExactly(
                     dockerLoginToEcrCommand(),
-                    removeOldBuildxBuilderInstanceCommand(),
-                    createNewBuildxBuilderInstanceCommand());
+                    createBuildxBuilderInstanceCommand(),
+                    useBuildxBuilderInstanceCommand());
         }
 
         @Test

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
@@ -31,9 +31,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildAndPushMultiplatformImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildLambdaImageCommand;
-import static sleeper.clients.deploy.container.DockerImageCommandTestData.createNewBuildxBuilderInstanceCommand;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.createBuildxBuilderInstanceCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.pushImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.removeOldBuildxBuilderInstanceCommand;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.useBuildxBuilderInstanceCommand;
 
 @DisplayName("Upload Docker images")
 public class UploadDockerImagesToRepositoryTest extends DockerImagesTestBase {
@@ -56,8 +57,8 @@ public class UploadDockerImagesToRepositoryTest extends DockerImagesTestBase {
         String expectedCompactionTag = "www.somedocker.com/prefix/compaction:1.0.0";
         String expectedEmrTag = "www.somedocker.com/prefix/bulk-import-runner-emr-serverless:1.0.0";
         assertThat(commandsThatRan).containsExactly(
-                removeOldBuildxBuilderInstanceCommand(),
-                createNewBuildxBuilderInstanceCommand(),
+                createBuildxBuilderInstanceCommand(),
+                useBuildxBuilderInstanceCommand(),
                 buildImageCommand(expectedCommitterTag, "./docker/statestore-committer"),
                 pushImageCommand(expectedCommitterTag),
                 buildImageCommand(expectedIngestTag, "./docker/ingest"),
@@ -151,7 +152,7 @@ public class UploadDockerImagesToRepositoryTest extends DockerImagesTestBase {
                 });
         assertThat(commandsThatRan).containsExactly(
                 removeOldBuildxBuilderInstanceCommand(),
-                createNewBuildxBuilderInstanceCommand(),
+                createBuildxBuilderInstanceCommand(),
                 buildImageCommand);
     }
 

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
@@ -33,7 +33,6 @@ import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildI
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildLambdaImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.createBuildxBuilderInstanceCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.pushImageCommand;
-import static sleeper.clients.deploy.container.DockerImageCommandTestData.removeOldBuildxBuilderInstanceCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.useBuildxBuilderInstanceCommand;
 
 @DisplayName("Upload Docker images")
@@ -151,8 +150,8 @@ public class UploadDockerImagesToRepositoryTest extends DockerImagesTestBase {
                     assertThat(e.getExitCode()).isEqualTo(42);
                 });
         assertThat(commandsThatRan).containsExactly(
-                removeOldBuildxBuilderInstanceCommand(),
                 createBuildxBuilderInstanceCommand(),
+                useBuildxBuilderInstanceCommand(),
                 buildImageCommand);
     }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7034

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated existing tests
    - Tested in AWS
      - Deployed with scripts/test/deployAll
      - Added EksBulkImportStack with scripts/utility/adminClient.sh
      - Docker image layers were cached from previous build, for all images including compaction

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
