### PR TITLE
Issue 7267 - Document conventions for null handling

### DIFF
--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -57,6 +57,19 @@ public Partition(Builder builder) {
 }
 ```
 
+## Null handling
+
+Whenever it's necessary to have an empty value, we prefer a non-null value, e.g. a no-op instead of a null for a
+Supplier object.
+
+We avoid any need for null checks, except in data classes. In a data class, a field can be null if it's optional by
+necessity. We prefer to use an Optional to expose the value outside the class. Wherever possible, we avoid using
+null values in a class responsible for logic, wiring or high level policy.
+
+We avoid ever using null as an uninitialised value. We avoid leaving fields uninitialised, except in a builder, where
+fields will be set before the object is built. Wherever possible we ensure an object is fully initialised
+after it's constructed. We avoid passing null as a parameter to a function.
+
 ## Ordering within a Java class
 
 We try to keep to this ordering of elements in a class declaration:

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -59,16 +59,34 @@ public Partition(Builder builder) {
 
 ## Null handling
 
-Whenever it's necessary to have an empty value, we prefer a non-null value, e.g. a no-op instead of a null for a
-Supplier object.
+When we need an empty value, we prefer a non-null value, e.g. a no-op instead of a null for a Supplier object. Many
+types have a more natural empty value than a null. Usually it is not necessary to wrap a value in an Optional to achieve
+this, but it can be useful to clarify the optionality in a limited context.
 
-We avoid any need for null checks, except in data classes. In a data class, a field can be null if it's optional by
-necessity. We prefer to use an Optional to expose the value outside the class. Wherever possible, we avoid using
-null values in a class responsible for logic, wiring or high level policy.
+We avoid using an Optional as a function parameter or a field. A null can be used for these purposes, but we use
+various patterns to avoid dealing with a null explicitly.
 
-We avoid ever using null as an uninitialised value. We avoid leaving fields uninitialised, except in a builder, where
-fields will be set before the object is built. Wherever possible we ensure an object is fully initialised
-after it's constructed. We avoid passing null as a parameter to a function.
+When a class does contain a nullable field or an optional parameter, we expect it to bear the responsibility of managing
+null values within a limited context, internal to the class. It should present an API that avoids the need for null
+checks, or passing a null explicitly. For example, we avoid passing a null to test helper methods.
+
+We avoid using null as an uninitialised value for later initialisation. We avoid leaving fields uninitialised, except in
+a builder, where fields will be set before the object is built. Wherever possible we ensure an object is fully
+initialised after it's constructed.
+
+### Patterns for optional values
+
+We consider using multiple function signatures, where one includes the optional parameter as non-optional, and the other
+doesn't include it at all.
+
+We consider a [parameter object](https://refactoring.guru/introduce-parameter-object), where setting the null can be the
+responsibility of a builder or a static factory method.
+
+A builder pattern is often helpful for managing optional fields, where we can document explicitly which are optional,
+and we don't need to call the setter methods when not initialising those fields.
+
+In a data class, a field can be null if it's optional by necessity. An Optional can be used to expose the value outside
+the class. Wherever possible, we avoid using null values in a class responsible for logic, wiring or high level policy.
 
 ## Ordering within a Java class
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7267

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Just documentation

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
