### PR TITLE
7218 Remove wildcarded IAM policy in SystemTeskClusterStack

### DIFF
--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
@@ -141,18 +141,18 @@ public class SystemTestClusterStack extends NestedStack {
 
         List<String> roleArns = new ArrayList<>();
         if (null != ingestByQueueRoleArn && !ingestByQueueRoleArn.isEmpty()) {
-                roleArns.add(ingestByQueueRoleArn);
+            roleArns.add(ingestByQueueRoleArn);
         }
         if (null != ingestDirectRoleArn && !ingestDirectRoleArn.isEmpty()) {
-                roleArns.add(ingestDirectRoleArn);
+            roleArns.add(ingestDirectRoleArn);
         }
 
         if (!roleArns.isEmpty()) {
-                taskRole.addToPrincipalPolicy(PolicyStatement.Builder.create()
-                        .effect(Effect.ALLOW)
-                        .actions(List.of("sts:AssumeRole"))
-                        .resources(roleArns)
-                        .build());
+            taskRole.addToPrincipalPolicy(PolicyStatement.Builder.create()
+                    .effect(Effect.ALLOW)
+                    .actions(List.of("sts:AssumeRole"))
+                    .resources(roleArns)
+                    .build());
         }
     }
 }

--- a/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
+++ b/java/system-test/system-test-cdk/src/main/java/sleeper/systemtest/cdk/SystemTestClusterStack.java
@@ -49,8 +49,11 @@ import sleeper.systemtest.configuration.SystemTestPropertySetter;
 import sleeper.systemtest.configuration.SystemTestPropertyValues;
 import sleeper.systemtest.configuration.SystemTestStandaloneProperties;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.INGEST_BY_QUEUE_ROLE_ARN;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.INGEST_DIRECT_ROLE_ARN;
 import static sleeper.core.properties.instance.CommonProperty.ID;
 import static sleeper.core.properties.instance.CommonProperty.JARS_BUCKET;
 import static sleeper.systemtest.configuration.SystemTestProperty.SYSTEM_TEST_CLUSTER_NAME;
@@ -132,10 +135,24 @@ public class SystemTestClusterStack extends NestedStack {
 
         Bucket.fromBucketName(this, "JarsBucket", instanceProperties.get(JARS_BUCKET)).grantRead(taskRole);
         bucketStack.getBucket().grantReadWrite(taskRole);
-        taskRole.addToPrincipalPolicy(PolicyStatement.Builder.create()
-                .effect(Effect.ALLOW)
-                .actions(List.of("sts:AssumeRole"))
-                .resources(List.of("arn:aws:iam::*:role/sleeper-ingest-*"))
-                .build());
+
+        String ingestByQueueRoleArn = instanceProperties.get(INGEST_BY_QUEUE_ROLE_ARN);
+        String ingestDirectRoleArn = instanceProperties.get(INGEST_DIRECT_ROLE_ARN);
+
+        List<String> roleArns = new ArrayList<>();
+        if (null != ingestByQueueRoleArn && !ingestByQueueRoleArn.isEmpty()) {
+                roleArns.add(ingestByQueueRoleArn);
+        }
+        if (null != ingestDirectRoleArn && !ingestDirectRoleArn.isEmpty()) {
+                roleArns.add(ingestDirectRoleArn);
+        }
+
+        if (!roleArns.isEmpty()) {
+                taskRole.addToPrincipalPolicy(PolicyStatement.Builder.create()
+                        .effect(Effect.ALLOW)
+                        .actions(List.of("sts:AssumeRole"))
+                        .resources(roleArns)
+                        .build());
+        }
     }
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7218

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
