### PR TITLE
Issue 7157 - Lower log level for cache hit in TablePropertiesProvider

### DIFF
--- a/java/core/src/main/java/sleeper/core/properties/table/TablePropertiesProvider.java
+++ b/java/core/src/main/java/sleeper/core/properties/table/TablePropertiesProvider.java
@@ -108,7 +108,7 @@ public class TablePropertiesProvider {
             cache(properties, currentTime);
         } else {
             properties = currentEntry.getTableProperties();
-            LOGGER.debug("Cache hit for table {}", properties.getStatus());
+            LOGGER.trace("Cache hit for table {}", properties.getStatus());
         }
         return properties;
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7157

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
