### PR TITLE
Issue 7353 - Remove ECS-based committer system test from quick suite, improve timing logs

### DIFF
--- a/docs/development/system-test-suites.md
+++ b/docs/development/system-test-suites.md
@@ -9,7 +9,7 @@ it takes to complete the nightly system tests.
 | AutoStopEcsTaskST          | EksBulkImportST                    | CompactionCreationST            |
 | AutoDeleteS3ObjectsST      | CompactionOnEC2ST                  | MultipleTablesST                |
 | RedeployOptionalStacksST   | ECSStateStoreCommitterThroughputST | StateStoreCommitterThroughputST |
-| EmrPersistentBulkImportST  |
+| EmrPersistentBulkImportST  | ECSStateStoreCommitterST
 | OptionalFeaturesDisabledST |
 
 

--- a/docs/development/system-test-suites.md
+++ b/docs/development/system-test-suites.md
@@ -1,5 +1,5 @@
 # Current Slow and Expensive test suites
-### This looks imbalanced but EKSBulkImportST is a lot slower than others
+### This looks imbalanced but EksBulkImportST is a lot slower than others
 
 These tables show which system tests run in which suite. Each suite runs in parallel to the others to speed up the time
 it takes to complete the nightly system tests.

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ECSStateStoreCommitterST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/ECSStateStoreCommitterST.java
@@ -24,6 +24,7 @@ import sleeper.core.statestore.FileReferenceFactory;
 import sleeper.systemtest.dsl.SleeperDsl;
 import sleeper.systemtest.dsl.statestore.StateStoreCommitMessage;
 import sleeper.systemtest.suite.testutil.SystemTest;
+import sleeper.systemtest.suite.testutil.parallel.Slow2;
 
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -34,6 +35,7 @@ import static sleeper.systemtest.dsl.util.SystemTestSchema.DEFAULT_SCHEMA;
 import static sleeper.systemtest.suite.fixtures.SystemTestInstance.ECS_STATESTORE;
 
 @SystemTest
+@Slow2
 public class ECSStateStoreCommitterST {
 
     @BeforeEach

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -146,15 +146,20 @@ runMavenSystemTests() {
 
 runTestSuite(){
     SUITE=$3
+    local COPY_START=$(record_time)
     copyFolderForParallelRun "$SUITE"
+    local COPY_END=$(record_time)
+    echo "[$(recorded_time_str "$COPY_END")] Finished folder copy for suite: $SUITE, took $(elapsed_time_str "$COPY_START" "$COPY_END")"
     # Wait short time to not have clashes with other process deploying
     sleep $1
     shift 1
-    echo "[$(time_str)] Starting test suite: $SUITE"
+    local SUITE_START=$(record_time)
+    echo "[$(recorded_time_str "$SUITE_START")] Starting test suite: $SUITE"
     pushd "$REPO_PARENT_DIR/$SUITE/scripts/test" #Move into isolated repo copy
     runMavenSystemTests "$@"
     popd
-    echo "[$(time_str)] Finished test suite: $SUITE"
+    local SUITE_END=$(record_time)
+    echo "[$(recorded_time_str "$SUITE_END")] Finished test suite: $SUITE, took $(elapsed_time_str "$SUITE_START" "$SUITE_END"), folder copy took $(elapsed_time_str "$COPY_START" "$COPY_END")"
     removeFolderAfterParallelRun "$SUITE"
 }
 

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -111,7 +111,7 @@ runMavenSystemTests() {
 
     # Run tests
     local TEST_START=$(record_time)
-    echo "[$(recorded_time_str "$SUITE_START")] Starting test suite: $SHORT_ID"
+    echo "[$(recorded_time_str "$TEST_START")] Running Maven test suite with short ID: $SHORT_ID"
     ./maven/deployTest.sh "$SHORT_ID" "$VPC" "$SUBNETS" \
       -Dsleeper.system.test.output.dir="$TEST_OUTPUT_DIR" \
       "${EXTRA_MAVEN_PARAMS[@]}" \
@@ -126,7 +126,7 @@ runMavenSystemTests() {
 
     # Generate site HTML
     pushd "$NEW_MAVEN_DIR"
-    echo "[$(recorded_time_str "$TEST_END")] Generating site HTML for suite: $SHORT_ID"
+    echo "[$(recorded_time_str "$TEST_END")] Generating site HTML for short ID: $SHORT_ID"
     mvn --batch-mode site site:stage -pl system-test/system-test-suite \
        -DskipTests=true \
        -DstagingDirectory="$TEST_OUTPUT_DIR/site"
@@ -147,9 +147,9 @@ runMavenSystemTests() {
     fi
     echo -n "$TEST_EXIT_CODE $SHORT_ID" > "$OUTPUT_DIR/$TEST_NAME.status"
     local TEARDOWN_END=$(record_time)
-    echo "[$(recorded_time_str "$SUITE_END")] Finished teardown for test suite: $SHORT_ID"
+    echo "[$(recorded_time_str "$SUITE_END")] Finished teardown of short ID: $SHORT_ID"
     echo "Started at $(recorded_time_str "$TEST_START")"
-    echo "Finished tests at $(recorded_time_str "$TEST_END"), took $(elapsed_time_str "$TEST_START" "$TEST_END")"
+    echo "Finished Maven test suite at $(recorded_time_str "$TEST_END"), took $(elapsed_time_str "$TEST_START" "$TEST_END")"
     echo "Finished site HTML at $(recorded_time_str "$SITE_END"), took $(elapsed_time_str "$TEST_END" "$SITE_END")"
     echo "Finished tear down at $(recorded_time_str "$TEARDOWN_END"), took $(elapsed_time_str "$SITE_END" "$TEARDOWN_END")"
 }

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -173,7 +173,7 @@ runTestSuite(){
     removeFolderAfterParallelRun "$SUITE"
     local REMOVE_FOLDER_END=$(record_time)
     echo "[$(recorded_time_str "$REMOVE_FOLDER_END")] Finished test suite: $SUITE"
-    echo "Folder copy ran from $(recorded_time_str "$COPY_START") to $(recorded_time_str "$COPY_START"), took $(elapsed_time_str "$COPY_START" "$COPY_END")"
+    echo "Folder copy ran from $(recorded_time_str "$COPY_START") to $(recorded_time_str "$COPY_END"), took $(elapsed_time_str "$COPY_START" "$COPY_END")"
     echo "Maven operations and tear down ran from $(recorded_time_str "$SUITE_START") to $(recorded_time_str "$SUITE_END"), took $(elapsed_time_str "$SUITE_START" "$SUITE_END")"
     echo "Folder removal finished at $(recorded_time_str "$REMOVE_FOLDER_END"), took $(elapsed_time_str "$SUITE_END" "$REMOVE_FOLDER_END")"
 }

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -77,8 +77,8 @@ docker buildx create --name sleeper --use
 set +e
 
 copyFolderForParallelRun() {
-    COPY_DIR=$1
-    echo "Making folder $COPY_DIR for parallel build"
+    local COPY_DIR=$1
+    echo "Making parallel build folder: $COPY_DIR"
     pushd $REPO_PARENT_DIR
     sudo rm -rf $COPY_DIR
     mkdir $COPY_DIR

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -71,11 +71,6 @@ set +e
 
 END_EXIT_CODE=0
 
-docker buildx rm sleeper
-set -e
-docker buildx create --name sleeper --use
-set +e
-
 copyFolderForParallelRun() {
     local COPY_DIR=$1
     echo "Making parallel build folder: $COPY_DIR"

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -99,17 +99,19 @@ removeFolderAfterParallelRun() {
 
 runMavenSystemTests() {
     # Setup
-    NEW_MAVEN_DIR=$(cd ../../java && pwd)
-    SHORT_ID=$1
-    TEST_NAME=$2
+    local NEW_MAVEN_DIR=$(cd ../../java && pwd)
+    local SHORT_ID=$1
+    local TEST_NAME=$2
     shift 2
-    TEST_EXIT_CODE=0
-    EXTRA_MAVEN_PARAMS=("$@")
-    TEST_OUTPUT_DIR="$OUTPUT_DIR/$TEST_NAME"
+    local TEST_EXIT_CODE=0
+    local EXTRA_MAVEN_PARAMS=("$@")
+    local TEST_OUTPUT_DIR="$OUTPUT_DIR/$TEST_NAME"
     mkdir "$TEST_OUTPUT_DIR"
     echo "Made output directory: $TEST_OUTPUT_DIR for SHORT_ID: $SHORT_ID"
 
     # Run tests
+    local TEST_START=$(record_time)
+    echo "[$(recorded_time_str "$SUITE_START")] Starting test suite: $SHORT_ID"
     ./maven/deployTest.sh "$SHORT_ID" "$VPC" "$SUBNETS" \
       -Dsleeper.system.test.output.dir="$TEST_OUTPUT_DIR" \
       "${EXTRA_MAVEN_PARAMS[@]}" \
@@ -120,10 +122,11 @@ runMavenSystemTests() {
       END_EXIT_CODE=$RUN_TESTS_EXIT_CODE
       TEST_EXIT_CODE=$RUN_TESTS_EXIT_CODE
     fi
+    local TEST_END=$(record_time)
 
     # Generate site HTML
     pushd "$NEW_MAVEN_DIR"
-    echo "Generating site HTML for $SHORT_ID"
+    echo "[$(recorded_time_str "$TEST_END")] Generating site HTML for suite: $SHORT_ID"
     mvn --batch-mode site site:stage -pl system-test/system-test-suite \
        -DskipTests=true \
        -DstagingDirectory="$TEST_OUTPUT_DIR/site"
@@ -132,20 +135,27 @@ runMavenSystemTests() {
     zip -r "$OUTPUT_DIR/$TEST_NAME-site.zip" "."
     popd
     rm -rf "$TEST_OUTPUT_DIR/site"
+    local SITE_END=$(record_time)
 
     # Tear down instances used for tests
-    SHORT_INSTANCE_NAMES=$(read_short_instance_names_from_instance_ids "$SHORT_ID" "$TEST_OUTPUT_DIR/instanceIds.txt")
+    local SHORT_INSTANCE_NAMES=$(read_short_instance_names_from_instance_ids "$SHORT_ID" "$TEST_OUTPUT_DIR/instanceIds.txt")
     ./maven/tearDown.sh "$SHORT_ID" "$SHORT_INSTANCE_NAMES" &> "$OUTPUT_DIR/$TEST_NAME.tearDown.log"
-    TEARDOWN_EXIT_CODE=$?
+    local TEARDOWN_EXIT_CODE=$?
     if [ $TEARDOWN_EXIT_CODE -ne 0 ]; then
       TEST_EXIT_CODE=$TEARDOWN_EXIT_CODE
       END_EXIT_CODE=$TEARDOWN_EXIT_CODE
     fi
     echo -n "$TEST_EXIT_CODE $SHORT_ID" > "$OUTPUT_DIR/$TEST_NAME.status"
+    local TEARDOWN_END=$(record_time)
+    echo "[$(recorded_time_str "$SUITE_END")] Finished teardown for test suite: $SHORT_ID"
+    echo "Started at $(recorded_time_str "$TEST_START")"
+    echo "Finished tests at $(recorded_time_str "$TEST_END"), took $(elapsed_time_str "$TEST_START" "$TEST_END")"
+    echo "Finished site HTML at $(recorded_time_str "$SITE_END"), took $(elapsed_time_str "$TEST_END" "$SITE_END")"
+    echo "Finished tear down at $(recorded_time_str "$TEARDOWN_END"), took $(elapsed_time_str "$SITE_END" "$TEARDOWN_END")"
 }
 
 runTestSuite(){
-    SUITE=$3
+    local SUITE=$3
     local COPY_START=$(record_time)
     copyFolderForParallelRun "$SUITE"
     local COPY_END=$(record_time)
@@ -159,8 +169,13 @@ runTestSuite(){
     runMavenSystemTests "$@"
     popd
     local SUITE_END=$(record_time)
-    echo "[$(recorded_time_str "$SUITE_END")] Finished test suite: $SUITE, took $(elapsed_time_str "$SUITE_START" "$SUITE_END"), folder copy took $(elapsed_time_str "$COPY_START" "$COPY_END")"
+    echo "[$(recorded_time_str "$SUITE_END")] Removing folder for test suite: $SUITE"
     removeFolderAfterParallelRun "$SUITE"
+    local REMOVE_FOLDER_END=$(record_time)
+    echo "[$(recorded_time_str "$REMOVE_FOLDER_END")] Finished test suite: $SUITE"
+    echo "Folder copy ran from $(recorded_time_str "$COPY_START") to $(recorded_time_str "$COPY_START"), took $(elapsed_time_str "$COPY_START" "$COPY_END")"
+    echo "Maven operations and tear down ran from $(recorded_time_str "$SUITE_START") to $(recorded_time_str "$SUITE_END"), took $(elapsed_time_str "$SUITE_START" "$SUITE_END")"
+    echo "Folder removal finished at $(recorded_time_str "$REMOVE_FOLDER_END"), took $(elapsed_time_str "$SUITE_END" "$REMOVE_FOLDER_END")"
 }
 
 if [ "$MAIN_SUITE_NAME" == "performance" ]; then

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -147,7 +147,7 @@ runMavenSystemTests() {
     fi
     echo -n "$TEST_EXIT_CODE $SHORT_ID" > "$OUTPUT_DIR/$TEST_NAME.status"
     local TEARDOWN_END=$(record_time)
-    echo "[$(recorded_time_str "$SUITE_END")] Finished teardown of short ID: $SHORT_ID"
+    echo "[$(recorded_time_str "$TEARDOWN_END")] Finished teardown of short ID: $SHORT_ID"
     echo "Started at $(recorded_time_str "$TEST_START")"
     echo "Finished Maven test suite at $(recorded_time_str "$TEST_END"), took $(elapsed_time_str "$TEST_START" "$TEST_END")"
     echo "Finished site HTML at $(recorded_time_str "$SITE_END"), took $(elapsed_time_str "$TEST_END" "$SITE_END")"


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7353

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Started performance test suite in an environment build EC2 with `scripts/test/nightly/runTests.sh <deploy-id> <vpc> <subnets> <results-bucket> performance`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
