### PR TITLE
7276: Improve usability of specifying instance configuration in CDK app

### DIFF
--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -107,16 +107,16 @@ read from the same directory either way). The following commands will deploy a S
 deployed instance to the version of Sleeper you're using:
 
 ```bash
-INSTANCE_PROPERTIES=/path/to/instance.properties
+CONFIGURATION_DIR=/path/to/configuration-dir # Contains instance.properties, tables/, etc.
 INSTANCE_ID=my-instance-id
 VPC_ID=my-vpc-id
 SUBNETS=my-subnet-1,my-subnet-2,my-subnet-3
 SCRIPTS_DIR=./scripts # This is from the root of the Sleeper Git repository
 VERSION=$(cat "$SCRIPTS_DIR/templates/version.txt")
 cdk deploy --all --app "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperArtefactsCdkApp" -c id=$INSTANCE_ID
-"$SCRIPTS_DIR/deploy/uploadArtefacts.sh" --id $INSTANCE_ID --properties $INSTANCE_PROPERTIES
+"$SCRIPTS_DIR/deploy/uploadArtefacts.sh" --id $INSTANCE_ID --properties "$CONFIGURATION_DIR/instance.properties"
 cdk deploy --all -a "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperCdkApp" \
-    -c id=$INSTANCE_ID -c propertiesfile="$INSTANCE_PROPERTIES" \
+    -c id=$INSTANCE_ID -c configurationdir="$CONFIGURATION_DIR" \
     -c vpc=$VPC_ID -c subnets=$SUBNETS -c newinstance=true
 ```
 
@@ -126,7 +126,7 @@ command.
 If you'd like to include random data generation, use the demonstration CDK app instead.
 
 ```bash
-INSTANCE_PROPERTIES=/path/to/instance.properties
+CONFIGURATION_DIR=/path/to/configuration-dir # Contains instance.properties, tables/, etc.
 INSTANCE_ID=my-instance-id
 VPC_ID=my-vpc-id
 SUBNETS=my-subnet-1,my-subnet-2,my-subnet-3
@@ -134,9 +134,9 @@ SCRIPTS_DIR=./scripts # This is from the root of the Sleeper Git repository
 VERSION=$(cat "$SCRIPTS_DIR/templates/version.txt")
 cdk deploy --all --app "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperArtefactsCdkApp" \
     -c id=$INSTANCE_ID
-"$SCRIPTS_DIR/deploy/uploadArtefacts.sh" --id $INSTANCE_ID --properties $INSTANCE_PROPERTIES --cdk-app demonstration
+"$SCRIPTS_DIR/deploy/uploadArtefacts.sh" --id $INSTANCE_ID --properties "$CONFIGURATION_DIR/instance.properties" --cdk-app demonstration
 cdk deploy --all -a "java -cp $SCRIPTS_DIR/jars/system-test-cdk-$VERSION.jar sleeper.systemtest.cdk.SleeperDemonstrationCdkApp" \
-    -c id=$INSTANCE_ID -c propertiesfile="$INSTANCE_PROPERTIES" \
+    -c id=$INSTANCE_ID -c configurationdir="$CONFIGURATION_DIR" \
     -c vpc=$VPC_ID -c subnets=$SUBNETS -c newinstance=true
 # Write some random data
 "$SCRIPTS_DIR/utility/addTable.sh" $INSTANCE_ID system-test
@@ -151,11 +151,11 @@ If the artefacts and the Sleeper instance are each deployed in their own CDK app
 CLI. You may need to delete the Sleeper instance before deleting the artefacts used to deploy it. Here's an example:
 
 ```bash
-INSTANCE_PROPERTIES=/path/to/instance.properties
+CONFIGURATION_DIR=/path/to/configuration-dir # Contains instance.properties, tables/, etc.
 INSTANCE_ID=my-instance-id
 SCRIPTS_DIR=./scripts # From the root of the Sleeper Git repository
 VERSION=$(cat "$SCRIPTS_DIR/templates/version.txt")
 
-cdk destroy --all -c id=$INSTANCE_ID -c propertiesfile="$INSTANCE_PROPERTIES" -c validate=false -a "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperCdkApp"
+cdk destroy --all -c id=$INSTANCE_ID -c configurationdir="$CONFIGURATION_DIR" -c validate=false -a "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperCdkApp"
 cdk destroy --all -c id=$INSTANCE_ID -a "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperArtefactsCdkApp"
 ```

--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -101,10 +101,20 @@ described in the section above. You can either use the instance ID as the deploy
 set the deployment ID in the CDK context variable `artefactsId`, or the instance property `sleeper.artefacts.deployment`.
 
 You can use the same CDK apps used by the automated scripts, or your own CDK configuration. We'll give examples with the
-CDK apps used by the automated scripts. The `propertiesfile` context variable can be set either to the path of the
-`instance.properties` file or to the path of the instance configuration directory containing it (table properties are
-read from the same directory either way). The following commands will deploy a Sleeper instance, or upgrade a previously
-deployed instance to the version of Sleeper you're using:
+CDK apps used by the automated scripts.
+
+When deploying via the CDK, choose one of two context variables to point at your configuration:
+
+* `-c propertiesfile=<path>` — the path to your `instance.properties` file. Only this file and an adjacent
+  `tags.properties` are read; table properties are not loaded.
+* `-c configurationdir=<path>` — the path to the root configuration directory. The whole directory structure is read:
+  `instance.properties`, `tags.properties`, `table.properties`, `schema.json`, `splits.txt`, and any tables under a
+  `tables/` subdirectory. Passing the `instance.properties` file path here also works — it falls back to the directory
+  containing it.
+
+Set exactly one of these; setting both, or neither, is an error.
+
+The following commands will deploy a Sleeper instance, or upgrade a previously deployed instance to the version of Sleeper you're using:
 
 ```bash
 CONFIGURATION_DIR=/path/to/configuration-dir # Contains instance.properties, tables/, etc.

--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -107,10 +107,9 @@ When deploying via the CDK, choose one of two context variables to point at your
 
 * `-c propertiesfile=<path>` — the path to your `instance.properties` file. Only this file and an adjacent
   `tags.properties` are read; table properties are not loaded.
-* `-c configurationdir=<path>` — the path to the root configuration directory. The whole directory structure is read:
-  `instance.properties`, `tags.properties`, `table.properties`, `schema.json`, `splits.txt`, and any tables under a
-  `tables/` subdirectory. Passing the `instance.properties` file path here also works — it falls back to the directory
-  containing it.
+* `-c configurationdir=<path>` — the path to the root configuration directory. The whole directory structure is read including `instance.properties` and `table.properties`. Passing the `instance.properties` file path here also works — it falls back to the directory
+  containing it. For a full description of what can be defined in the directory, refer to the configuration folder structure in the
+   [instant configuration documentation](./instance-configuration.md#configuration-folder-structure).
 
 Set exactly one of these; setting both, or neither, is an error.
 

--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -101,19 +101,7 @@ described in the section above. You can either use the instance ID as the deploy
 set the deployment ID in the CDK context variable `artefactsId`, or the instance property `sleeper.artefacts.deployment`.
 
 You can use the same CDK apps used by the automated scripts, or your own CDK configuration. We'll give examples with the
-CDK apps used by the automated scripts.
-
-When deploying via the CDK, choose one of two context variables to point at your configuration:
-
-* `-c propertiesfile=<path>` — the path to your `instance.properties` file. Only this file and an adjacent
-  `tags.properties` are read; table properties are not loaded.
-* `-c configurationdir=<path>` — the path to the root configuration directory. The whole directory structure is read including `instance.properties` and `table.properties`. Passing the `instance.properties` file path here also works — it falls back to the directory
-  containing it. For a full description of what can be defined in the directory, refer to the configuration folder structure in the
-   [instant configuration documentation](./instance-configuration.md#configuration-folder-structure).
-
-Set exactly one of these; setting both, or neither, is an error.
-
-The following commands will deploy a Sleeper instance, or upgrade a previously deployed instance to the version of Sleeper you're using:
+CDK apps used by the automated scripts. The following commands will deploy a Sleeper instance, or upgrade a previously deployed instance to the version of Sleeper you're using:
 
 ```bash
 CONFIGURATION_DIR=/path/to/configuration-dir # Contains instance.properties, tables/, etc.
@@ -168,3 +156,15 @@ VERSION=$(cat "$SCRIPTS_DIR/templates/version.txt")
 cdk destroy --all -c id=$INSTANCE_ID -c configurationdir="$CONFIGURATION_DIR" -c validate=false -a "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperCdkApp"
 cdk destroy --all -c id=$INSTANCE_ID -a "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperArtefactsCdkApp"
 ```
+
+### CDK context variables
+
+When deploying via the CDK, choose one of two context variables to point at your configuration:
+
+* `-c propertiesfile=<path>` — the path to your `instance.properties` file. Only this file and an adjacent
+  `tags.properties` are read; table properties are not loaded.
+* `-c configurationdir=<path>` — the path to the root configuration directory. The whole directory structure is read including `instance.properties` and `table.properties`. Passing the `instance.properties` file path here also works — it falls back to the directory
+  containing it. For a full description of what can be defined in the directory, refer to the configuration folder structure in the
+   [instant configuration documentation](./instance-configuration.md#configuration-folder-structure).
+
+Set exactly one of these; setting both, or neither, is an error.

--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -101,7 +101,9 @@ described in the section above. You can either use the instance ID as the deploy
 set the deployment ID in the CDK context variable `artefactsId`, or the instance property `sleeper.artefacts.deployment`.
 
 You can use the same CDK apps used by the automated scripts, or your own CDK configuration. We'll give examples with the
-CDK apps used by the automated scripts. The following commands will deploy a Sleeper instance, or upgrade a previously
+CDK apps used by the automated scripts. The `propertiesfile` context variable can be set either to the path of the
+`instance.properties` file or to the path of the instance configuration directory containing it (table properties are
+read from the same directory either way). The following commands will deploy a Sleeper instance, or upgrade a previously
 deployed instance to the version of Sleeper you're using:
 
 ```bash

--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -157,7 +157,7 @@ cdk destroy --all -c id=$INSTANCE_ID -c configurationdir="$CONFIGURATION_DIR" -c
 cdk destroy --all -c id=$INSTANCE_ID -a "java -cp $SCRIPTS_DIR/jars/cdk-$VERSION.jar sleeper.cdk.SleeperArtefactsCdkApp"
 ```
 
-### CDK context variables
+#### CDK context variables
 
 When deploying via the CDK, choose one of two context variables to point at your configuration:
 

--- a/docs/deployment/instance-configuration.md
+++ b/docs/deployment/instance-configuration.md
@@ -31,6 +31,10 @@ The `.properties` files are Java properties files. The directory containing `ins
 the root directory of your configuration. You can find descriptions of all properties in the
 system [here](usage/property-master.md).
 
+When deploying via the CDK, the `-c propertiesfile=...` context variable may be set either to the path of the
+`instance.properties` file or to the path of this root configuration directory; table properties are loaded from
+the same directory either way.
+
 You can optionally create a `tags.properties` file next to your `instance.properties`, to apply tags to AWS resources
 deployed by Sleeper. An example tags.properties file can be found [here](../../example/full/tags.properties).
 

--- a/docs/deployment/instance-configuration.md
+++ b/docs/deployment/instance-configuration.md
@@ -31,9 +31,16 @@ The `.properties` files are Java properties files. The directory containing `ins
 the root directory of your configuration. You can find descriptions of all properties in the
 system [here](usage/property-master.md).
 
-When deploying via the CDK, the `-c propertiesfile=...` context variable may be set either to the path of the
-`instance.properties` file or to the path of this root configuration directory; table properties are loaded from
-the same directory either way.
+When deploying via the CDK, choose one of two context variables to point at your configuration:
+
+* `-c propertiesfile=<path>` — the path to your `instance.properties` file. Only this file and an adjacent
+  `tags.properties` are read; table properties are not loaded.
+* `-c configurationdir=<path>` — the path to the root configuration directory. The whole directory structure is read:
+  `instance.properties`, `tags.properties`, `table.properties`, `schema.json`, `splits.txt`, and any tables under a
+  `tables/` subdirectory. Passing the `instance.properties` file path here also works — it falls back to the directory
+  containing it.
+
+Set exactly one of these; setting both, or neither, is an error.
 
 You can optionally create a `tags.properties` file next to your `instance.properties`, to apply tags to AWS resources
 deployed by Sleeper. An example tags.properties file can be found [here](../../example/full/tags.properties).

--- a/docs/deployment/instance-configuration.md
+++ b/docs/deployment/instance-configuration.md
@@ -31,17 +31,6 @@ The `.properties` files are Java properties files. The directory containing `ins
 the root directory of your configuration. You can find descriptions of all properties in the
 system [here](usage/property-master.md).
 
-When deploying via the CDK, choose one of two context variables to point at your configuration:
-
-* `-c propertiesfile=<path>` — the path to your `instance.properties` file. Only this file and an adjacent
-  `tags.properties` are read; table properties are not loaded.
-* `-c configurationdir=<path>` — the path to the root configuration directory. The whole directory structure is read:
-  `instance.properties`, `tags.properties`, `table.properties`, `schema.json`, `splits.txt`, and any tables under a
-  `tables/` subdirectory. Passing the `instance.properties` file path here also works — it falls back to the directory
-  containing it.
-
-Set exactly one of these; setting both, or neither, is an error.
-
 You can optionally create a `tags.properties` file next to your `instance.properties`, to apply tags to AWS resources
 deployed by Sleeper. An example tags.properties file can be found [here](../../example/full/tags.properties).
 

--- a/java/clients/src/main/java/sleeper/clients/admin/properties/AdminClientPropertiesStore.java
+++ b/java/clients/src/main/java/sleeper/clients/admin/properties/AdminClientPropertiesStore.java
@@ -109,7 +109,7 @@ public class AdminClientPropertiesStore {
         saveInstanceProperties(properties, () -> {
             uploadDockerImages.upload(UploadDockerImagesToEcrRequest.forDeployment(properties, cdkApp, dockerImageConfiguration));
             LOGGER.info("Deploying by CDK");
-            cdk.invoke(cdkApp, CdkCommand.deployPropertiesChange(generatedDirectory.resolve("instance.properties")));
+            cdk.invoke(cdkApp, CdkCommand.deployPropertiesChange(generatedDirectory));
         });
     }
 

--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployInstance.java
@@ -91,7 +91,7 @@ public class DeployInstance {
         LOGGER.info("-------------------------------------------------------");
         LOGGER.info("Deploying Stacks");
         LOGGER.info("-------------------------------------------------------");
-        invokeCdk.invoke(request.getCdkApp(), request.getCdkCommand().withPropertiesFile(configurationDirectory));
+        invokeCdk.invoke(request.getCdkApp(), request.getCdkCommand().withConfigurationDirectory(configurationDirectory));
     }
 
     public interface WriteLocalProperties {

--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployInstance.java
@@ -87,11 +87,11 @@ public class DeployInstance {
         syncJars.sync(SyncJarsRequest.from(instanceProperties));
         dockerImageUploader.upload(
                 UploadDockerImagesToEcrRequest.forDeployment(instanceProperties, request.getCdkApp(), DockerImageConfiguration.getDefault()));
-        Path propertiesFile = writeLocalProperties.write(instanceConfig);
+        Path configurationDirectory = writeLocalProperties.write(instanceConfig);
         LOGGER.info("-------------------------------------------------------");
         LOGGER.info("Deploying Stacks");
         LOGGER.info("-------------------------------------------------------");
-        invokeCdk.invoke(request.getCdkApp(), request.getCdkCommand().withPropertiesFile(propertiesFile));
+        invokeCdk.invoke(request.getCdkApp(), request.getCdkCommand().withPropertiesFile(configurationDirectory));
     }
 
     public interface WriteLocalProperties {
@@ -109,7 +109,7 @@ public class DeployInstance {
                 SaveLocalProperties.saveToDirectory(directory,
                         instanceConfig.getInstanceProperties(),
                         instanceConfig.getTableProperties().stream());
-                return directory.resolve("instance.properties");
+                return directory;
             };
         }
     }

--- a/java/clients/src/main/java/sleeper/clients/util/cdk/CdkCommand.java
+++ b/java/clients/src/main/java/sleeper/clients/util/cdk/CdkCommand.java
@@ -31,8 +31,8 @@ public record CdkCommand(List<String> command, List<String> arguments) {
                 .build();
     }
 
-    public static CdkCommand deployPropertiesChange(Path propertiesFile) {
-        return builder().deploy().propertiesFile(propertiesFile).build();
+    public static CdkCommand deployPropertiesChange(Path configurationDirectory) {
+        return builder().deploy().configurationDirectory(configurationDirectory).build();
     }
 
     public static CdkCommand deploySystemTestStandalone(Path propertiesFile) {
@@ -63,6 +63,10 @@ public record CdkCommand(List<String> command, List<String> arguments) {
         return builder().command(command).propertiesFile(propertiesFile).arguments(arguments).build();
     }
 
+    public CdkCommand withConfigurationDirectory(Path configurationDirectory) {
+        return builder().command(command).configurationDirectory(configurationDirectory).arguments(arguments).build();
+    }
+
     public static final class Builder {
         private List<String> command;
         private List<String> arguments = new ArrayList<>();
@@ -91,6 +95,10 @@ public record CdkCommand(List<String> command, List<String> arguments) {
 
         public Builder propertiesFile(Path propertiesFile) {
             return context("propertiesfile", propertiesFile.toString());
+        }
+
+        public Builder configurationDirectory(Path configurationDirectory) {
+            return context("configurationdir", configurationDirectory.toString());
         }
 
         public Builder ensureNewInstance(boolean ensureNewInstance) {

--- a/java/clients/src/test/java/sleeper/clients/admin/InstanceConfigurationScreenTest.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/InstanceConfigurationScreenTest.java
@@ -468,7 +468,7 @@ class InstanceConfigurationScreenTest extends AdminClientInMemoryTestBase {
                     "-a", "java -cp \"./test/jars/cdk-1.2.3.jar\" sleeper.cdk.SleeperCdkApp",
                     "deploy",
                     "--require-approval", "never",
-                    "-c", "propertiesfile=./test/generated",
+                    "-c", "configurationdir=./test/generated",
                     "*")));
             // And this is displayed to the user
             assertThat(output).isEqualTo(DISPLAY_MAIN_SCREEN +

--- a/java/clients/src/test/java/sleeper/clients/admin/InstanceConfigurationScreenTest.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/InstanceConfigurationScreenTest.java
@@ -468,7 +468,7 @@ class InstanceConfigurationScreenTest extends AdminClientInMemoryTestBase {
                     "-a", "java -cp \"./test/jars/cdk-1.2.3.jar\" sleeper.cdk.SleeperCdkApp",
                     "deploy",
                     "--require-approval", "never",
-                    "-c", "propertiesfile=./test/generated/instance.properties",
+                    "-c", "propertiesfile=./test/generated",
                     "*")));
             // And this is displayed to the user
             assertThat(output).isEqualTo(DISPLAY_MAIN_SCREEN +

--- a/java/clients/src/test/java/sleeper/clients/admin/properties/AdminClientPropertiesStoreIT.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/properties/AdminClientPropertiesStoreIT.java
@@ -409,7 +409,7 @@ public class AdminClientPropertiesStoreIT extends AdminClientITBase {
             tablePropertiesHolder.clear();
             loadTablesFromDirectory(properties, tempDir).forEach(tablePropertiesHolder::add);
             return null;
-        }).when(cdk).invoke(any(), eq(CdkCommand.deployPropertiesChange(propertiesFile())));
+        }).when(cdk).invoke(any(), eq(CdkCommand.deployPropertiesChange(configurationDirectory())));
     }
 
     private void createTableInS3(String tableName) {
@@ -434,10 +434,10 @@ public class AdminClientPropertiesStoreIT extends AdminClientITBase {
     }
 
     private void verifyAnyAppDeployedWithCdk() throws Exception {
-        verify(cdk).invoke(any(), eq(CdkCommand.deployPropertiesChange(propertiesFile())));
+        verify(cdk).invoke(any(), eq(CdkCommand.deployPropertiesChange(configurationDirectory())));
     }
 
     private void doThrowWhenPropertiesDeployedWithCdk(Throwable throwable) throws Exception {
-        doThrow(throwable).when(cdk).invoke(any(), eq(CdkCommand.deployPropertiesChange(propertiesFile())));
+        doThrow(throwable).when(cdk).invoke(any(), eq(CdkCommand.deployPropertiesChange(configurationDirectory())));
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/admin/testutils/AdminClientITBase.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/testutils/AdminClientITBase.java
@@ -104,7 +104,7 @@ public abstract class AdminClientITBase extends AdminClientTestBase {
         tablePropertiesStore.save(tableProperties);
     }
 
-    protected Path propertiesFile() {
-        return tempDir.resolve("instance.properties");
+    protected Path configurationDirectory() {
+        return tempDir;
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/util/cdk/InvokeCdkTest.java
+++ b/java/clients/src/test/java/sleeper/clients/util/cdk/InvokeCdkTest.java
@@ -40,6 +40,7 @@ class InvokeCdkTest {
 
     private final List<CommandPipeline> commandsThatRan = new ArrayList<>();
     private final Path propertiesFile = Path.of("instance.properties");
+    private final Path configurationDirectory = Path.of("config");
 
     private InvokeCdk cdk() {
         return cdk(recordCommandsRun(commandsThatRan));
@@ -59,7 +60,7 @@ class InvokeCdkTest {
         @Test
         void shouldDeployStandardCdkApp() throws IOException, InterruptedException {
             // When
-            cdk().invoke(SleeperInternalCdkApp.STANDARD, CdkCommand.deployPropertiesChange(propertiesFile));
+            cdk().invoke(SleeperInternalCdkApp.STANDARD, CdkCommand.deployPropertiesChange(configurationDirectory));
 
             // Then
             assertThat(commandsThatRan).containsExactly(pipeline(command(
@@ -67,21 +68,21 @@ class InvokeCdkTest {
                     "-a", "java -cp \"./cdk-1.0.jar\" sleeper.cdk.SleeperCdkApp",
                     "deploy",
                     "--require-approval", "never",
-                    "-c", "propertiesfile=instance.properties",
+                    "-c", "configurationdir=config",
                     "*")));
         }
 
         @Test
         void shouldDeployDemonstrationCdkApp() throws IOException, InterruptedException {
             // When
-            cdk().invoke(SleeperInternalCdkApp.DEMONSTRATION, CdkCommand.deployPropertiesChange(propertiesFile));
+            cdk().invoke(SleeperInternalCdkApp.DEMONSTRATION, CdkCommand.deployPropertiesChange(configurationDirectory));
 
             // Then
             assertThat(commandsThatRan).containsExactly(pipeline(command("cdk",
                     "-a", "java -cp \"./system-test-cdk-1.0.jar\" sleeper.systemtest.cdk.SleeperDemonstrationCdkApp",
                     "deploy",
                     "--require-approval", "never",
-                    "-c", "propertiesfile=instance.properties",
+                    "-c", "configurationdir=config",
                     "*")));
         }
 

--- a/java/core/src/main/java/sleeper/core/deploy/SleeperInstanceConfiguration.java
+++ b/java/core/src/main/java/sleeper/core/deploy/SleeperInstanceConfiguration.java
@@ -68,13 +68,13 @@ public class SleeperInstanceConfiguration {
     /**
      * Creates a configuration for a new instance, setting tables from templates if not specified.
      *
-     * @param  configurationPath the path to the instance configuration directory, or to the instance.properties file
-     * @param  fromTemplates     the settings to load the templates
-     * @return                   the instance configuration
+     * @param  instancePropertiesPath the path to the local configuration instance properties file
+     * @param  fromTemplates          the settings to load the templates
+     * @return                        the instance configuration
      */
     public static SleeperInstanceConfiguration forNewInstanceDefaultingTables(
-            Path configurationPath, SleeperInstanceConfigurationFromTemplates fromTemplates) {
-        SleeperInstanceConfiguration configuration = fromLocalConfiguration(configurationPath);
+            Path instancePropertiesPath, SleeperInstanceConfigurationFromTemplates fromTemplates) {
+        SleeperInstanceConfiguration configuration = fromLocalConfigurationDirectory(instancePropertiesPath);
         if (configuration.getTableProperties().isEmpty()) {
             configuration = configuration.withTableProperties(instanceProperties -> List.of(
                     fromTemplates.loadTableProperties(instanceProperties)));
@@ -86,15 +86,15 @@ public class SleeperInstanceConfiguration {
      * Creates a configuration for a new instance, setting instance properties from templates if not
      * specified.
      *
-     * @param  configurationPath the path to the instance configuration directory or to the instance.properties file,
-     *                           or null if not present
-     * @param  templatesDir      the directory to load the templates from
-     * @return                   the instance configuration
+     * @param  instancePropertiesPath the path to the local configuration instance properties file, or null if not
+     *                                present
+     * @param  templatesDir           the directory to load the templates from
+     * @return                        the instance configuration
      */
     public static SleeperInstanceConfiguration forNewInstanceDefaultingInstance(
-            Path configurationPath, Path templatesDir) {
-        if (configurationPath != null) {
-            return fromLocalConfiguration(configurationPath);
+            Path instancePropertiesPath, Path templatesDir) {
+        if (instancePropertiesPath != null) {
+            return fromLocalConfigurationDirectory(instancePropertiesPath);
         } else {
             return new SleeperInstanceConfiguration(SleeperInstanceConfigurationFromTemplates.loadInstanceProperties(templatesDir),
                     List.of());
@@ -102,27 +102,40 @@ public class SleeperInstanceConfiguration {
     }
 
     /**
-     * Creates an instance configuration from local files. The path may be either the instance configuration
-     * directory or the instance.properties file itself. When given the configuration directory, all configuration
-     * files defined by the directory structure (instance.properties, tags.properties, table.properties, schema.json,
-     * splits.txt, and any tables under a tables/ subdirectory) are read. When given the instance.properties file, only
-     * that file and an adjacent tags.properties are read - table properties are not loaded.
+     * Creates an instance configuration from a local instance.properties file. Only that file and an adjacent
+     * tags.properties are read - table properties are not loaded. To load the full configuration from a directory
+     * structure (instance.properties, tags.properties, table.properties, schema.json, splits.txt, and any tables
+     * under a tables/ subdirectory), use {@link #fromLocalConfigurationDirectory(Path)}.
      *
-     * @param  configurationPath the path to the instance configuration directory, or to the instance.properties file
-     * @return                   the instance configuration
+     * @param  instancePropertiesFile the path to the instance.properties file
+     * @return                        the instance configuration
      */
-    public static SleeperInstanceConfiguration fromLocalConfiguration(Path configurationPath) {
-        InstanceProperties instanceProperties;
-        List<TableProperties> tableProperties;
-        if (Files.isDirectory(configurationPath)) {
-            instanceProperties = LoadLocalProperties.loadInstancePropertiesNoValidationFromDirectory(configurationPath);
-            tableProperties = LoadLocalProperties
-                    .loadTablesFromDirectoryNoValidation(instanceProperties, configurationPath)
-                    .collect(Collectors.toUnmodifiableList());
-        } else {
-            instanceProperties = LoadLocalProperties.loadInstancePropertiesNoValidation(configurationPath);
-            tableProperties = List.of();
+    public static SleeperInstanceConfiguration fromLocalConfiguration(Path instancePropertiesFile) {
+        InstanceProperties instanceProperties = LoadLocalProperties.loadInstancePropertiesNoValidation(instancePropertiesFile);
+        return SleeperInstanceConfiguration.builder()
+                .instanceProperties(instanceProperties)
+                .tableProperties(List.of()).build();
+    }
+
+    /**
+     * Creates an instance configuration from a local configuration directory. All configuration files defined by the
+     * directory structure are read: instance.properties, tags.properties, table.properties, schema.json, splits.txt,
+     * and any tables under a tables/ subdirectory. If the given path points to a file rather than a directory (e.g.
+     * the instance.properties file itself), the configuration is loaded from the directory containing that file.
+     *
+     * @param  configurationDirectory the path to the configuration directory, or to a file within it
+     * @return                        the instance configuration
+     */
+    public static SleeperInstanceConfiguration fromLocalConfigurationDirectory(Path configurationDirectory) {
+        Path directory = configurationDirectory;
+        if (!Files.isDirectory(directory)) {
+            Path parent = directory.getParent();
+            directory = parent != null ? parent : Path.of(".");
         }
+        InstanceProperties instanceProperties = LoadLocalProperties.loadInstancePropertiesNoValidationFromDirectory(directory);
+        List<TableProperties> tableProperties = LoadLocalProperties
+                .loadTablesFromDirectoryNoValidation(instanceProperties, directory)
+                .collect(Collectors.toUnmodifiableList());
         return SleeperInstanceConfiguration.builder()
                 .instanceProperties(instanceProperties)
                 .tableProperties(tableProperties).build();

--- a/java/core/src/main/java/sleeper/core/deploy/SleeperInstanceConfiguration.java
+++ b/java/core/src/main/java/sleeper/core/deploy/SleeperInstanceConfiguration.java
@@ -22,6 +22,7 @@ import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.local.LoadLocalProperties;
 import sleeper.core.properties.table.TableProperties;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
@@ -67,13 +68,13 @@ public class SleeperInstanceConfiguration {
     /**
      * Creates a configuration for a new instance, setting tables from templates if not specified.
      *
-     * @param  instancePropertiesPath the path to the local configuration instance properties file
-     * @param  fromTemplates          the settings to load the templates
-     * @return                        the instance configuration
+     * @param  configurationPath the path to the instance configuration directory, or to the instance.properties file
+     * @param  fromTemplates     the settings to load the templates
+     * @return                   the instance configuration
      */
     public static SleeperInstanceConfiguration forNewInstanceDefaultingTables(
-            Path instancePropertiesPath, SleeperInstanceConfigurationFromTemplates fromTemplates) {
-        SleeperInstanceConfiguration configuration = fromLocalConfiguration(instancePropertiesPath);
+            Path configurationPath, SleeperInstanceConfigurationFromTemplates fromTemplates) {
+        SleeperInstanceConfiguration configuration = fromLocalConfiguration(configurationPath);
         if (configuration.getTableProperties().isEmpty()) {
             configuration = configuration.withTableProperties(instanceProperties -> List.of(
                     fromTemplates.loadTableProperties(instanceProperties)));
@@ -85,15 +86,15 @@ public class SleeperInstanceConfiguration {
      * Creates a configuration for a new instance, setting instance properties from templates if not
      * specified.
      *
-     * @param  instancePropertiesPath the path to the local configuration instance properties file, or null if not
-     *                                present
-     * @param  templatesDir           the directory to load the templates from
-     * @return                        the instance configuration
+     * @param  configurationPath the path to the instance configuration directory or to the instance.properties file,
+     *                           or null if not present
+     * @param  templatesDir      the directory to load the templates from
+     * @return                   the instance configuration
      */
     public static SleeperInstanceConfiguration forNewInstanceDefaultingInstance(
-            Path instancePropertiesPath, Path templatesDir) {
-        if (instancePropertiesPath != null) {
-            return fromLocalConfiguration(instancePropertiesPath);
+            Path configurationPath, Path templatesDir) {
+        if (configurationPath != null) {
+            return fromLocalConfiguration(configurationPath);
         } else {
             return new SleeperInstanceConfiguration(SleeperInstanceConfigurationFromTemplates.loadInstanceProperties(templatesDir),
                     List.of());
@@ -101,16 +102,27 @@ public class SleeperInstanceConfiguration {
     }
 
     /**
-     * Creates an instance configuration from local files.
+     * Creates an instance configuration from local files. The path may be either the instance configuration
+     * directory or the instance.properties file itself. When given the configuration directory, all configuration
+     * files defined by the directory structure (instance.properties, tags.properties, table.properties, schema.json,
+     * splits.txt, and any tables under a tables/ subdirectory) are read. When given the instance.properties file, only
+     * that file and an adjacent tags.properties are read - table properties are not loaded.
      *
-     * @param  instancePropertiesPath the path to the local configuration instance properties file
-     * @return                        the instance configuration
+     * @param  configurationPath the path to the instance configuration directory, or to the instance.properties file
+     * @return                   the instance configuration
      */
-    public static SleeperInstanceConfiguration fromLocalConfiguration(Path instancePropertiesPath) {
-        InstanceProperties instanceProperties = LoadLocalProperties.loadInstancePropertiesNoValidation(instancePropertiesPath);
-        List<TableProperties> tableProperties = LoadLocalProperties
-                .loadTablesFromInstancePropertiesFileNoValidation(instanceProperties, instancePropertiesPath)
-                .collect(Collectors.toUnmodifiableList());
+    public static SleeperInstanceConfiguration fromLocalConfiguration(Path configurationPath) {
+        InstanceProperties instanceProperties;
+        List<TableProperties> tableProperties;
+        if (Files.isDirectory(configurationPath)) {
+            instanceProperties = LoadLocalProperties.loadInstancePropertiesNoValidationFromDirectory(configurationPath);
+            tableProperties = LoadLocalProperties
+                    .loadTablesFromDirectoryNoValidation(instanceProperties, configurationPath)
+                    .collect(Collectors.toUnmodifiableList());
+        } else {
+            instanceProperties = LoadLocalProperties.loadInstancePropertiesNoValidation(configurationPath);
+            tableProperties = List.of();
+        }
         return SleeperInstanceConfiguration.builder()
                 .instanceProperties(instanceProperties)
                 .tableProperties(tableProperties).build();

--- a/java/core/src/main/java/sleeper/core/deploy/SleeperInstanceConfiguration.java
+++ b/java/core/src/main/java/sleeper/core/deploy/SleeperInstanceConfiguration.java
@@ -68,13 +68,13 @@ public class SleeperInstanceConfiguration {
     /**
      * Creates a configuration for a new instance, setting tables from templates if not specified.
      *
-     * @param  instancePropertiesPath the path to the local configuration instance properties file
-     * @param  fromTemplates          the settings to load the templates
-     * @return                        the instance configuration
+     * @param  configurationPath the path to the local configuration instance properties file
+     * @param  fromTemplates     the settings to load the templates
+     * @return                   the instance configuration
      */
     public static SleeperInstanceConfiguration forNewInstanceDefaultingTables(
-            Path instancePropertiesPath, SleeperInstanceConfigurationFromTemplates fromTemplates) {
-        SleeperInstanceConfiguration configuration = fromLocalConfigurationDirectory(instancePropertiesPath);
+            Path configurationPath, SleeperInstanceConfigurationFromTemplates fromTemplates) {
+        SleeperInstanceConfiguration configuration = fromLocalConfigurationDirectory(configurationPath);
         if (configuration.getTableProperties().isEmpty()) {
             configuration = configuration.withTableProperties(instanceProperties -> List.of(
                     fromTemplates.loadTableProperties(instanceProperties)));
@@ -86,15 +86,15 @@ public class SleeperInstanceConfiguration {
      * Creates a configuration for a new instance, setting instance properties from templates if not
      * specified.
      *
-     * @param  instancePropertiesPath the path to the local configuration instance properties file, or null if not
-     *                                present
-     * @param  templatesDir           the directory to load the templates from
-     * @return                        the instance configuration
+     * @param  configurationPath the path to the local configuration instance properties file, or null if not
+     *                           present
+     * @param  templatesDir      the directory to load the templates from
+     * @return                   the instance configuration
      */
     public static SleeperInstanceConfiguration forNewInstanceDefaultingInstance(
-            Path instancePropertiesPath, Path templatesDir) {
-        if (instancePropertiesPath != null) {
-            return fromLocalConfigurationDirectory(instancePropertiesPath);
+            Path configurationPath, Path templatesDir) {
+        if (configurationPath != null) {
+            return fromLocalConfigurationDirectory(configurationPath);
         } else {
             return new SleeperInstanceConfiguration(SleeperInstanceConfigurationFromTemplates.loadInstanceProperties(templatesDir),
                     List.of());

--- a/java/core/src/test/java/sleeper/core/deploy/SleeperInstanceConfigurationIT.java
+++ b/java/core/src/test/java/sleeper/core/deploy/SleeperInstanceConfigurationIT.java
@@ -106,7 +106,7 @@ public class SleeperInstanceConfigurationIT {
     @DisplayName("Load from instance properties")
     class LoadFromInstanceProperties {
         @Test
-        void shouldLoadTablePropertiesAndSchemaIfFoundNearInstanceProperties() throws Exception {
+        void shouldLoadTagsButNotTablesWhenGivenInstancePropertiesFile() throws Exception {
             // Given
             Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
             Files.writeString(propertiesDir.resolve("tags.properties"), "Project=TestProject");
@@ -116,6 +116,47 @@ public class SleeperInstanceConfigurationIT {
             // When
             SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(
                     propertiesDir.resolve("instance.properties"));
+
+            // Then
+            InstanceProperties expectedInstanceProperties = new InstanceProperties();
+            expectedInstanceProperties.set(ID, "test-instance");
+            expectedInstanceProperties.setTags(Map.of("Project", "TestProject"));
+            assertThat(instanceConfiguration)
+                    .isEqualTo(SleeperInstanceConfiguration.builder()
+                            .instanceProperties(expectedInstanceProperties)
+                            .tableProperties(List.of())
+                            .build());
+        }
+
+        @Test
+        void shouldLoadNoTablesIfNotFoundNearInstanceProperties() throws Exception {
+            // Given
+            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
+
+            // When
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(
+                    propertiesDir.resolve("instance.properties"));
+
+            // Then
+            InstanceProperties expectedInstanceProperties = new InstanceProperties();
+            expectedInstanceProperties.set(ID, "test-instance");
+            assertThat(instanceConfiguration)
+                    .isEqualTo(SleeperInstanceConfiguration.builder()
+                            .instanceProperties(expectedInstanceProperties)
+                            .tableProperties(List.of())
+                            .build());
+        }
+
+        @Test
+        void shouldLoadFromConfigurationDirectoryWithSingleTable() throws Exception {
+            // Given
+            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
+            Files.writeString(propertiesDir.resolve("tags.properties"), "Project=TestProject");
+            Files.writeString(propertiesDir.resolve("table.properties"), "sleeper.table.name=test-table");
+            Files.writeString(propertiesDir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key")));
+
+            // When
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(propertiesDir);
 
             // Then
             InstanceProperties expectedInstanceProperties = new InstanceProperties();
@@ -132,13 +173,32 @@ public class SleeperInstanceConfigurationIT {
         }
 
         @Test
-        void shouldLoadNoTablesIfNotFoundNearInstanceProperties() throws Exception {
+        void shouldLoadFromConfigurationDirectoryWithTablesSubdirectory() throws Exception {
+            // Given
+            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
+            Path table1Dir = Files.createDirectories(propertiesDir.resolve("tables/table-1"));
+            Files.writeString(table1Dir.resolve("table.properties"), "sleeper.table.name=table-1");
+            Files.writeString(table1Dir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key1")));
+            Path table2Dir = Files.createDirectories(propertiesDir.resolve("tables/table-2"));
+            Files.writeString(table2Dir.resolve("table.properties"), "sleeper.table.name=table-2");
+            Files.writeString(table2Dir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key2")));
+
+            // When
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(propertiesDir);
+
+            // Then
+            assertThat(instanceConfiguration.getTableProperties())
+                    .extracting(properties -> properties.get(TABLE_NAME))
+                    .containsExactly("table-1", "table-2");
+        }
+
+        @Test
+        void shouldLoadFromConfigurationDirectoryWithNoTables() throws Exception {
             // Given
             Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
 
             // When
-            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(
-                    propertiesDir.resolve("instance.properties"));
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(propertiesDir);
 
             // Then
             InstanceProperties expectedInstanceProperties = new InstanceProperties();
@@ -200,7 +260,7 @@ public class SleeperInstanceConfigurationIT {
         void shouldPopulateTablePropertiesFromLocalConfig() throws Exception {
             // Given
             writeTemplates();
-            Path instancePropertiesPath = Files.writeString(
+            Files.writeString(
                     propertiesDir.resolve("instance.properties"),
                     "sleeper.filesystem=test://");
             Files.writeString(
@@ -212,7 +272,7 @@ public class SleeperInstanceConfigurationIT {
 
             // When
             SleeperInstanceConfiguration config = SleeperInstanceConfiguration.forNewInstanceDefaultingTables(
-                    instancePropertiesPath, fromTemplates);
+                    propertiesDir, fromTemplates);
 
             // Then
             InstanceProperties expectedInstanceProperties = new InstanceProperties();

--- a/java/core/src/test/java/sleeper/core/deploy/SleeperInstanceConfigurationIT.java
+++ b/java/core/src/test/java/sleeper/core/deploy/SleeperInstanceConfigurationIT.java
@@ -16,6 +16,7 @@
 
 package sleeper.core.deploy;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,126 +106,98 @@ public class SleeperInstanceConfigurationIT {
     @Nested
     @DisplayName("Load from instance properties")
     class LoadFromInstanceProperties {
+
+        @BeforeEach
+        void writeInstanceProperties() throws IOException {
+            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
+        }
+
         @Test
         void shouldLoadTagsButNotTablesWhenGivenInstancePropertiesFile() throws Exception {
             // Given
-            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
-            Files.writeString(propertiesDir.resolve("tags.properties"), "Project=TestProject");
-            Files.writeString(propertiesDir.resolve("table.properties"), "sleeper.table.name=test-table");
-            Files.writeString(propertiesDir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key")));
+            writeTagsProperties();
+            writeTableFiles(propertiesDir, "test-table", "key");
 
             // When
             SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(
                     propertiesDir.resolve("instance.properties"));
 
             // Then
-            InstanceProperties expectedInstanceProperties = new InstanceProperties();
-            expectedInstanceProperties.set(ID, "test-instance");
+            InstanceProperties expectedInstanceProperties = expectedInstanceProperties();
             expectedInstanceProperties.setTags(Map.of("Project", "TestProject"));
             assertThat(instanceConfiguration)
-                    .isEqualTo(SleeperInstanceConfiguration.builder()
-                            .instanceProperties(expectedInstanceProperties)
-                            .tableProperties(List.of())
-                            .build());
+                    .isEqualTo(new SleeperInstanceConfiguration(expectedInstanceProperties, List.of()));
         }
 
         @Test
         void shouldLoadNoTablesIfNotFoundNearInstanceProperties() throws Exception {
-            // Given
-            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
-
             // When
             SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(
                     propertiesDir.resolve("instance.properties"));
 
             // Then
-            InstanceProperties expectedInstanceProperties = new InstanceProperties();
-            expectedInstanceProperties.set(ID, "test-instance");
             assertThat(instanceConfiguration)
-                    .isEqualTo(SleeperInstanceConfiguration.builder()
-                            .instanceProperties(expectedInstanceProperties)
-                            .tableProperties(List.of())
-                            .build());
+                    .isEqualTo(new SleeperInstanceConfiguration(expectedInstanceProperties(), List.of()));
         }
 
         @Test
         void shouldLoadFromConfigurationDirectoryWithSingleTable() throws Exception {
             // Given
-            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
-            Files.writeString(propertiesDir.resolve("tags.properties"), "Project=TestProject");
-            Files.writeString(propertiesDir.resolve("table.properties"), "sleeper.table.name=test-table");
-            Files.writeString(propertiesDir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key")));
+            writeTagsProperties();
+            writeTableFiles(propertiesDir, "test-table", "key");
 
             // When
             SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(propertiesDir);
 
             // Then
-            InstanceProperties expectedInstanceProperties = new InstanceProperties();
-            expectedInstanceProperties.set(ID, "test-instance");
+            InstanceProperties expectedInstanceProperties = expectedInstanceProperties();
             expectedInstanceProperties.setTags(Map.of("Project", "TestProject"));
-            TableProperties expectedTableProperties = new TableProperties(expectedInstanceProperties);
-            expectedTableProperties.set(TABLE_NAME, "test-table");
-            expectedTableProperties.setSchema(createSchemaWithKey("key"));
             assertThat(instanceConfiguration)
-                    .isEqualTo(SleeperInstanceConfiguration.builder()
-                            .instanceProperties(expectedInstanceProperties)
-                            .tableProperties(expectedTableProperties)
-                            .build());
+                    .isEqualTo(new SleeperInstanceConfiguration(expectedInstanceProperties,
+                            expectedTableProperties(expectedInstanceProperties, "test-table", "key")));
         }
 
         @Test
         void shouldLoadFromConfigurationDirectoryWithTablesSubdirectory() throws Exception {
             // Given
-            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
-            Path table1Dir = Files.createDirectories(propertiesDir.resolve("tables/table-1"));
-            Files.writeString(table1Dir.resolve("table.properties"), "sleeper.table.name=table-1");
-            Files.writeString(table1Dir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key1")));
-            Path table2Dir = Files.createDirectories(propertiesDir.resolve("tables/table-2"));
-            Files.writeString(table2Dir.resolve("table.properties"), "sleeper.table.name=table-2");
-            Files.writeString(table2Dir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key2")));
+            writeTableFiles(Files.createDirectories(propertiesDir.resolve("tables/table-1")), "table-1", "key1");
+            writeTableFiles(Files.createDirectories(propertiesDir.resolve("tables/table-2")), "table-2", "key2");
 
             // When
             SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(propertiesDir);
 
             // Then
-            assertThat(instanceConfiguration.getTableProperties())
-                    .extracting(properties -> properties.get(TABLE_NAME))
-                    .containsExactly("table-1", "table-2");
+            InstanceProperties expectedInstanceProperties = expectedInstanceProperties();
+            assertThat(instanceConfiguration)
+                    .isEqualTo(new SleeperInstanceConfiguration(expectedInstanceProperties, List.of(
+                            expectedTableProperties(expectedInstanceProperties, "table-1", "key1"),
+                            expectedTableProperties(expectedInstanceProperties, "table-2", "key2"))));
         }
 
         @Test
         void shouldLoadFromConfigurationDirectoryWhenGivenInstancePropertiesFileWithinIt() throws Exception {
             // Given
-            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
-            Files.writeString(propertiesDir.resolve("table.properties"), "sleeper.table.name=test-table");
-            Files.writeString(propertiesDir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key")));
+            writeTableFiles(propertiesDir, "test-table", "key");
 
             // When
             SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(
                     propertiesDir.resolve("instance.properties"));
 
             // Then
-            assertThat(instanceConfiguration.getTableProperties())
-                    .extracting(properties -> properties.get(TABLE_NAME))
-                    .containsExactly("test-table");
+            InstanceProperties expectedInstanceProperties = expectedInstanceProperties();
+            assertThat(instanceConfiguration)
+                    .isEqualTo(new SleeperInstanceConfiguration(expectedInstanceProperties,
+                            expectedTableProperties(expectedInstanceProperties, "test-table", "key")));
         }
 
         @Test
         void shouldLoadFromConfigurationDirectoryWithNoTables() throws Exception {
-            // Given
-            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
-
             // When
             SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(propertiesDir);
 
             // Then
-            InstanceProperties expectedInstanceProperties = new InstanceProperties();
-            expectedInstanceProperties.set(ID, "test-instance");
             assertThat(instanceConfiguration)
-                    .isEqualTo(SleeperInstanceConfiguration.builder()
-                            .instanceProperties(expectedInstanceProperties)
-                            .tableProperties(List.of())
-                            .build());
+                    .isEqualTo(new SleeperInstanceConfiguration(expectedInstanceProperties(), List.of()));
         }
     }
 
@@ -323,6 +296,28 @@ public class SleeperInstanceConfigurationIT {
             expectedTableProperties.setSchema(createSchemaWithKey("template-key"));
             assertThat(config).isEqualTo(new SleeperInstanceConfiguration(expectedInstanceProperties, expectedTableProperties));
         }
+    }
+
+    private void writeTagsProperties() throws IOException {
+        Files.writeString(propertiesDir.resolve("tags.properties"), "Project=TestProject");
+    }
+
+    private void writeTableFiles(Path directory, String tableName, String schemaKey) throws IOException {
+        Files.writeString(directory.resolve("table.properties"), "sleeper.table.name=" + tableName);
+        Files.writeString(directory.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey(schemaKey)));
+    }
+
+    private InstanceProperties expectedInstanceProperties() {
+        InstanceProperties expected = new InstanceProperties();
+        expected.set(ID, "test-instance");
+        return expected;
+    }
+
+    private TableProperties expectedTableProperties(InstanceProperties instanceProperties, String tableName, String schemaKey) {
+        TableProperties expected = new TableProperties(instanceProperties);
+        expected.set(TABLE_NAME, tableName);
+        expected.setSchema(createSchemaWithKey(schemaKey));
+        return expected;
     }
 
     private void writeTemplates() throws IOException {

--- a/java/core/src/test/java/sleeper/core/deploy/SleeperInstanceConfigurationIT.java
+++ b/java/core/src/test/java/sleeper/core/deploy/SleeperInstanceConfigurationIT.java
@@ -156,7 +156,7 @@ public class SleeperInstanceConfigurationIT {
             Files.writeString(propertiesDir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key")));
 
             // When
-            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(propertiesDir);
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(propertiesDir);
 
             // Then
             InstanceProperties expectedInstanceProperties = new InstanceProperties();
@@ -184,7 +184,7 @@ public class SleeperInstanceConfigurationIT {
             Files.writeString(table2Dir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key2")));
 
             // When
-            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(propertiesDir);
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(propertiesDir);
 
             // Then
             assertThat(instanceConfiguration.getTableProperties())
@@ -193,12 +193,29 @@ public class SleeperInstanceConfigurationIT {
         }
 
         @Test
+        void shouldLoadFromConfigurationDirectoryWhenGivenInstancePropertiesFileWithinIt() throws Exception {
+            // Given
+            Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
+            Files.writeString(propertiesDir.resolve("table.properties"), "sleeper.table.name=test-table");
+            Files.writeString(propertiesDir.resolve("schema.json"), new SchemaSerDe().toJson(createSchemaWithKey("key")));
+
+            // When
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(
+                    propertiesDir.resolve("instance.properties"));
+
+            // Then
+            assertThat(instanceConfiguration.getTableProperties())
+                    .extracting(properties -> properties.get(TABLE_NAME))
+                    .containsExactly("test-table");
+        }
+
+        @Test
         void shouldLoadFromConfigurationDirectoryWithNoTables() throws Exception {
             // Given
             Files.writeString(propertiesDir.resolve("instance.properties"), "sleeper.id=test-instance");
 
             // When
-            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfiguration(propertiesDir);
+            SleeperInstanceConfiguration instanceConfiguration = SleeperInstanceConfiguration.fromLocalConfigurationDirectory(propertiesDir);
 
             // Then
             InstanceProperties expectedInstanceProperties = new InstanceProperties();
@@ -260,7 +277,7 @@ public class SleeperInstanceConfigurationIT {
         void shouldPopulateTablePropertiesFromLocalConfig() throws Exception {
             // Given
             writeTemplates();
-            Files.writeString(
+            Path instancePropertiesPath = Files.writeString(
                     propertiesDir.resolve("instance.properties"),
                     "sleeper.filesystem=test://");
             Files.writeString(
@@ -272,7 +289,7 @@ public class SleeperInstanceConfigurationIT {
 
             // When
             SleeperInstanceConfiguration config = SleeperInstanceConfiguration.forNewInstanceDefaultingTables(
-                    propertiesDir, fromTemplates);
+                    instancePropertiesPath, fromTemplates);
 
             // Then
             InstanceProperties expectedInstanceProperties = new InstanceProperties();

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/SleeperInstanceProps.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/SleeperInstanceProps.java
@@ -168,8 +168,8 @@ public class SleeperInstanceProps {
      * @return              the configuration
      */
     public static Builder builderFromContext(CdkContext context, S3Client s3Client, EcrClient ecrClient, DynamoDbClient dynamoClient) {
-        Path propertiesFile = Path.of(context.tryGetContext("propertiesfile"));
-        SleeperInstanceConfiguration configuration = SleeperInstanceConfiguration.fromLocalConfiguration(propertiesFile);
+        Path configurationPath = Path.of(context.tryGetContext("propertiesfile"));
+        SleeperInstanceConfiguration configuration = SleeperInstanceConfiguration.fromLocalConfiguration(configurationPath);
         String instanceId = context.tryGetContext("id");
         if (instanceId != null) {
             configuration.getInstanceProperties().set(ID, instanceId);

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/SleeperInstanceProps.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/SleeperInstanceProps.java
@@ -168,8 +168,7 @@ public class SleeperInstanceProps {
      * @return              the configuration
      */
     public static Builder builderFromContext(CdkContext context, S3Client s3Client, EcrClient ecrClient, DynamoDbClient dynamoClient) {
-        Path configurationPath = Path.of(context.tryGetContext("propertiesfile"));
-        SleeperInstanceConfiguration configuration = SleeperInstanceConfiguration.fromLocalConfiguration(configurationPath);
+        SleeperInstanceConfiguration configuration = loadConfiguration(context);
         String instanceId = context.tryGetContext("id");
         if (instanceId != null) {
             configuration.getInstanceProperties().set(ID, instanceId);
@@ -185,6 +184,23 @@ public class SleeperInstanceProps {
                 .ensureInstanceDoesNotExist(context.getBooleanOrDefault("newinstance", false))
                 .skipCheckingVersionMatchesProperties(context.getBooleanOrDefault("skipVersionCheck", false))
                 .deployPaused(context.getBooleanOrDefault("deployPaused", false));
+    }
+
+    private static SleeperInstanceConfiguration loadConfiguration(CdkContext context) {
+        String propertiesFile = context.tryGetContext("propertiesfile");
+        String configurationDir = context.tryGetContext("configurationdir");
+        if (propertiesFile != null && configurationDir != null) {
+            throw new IllegalArgumentException(
+                    "Both 'propertiesfile' and 'configurationdir' context variables are set - specify exactly one");
+        }
+        if (propertiesFile != null) {
+            return SleeperInstanceConfiguration.fromLocalConfiguration(Path.of(propertiesFile));
+        }
+        if (configurationDir != null) {
+            return SleeperInstanceConfiguration.fromLocalConfigurationDirectory(Path.of(configurationDir));
+        }
+        throw new IllegalArgumentException(
+                "Either 'propertiesfile' or 'configurationdir' context variable must be set");
     }
 
     public void prepareProperties(Stack stack, SleeperNetworking networking) {

--- a/java/deployment/cdk/src/test/java/sleeper/cdk/stack/SleeperInstancePropsIT.java
+++ b/java/deployment/cdk/src/test/java/sleeper/cdk/stack/SleeperInstancePropsIT.java
@@ -28,6 +28,7 @@ import sleeper.cdk.networking.SleeperNetworking;
 import sleeper.cdk.util.MismatchedVersionException;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.local.SaveLocalProperties;
+import sleeper.core.properties.table.TableProperties;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -52,6 +53,8 @@ import static sleeper.core.properties.instance.CommonProperty.ID;
 import static sleeper.core.properties.instance.CommonProperty.JARS_BUCKET;
 import static sleeper.core.properties.instance.CommonProperty.SUBNETS;
 import static sleeper.core.properties.instance.CommonProperty.VPC_ID;
+import static sleeper.core.properties.table.TableProperty.TABLE_NAME;
+import static sleeper.core.schema.SchemaTestHelper.createSchemaWithKey;
 
 class SleeperInstancePropsIT {
 
@@ -228,6 +231,55 @@ class SleeperInstancePropsIT {
             // When/Then
             assertThatCode(() -> readProps())
                     .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("Choose between propertiesfile and configurationdir context variables")
+    class ChooseConfigurationSource {
+
+        @Test
+        void shouldLoadFromConfigurationDirectoryIncludingTables() throws IOException {
+            // Given
+            InstanceProperties properties = createUserDefinedInstanceProperties();
+            TableProperties tableProperties = new TableProperties(properties);
+            tableProperties.set(TABLE_NAME, "test-table");
+            tableProperties.setSchema(createSchemaWithKey("key"));
+            SaveLocalProperties.saveToDirectory(tempDir, properties, Stream.of(tableProperties));
+            cdkContext.clear();
+            cdkContext.put("configurationdir", tempDir.toString());
+
+            // When
+            SleeperInstanceProps props = readProps();
+
+            // Then
+            assertThat(props.getTableProperties())
+                    .extracting(p -> p.get(TABLE_NAME))
+                    .containsExactly("test-table");
+        }
+
+        @Test
+        void shouldFailWhenBothPropertiesFileAndConfigurationDirAreSet() throws IOException {
+            // Given
+            InstanceProperties properties = createUserDefinedInstanceProperties();
+            SaveLocalProperties.saveToDirectory(tempDir, properties, Stream.empty());
+            cdkContext.put("configurationdir", tempDir.toString());
+
+            // When / Then
+            assertThatThrownBy(() -> readProps())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Both 'propertiesfile' and 'configurationdir'");
+        }
+
+        @Test
+        void shouldFailWhenNeitherPropertiesFileNorConfigurationDirIsSet() {
+            // Given
+            cdkContext.clear();
+
+            // When / Then
+            assertThatThrownBy(() -> readProps())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Either 'propertiesfile' or 'configurationdir'");
         }
     }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7276

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated tests:
      - AdminClientITBase.java
      - InstanceConfigurationScreenTest.java
      - InvokeCdkTest.java
      - SleeperInstanceConfigurationIT.java
      - SleeperInstancePropsIT.java

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
