### PR TITLE
7269: Add Ephemeral Storage to Lambda Builder interface

### DIFF
--- a/java/deployment/cdk/src/main/java/sleeper/cdk/lambda/DockerFunctionBuilder.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/lambda/DockerFunctionBuilder.java
@@ -16,6 +16,7 @@
 package sleeper.cdk.lambda;
 
 import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.Size;
 import software.amazon.awscdk.services.ec2.ISecurityGroup;
 import software.amazon.awscdk.services.ec2.IVpc;
 import software.amazon.awscdk.services.ec2.SubnetSelection;
@@ -75,6 +76,12 @@ public class DockerFunctionBuilder implements LambdaBuilder {
     @Override
     public LambdaBuilder events(List<IEventSource> events) {
         builder.events(events);
+        return this;
+    }
+
+    @Override
+    public LambdaBuilder ephemeralStorageSize(Size ephemeralStorageSize) {
+        builder.ephemeralStorageSize(ephemeralStorageSize);
         return this;
     }
 

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/lambda/FunctionBuilder.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/lambda/FunctionBuilder.java
@@ -16,6 +16,7 @@
 package sleeper.cdk.lambda;
 
 import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.Size;
 import software.amazon.awscdk.services.ec2.ISecurityGroup;
 import software.amazon.awscdk.services.ec2.IVpc;
 import software.amazon.awscdk.services.ec2.SubnetSelection;
@@ -73,6 +74,12 @@ public class FunctionBuilder implements LambdaBuilder {
     @Override
     public LambdaBuilder events(List<IEventSource> events) {
         builder.events(events);
+        return this;
+    }
+
+    @Override
+    public LambdaBuilder ephemeralStorageSize(Size ephemeralStorageSize) {
+        builder.ephemeralStorageSize(ephemeralStorageSize);
         return this;
     }
 

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/lambda/LambdaBuilder.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/lambda/LambdaBuilder.java
@@ -16,6 +16,7 @@
 package sleeper.cdk.lambda;
 
 import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.Size;
 import software.amazon.awscdk.services.ec2.ISecurityGroup;
 import software.amazon.awscdk.services.ec2.IVpc;
 import software.amazon.awscdk.services.ec2.SubnetSelection;
@@ -90,6 +91,15 @@ public interface LambdaBuilder {
      * @return        this builder
      */
     LambdaBuilder events(List<IEventSource> events);
+
+    /**
+     * Sets the ephemeral storage size for the lambda. See
+     * {@link software.amazon.awscdk.services.lambda.Function.Builder#ephemeralStorageSize(Size)}.
+     *
+     * @param  ephemeralStorageSize the ephemeral storage size
+     * @return                      this builder
+     */
+    LambdaBuilder ephemeralStorageSize(Size ephemeralStorageSize);
 
     /**
      * Sets the reserved concurrent executions. See


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7269

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - No existing unit tests exist for these classes as they just pass through details to aws classes. 
    - It will be manually tested through 7214

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
