### PR TITLE
Issue 7351 - Build base Docker image at beginning of nightly system test suite

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
@@ -18,6 +18,7 @@ package sleeper.clients.deploy.container;
 import sleeper.clients.util.command.CommandPipelineRunner;
 import sleeper.clients.util.command.CommandUtils;
 import sleeper.core.SleeperVersion;
+import sleeper.core.deploy.ContainerPlatform;
 import sleeper.core.deploy.DockerDeployment;
 import sleeper.core.deploy.LambdaJar;
 import sleeper.core.util.cli.CommandArguments;
@@ -45,12 +46,15 @@ public class BuildDockerImage {
         CommandLineUsage usage = CommandLineUsage.builder()
                 .positionalArguments(List.of("scripts directory", "image name", "tag"))
                 .systemArguments(List.of("scripts directory"))
-                .options(List.of(CommandOption.longFlag("lambda")))
+                .options(List.of(CommandOption.longFlag("lambda"), CommandOption.longFlag("multiplatform")))
                 .helpSummary("Available Docker deployment image names: " +
                         DockerDeployment.all().stream().map(DockerDeployment::getDeploymentName).collect(joining(", ")) + "\n\n" +
                         "Available lambda image names: " +
                         LambdaJar.all().stream().map(LambdaJar::getImageName).collect(joining(", ")) + "\n\n" +
-                        "Other arguments will be passed through to Docker as options when specified at the end.")
+                        "The --lambda flag specifies that the image is one of the lambda options. The --multiplatform " +
+                        "flag specifies to build a multiplatform image if it's configured to be built that way. By " +
+                        "default an image is only built for the default platform. Other arguments will be passed " +
+                        "through to Docker as options when specified at the end.")
                 .passThroughExtraArguments(true)
                 .build();
         Arguments args = CommandArguments.parseAndValidateOrExit(usage, rawArgs, arguments -> new Arguments(
@@ -58,11 +62,13 @@ public class BuildDockerImage {
                 arguments.getString("image name"),
                 arguments.getString("tag"),
                 arguments.isFlagSet("lambda"),
+                arguments.isFlagSet("multiplatform"),
                 arguments.getPassthroughArguments()));
         DockerImageConfiguration configuration = DockerImageConfiguration.getDefault();
         CommandPipelineRunner commandRunner = CommandUtils::runCommandInheritIO;
 
         Path dockerfileDirectory;
+        List<ContainerPlatform> platforms = List.of();
         if (args.isLambda()) {
             dockerfileDirectory = args.dockerDir().resolve("lambda");
             LambdaJar jar = configuration.getLambdaJarByImageName(args.imageName()).orElseThrow();
@@ -72,16 +78,23 @@ public class BuildDockerImage {
         } else {
             DockerDeployment deployment = configuration.getDockerDeploymentByName(args.imageName()).orElseThrow();
             dockerfileDirectory = args.dockerDir().resolve(deployment.getDeploymentName());
+            platforms = deployment.getPlatforms();
         }
 
         List<String> dockerCommand = new ArrayList<>();
-        dockerCommand.addAll(List.of("docker", "build", "-t", args.tag()));
+        if (args.isMultiplatform() && !platforms.isEmpty()) {
+            UploadDockerImages.useBuildXBuilder(commandRunner);
+            String platformList = ContainerPlatform.buildPlatformListArgument(platforms);
+            dockerCommand.addAll(List.of("docker", "buildx", "build", "--platform", platformList, "-t", args.tag(), "--load"));
+        } else {
+            dockerCommand.addAll(List.of("docker", "build", "-t", args.tag()));
+        }
         dockerCommand.addAll(args.dockerOptions());
         dockerCommand.add(dockerfileDirectory.toString());
         commandRunner.runOrThrow(dockerCommand.toArray(String[]::new));
     }
 
-    private record Arguments(Path scriptsDir, String imageName, String tag, boolean isLambda, List<String> dockerOptions) {
+    private record Arguments(Path scriptsDir, String imageName, String tag, boolean isLambda, boolean isMultiplatform, List<String> dockerOptions) {
 
         Path dockerDir() {
             return scriptsDir.resolve("docker");

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
@@ -38,7 +38,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -84,6 +83,11 @@ public class UploadDockerImages {
         return deployConfig.dockerImageLocation() == DockerImageLocation.LOCAL_BUILD;
     }
 
+    public static void useBuildXBuilder(CommandPipelineRunner commandRunner) throws IOException, InterruptedException {
+        commandRunner.run("docker", "buildx", "create", "--name", "sleeper");
+        commandRunner.runOrThrow("docker", "buildx", "use", "sleeper");
+    }
+
     public void upload(String repositoryPrefix, List<StackDockerImage> imagesToUpload) throws IOException, InterruptedException {
         if (imagesToUpload.isEmpty()) {
             LOGGER.info("No images need to be built and uploaded, skipping");
@@ -93,8 +97,7 @@ public class UploadDockerImages {
 
         if (deployConfig.dockerImageLocation() == DockerImageLocation.LOCAL_BUILD
                 && createMultiplatformBuilder) {
-            commandRunner.run("docker", "buildx", "create", "--name", "sleeper");
-            commandRunner.runOrThrow("docker", "buildx", "use", "sleeper");
+            useBuildXBuilder(commandRunner);
         }
 
         if (deployConfig.dockerImageLocation() == DockerImageLocation.LOCAL_BUILD) {
@@ -119,9 +122,7 @@ public class UploadDockerImages {
         });
 
         if (image.isMultiplatform()) {
-            String platformList = image.getPlatforms().stream()
-                    .map(ContainerPlatform::toString)
-                    .collect(Collectors.joining(","));
+            String platformList = ContainerPlatform.buildPlatformListArgument(image.getPlatforms());
             commandRunner.runOrThrow("docker", "buildx", "build", "--build-arg", "BASE_IMAGE=" + baseTag, "--platform", platformList, "-t", tag, "--push", dockerfileDirectory.toString());
         } else {
             if (image.getLambdaJar().isPresent()) {

--- a/java/core/src/main/java/sleeper/core/deploy/ContainerPlatform.java
+++ b/java/core/src/main/java/sleeper/core/deploy/ContainerPlatform.java
@@ -15,7 +15,9 @@
  */
 package sleeper.core.deploy;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A platform that a container image is built for. Combines an operating system and an architecture, in the same form
@@ -46,6 +48,18 @@ public record ContainerPlatform(String os, String architecture) {
             throw new IllegalArgumentException("Platform must be in the form os/architecture, got: " + value);
         }
         return new ContainerPlatform(value.substring(0, slash), value.substring(slash + 1));
+    }
+
+    /**
+     * Builds an argument suitable to be passed to docker build as the value for the --platform option.
+     *
+     * @param  platforms the platforms
+     * @return           the platform list argument
+     */
+    public static String buildPlatformListArgument(List<ContainerPlatform> platforms) {
+        return platforms.stream()
+                .map(ContainerPlatform::toString)
+                .collect(Collectors.joining(","));
     }
 
     @Override

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -63,6 +63,7 @@ OUTPUT_DIR="$REPO_PARENT_DIR/logs/$START_TIME-$MAIN_SUITE_NAME"
 mkdir -p "$OUTPUT_DIR"
 "$SCRIPTS_DIR/build/build.sh"
 "$SCRIPTS_DIR/build/buildPython.sh"
+"$SCRIPTS_DIR/dev/buildDockerImage.sh" base sleeper-base:current --multiplatform
 VERSION=$(cat "$SCRIPTS_DIR/templates/version.txt")
 SYSTEM_TEST_JAR="$SCRIPTS_DIR/jars/system-test-${VERSION}-utility.jar"
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7351

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Ran `scripts/dev/buildDockerImage.sh base sleeper-base:current --multiplatform --no-cache`
    - After that finished successfully, ran `scripts/test/maven/deploy.sh`, verified:
      - Cached base image was used instead of building it from scratch
      - Cached base image was used for compaction runner image build
    - This code will be run nightly via `scripts/test/nightly/runTests.sh`, so no further automation is needed

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
