### PR TITLE
Issue 7318 - Allow container images to be built using a custom base image

### DIFF
--- a/docs/development/publishing.md
+++ b/docs/development/publishing.md
@@ -48,6 +48,15 @@ docker buildx create --name sleeper --use
 This may not be suitable for all use cases. You can disable this by passing "false" as the second argument. In that
 case, you will need to ensure a Docker builder is set that can build multiplatform images before calling this script.
 
+You can pass an optional third argument to override the directory used as the Docker build context for the base image.
+By default the base image is built from `scripts/docker/base`. Pass a different directory containing your own `Dockerfile` to substitute a custom base image, e.g.:
+
+```bash
+./scripts/dev/publishDocker.sh my.registry.com/path true ../some/path/my/base
+```
+
+This is intended for non-standard setups only. Every other image is still built from the standard Sleeper Dockerfiles, and they will use your custom base image as their `BASE_IMAGE` build arg. The same override is available on `setDeployConfig.sh` via `--override-base-image-dir <dir>`, so it is also picked up when deploying with `scripts/deploy/deployNew.sh` or `scripts/deploy/deployExisting.sh`. It cannot be combined with `--image-location repository`, because the override only applies when images are built locally.
+
 ### Installing published artefacts
 
 We have scripts to install Sleeper from published artefacts. We have not yet published Sleeper to Maven Central or

--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployConfiguration.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployConfiguration.java
@@ -22,14 +22,27 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Optional;
 
-public record DeployConfiguration(DockerImageLocation dockerImageLocation, String dockerRepositoryPrefix, ContainerRegistryCredentials dockerCredentials) {
+public record DeployConfiguration(
+        DockerImageLocation dockerImageLocation,
+        String dockerRepositoryPrefix,
+        ContainerRegistryCredentials dockerCredentials,
+        String overrideBaseImageDir) {
 
     public DeployConfiguration {
         Objects.requireNonNull(dockerImageLocation, "dockerImageLocation must not be null");
         if (dockerImageLocation == DockerImageLocation.REPOSITORY) {
             Objects.requireNonNull(dockerRepositoryPrefix, "dockerRepositoryPrefix must not be null");
         }
+    }
+
+    public DeployConfiguration(DockerImageLocation dockerImageLocation, String dockerRepositoryPrefix, ContainerRegistryCredentials dockerCredentials) {
+        this(dockerImageLocation, dockerRepositoryPrefix, dockerCredentials, null);
+    }
+
+    public Optional<Path> overrideBaseImageDirPath() {
+        return Optional.ofNullable(overrideBaseImageDir).map(Path::of);
     }
 
     public static DeployConfiguration fromScriptsDirectory(Path scriptsDirectory) throws IOException {
@@ -39,7 +52,11 @@ public record DeployConfiguration(DockerImageLocation dockerImageLocation, Strin
     }
 
     public static DeployConfiguration fromLocalBuild() {
-        return new DeployConfiguration(DockerImageLocation.LOCAL_BUILD, null, null);
+        return new DeployConfiguration(DockerImageLocation.LOCAL_BUILD, null, null, null);
+    }
+
+    public static DeployConfiguration fromLocalBuildWithOverrideBaseImageDir(String overrideBaseImageDir) {
+        return new DeployConfiguration(DockerImageLocation.LOCAL_BUILD, null, null, overrideBaseImageDir);
     }
 
     public static DeployConfiguration fromDockerRepository(String prefix) {
@@ -47,6 +64,6 @@ public record DeployConfiguration(DockerImageLocation dockerImageLocation, Strin
     }
 
     public static DeployConfiguration fromDockerRepository(String prefix, ContainerRegistryCredentials credentials) {
-        return new DeployConfiguration(DockerImageLocation.REPOSITORY, prefix, credentials);
+        return new DeployConfiguration(DockerImageLocation.REPOSITORY, prefix, credentials, null);
     }
 }

--- a/java/clients/src/main/java/sleeper/clients/deploy/SetDeployConfiguration.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/SetDeployConfiguration.java
@@ -46,7 +46,8 @@ public class SetDeployConfiguration {
                 .options(List.of(
                         CommandOption.longOption("image-location"),
                         CommandOption.longOption("image-repository-prefix"),
-                        CommandOption.longOption("image-username")))
+                        CommandOption.longOption("image-username"),
+                        CommandOption.longOption("override-base-image-dir")))
                 .helpSummary("" +
                         "Sets the configuration to deploy Sleeper. Saves the configuration to the local file system.\n" +
                         "\n" +
@@ -65,7 +66,14 @@ public class SetDeployConfiguration {
                         "Sets the username to authenticate with the container image registry. If this is set, the " +
                         "password will be read from stdin as a prompt. If this is not set, no authentication will be " +
                         "sent when communicating with the registry. Important: the credentials will be stored in " +
-                        "plain text in the local file system.")
+                        "plain text in the local file system.\n" +
+                        "\n" +
+                        "--override-base-image-dir <dir>\n" +
+                        "Advanced. Overrides the directory used as the Docker build context for the base image. " +
+                        "By default the base image is built from the \"base\" subdirectory of the scripts docker " +
+                        "directory. Set this only if you need to substitute a custom base Dockerfile. " +
+                        "Cannot be combined with \"--image-location repository\" — the override only applies to " +
+                        "local builds.")
                 .build();
         Arguments arguments = CommandArguments.parseAndValidateOrExit(usage, args, commandArgs -> new Arguments(
                 Path.of(commandArgs.getString("scripts directory")),
@@ -79,6 +87,7 @@ public class SetDeployConfiguration {
     private static DeployConfiguration readConfiguration(ConsoleInput input, CommandArguments arguments) {
         String imagePrefix = arguments.getOptionalString("image-repository-prefix").orElse(null);
         String imageUsername = arguments.getOptionalString("image-username").orElse(null);
+        String overrideBaseImageDir = arguments.getOptionalString("override-base-image-dir").orElse(null);
         DockerImageLocation imageLocation = arguments.getOptionalString("image-location")
                 .map(DockerImageLocation::parseOrNull)
                 .orElseGet(() -> {
@@ -88,8 +97,12 @@ public class SetDeployConfiguration {
                         throw new IllegalArgumentException("Container image location was not set, use --help for more information.");
                     }
                 });
+        if (overrideBaseImageDir != null && imageLocation == DockerImageLocation.REPOSITORY) {
+            throw new IllegalArgumentException("--override-base-image-dir cannot be combined with --image-location repository. " +
+                    "The override only applies to local builds.");
+        }
         ContainerRegistryCredentials imageCredentials = imageCredentials(input, imageUsername);
-        return new DeployConfiguration(imageLocation, imagePrefix, imageCredentials);
+        return new DeployConfiguration(imageLocation, imagePrefix, imageCredentials, overrideBaseImageDir);
     }
 
     private static ContainerRegistryCredentials imageCredentials(ConsoleInput input, String imageUsername) {

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
@@ -114,7 +114,7 @@ public class UploadDockerImages {
     }
 
     private void buildAndPushImage(String tag, StackDockerImage image, String baseTag) throws IOException, InterruptedException {
-        Path dockerfileDirectory = baseDockerDirectory.resolve(image.getDirectoryName());
+        Path dockerfileDirectory = resolveBuildContext(image);
         image.getLambdaJar().ifPresent(jar -> {
             copyFile.copyWrappingExceptions(
                     jarsDirectory.resolve(jar.getFilename(version)),
@@ -134,6 +134,14 @@ public class UploadDockerImages {
             }
             commandRunner.runOrThrow("docker", "push", tag);
         }
+    }
+
+    public Path resolveBuildContext(StackDockerImage image) {
+        if (image.equals(baseImage)) {
+            return deployConfig.overrideBaseImageDirPath()
+                    .orElseGet(() -> baseDockerDirectory.resolve(image.getDirectoryName()));
+        }
+        return baseDockerDirectory.resolve(image.getDirectoryName());
     }
 
     private void pullAndPushImage(String tag, StackDockerImage image) throws IOException, InterruptedException {

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImagesToRepository.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImagesToRepository.java
@@ -28,8 +28,9 @@ public class UploadDockerImagesToRepository {
     }
 
     public static void main(String[] args) throws Exception {
-        if (args.length < 2 || args.length > 3) {
-            System.out.println("Usage: <scripts-dir> <repository-prefix-path> <optional-create-buildx-builder-true-or-false>");
+        if (args.length < 2 || args.length > 4) {
+            System.out.println("Usage: <scripts-dir> <repository-prefix-path> " +
+                    "<optional-create-buildx-builder-true-or-false> <optional-override-base-image-dir>");
             System.exit(1);
             return;
         }
@@ -37,10 +38,13 @@ public class UploadDockerImagesToRepository {
         Path scriptsDirectory = Path.of(args[0]);
         String repositoryPrefix = args[1];
         boolean createMultiplatformBuilder = optionalArgument(args, 2).map(Boolean::parseBoolean).orElse(true);
+        DeployConfiguration deployConfig = optionalArgument(args, 3)
+                .map(DeployConfiguration::fromLocalBuildWithOverrideBaseImageDir)
+                .orElseGet(DeployConfiguration::fromLocalBuild);
 
         UploadDockerImages uploader = UploadDockerImages.builder()
                 .scriptsDirectory(scriptsDirectory)
-                .deployConfig(DeployConfiguration.fromLocalBuild())
+                .deployConfig(deployConfig)
                 .createMultiplatformBuilder(createMultiplatformBuilder)
                 .build();
         uploadAllImages(DockerImageConfiguration.getDefault(), uploader, repositoryPrefix);

--- a/java/clients/src/test/java/sleeper/clients/deploy/DeployConfigurationSerDeTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/DeployConfigurationSerDeTest.java
@@ -82,6 +82,23 @@ public class DeployConfigurationSerDeTest {
     }
 
     @Test
+    void shouldSerDeDeployFromLocalBuildWithOverrideBaseImageDir() {
+        // Given
+        DeployConfiguration configuration = DeployConfiguration.fromLocalBuildWithOverrideBaseImageDir("../custom/base");
+
+        // When
+        String json = serDe.toJson(configuration);
+
+        // Then
+        assertThat(serDe.fromJson(json)).isEqualTo(configuration);
+        assertThat(json).isEqualTo("""
+                {
+                  "dockerImageLocation": "localBuild",
+                  "overrideBaseImageDir": "../custom/base"
+                }""");
+    }
+
+    @Test
     void shouldNotDeserialiseWhenImageLocationIsNotRecognised() {
         // Given
         String json = """

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesResolveBuildContextTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesResolveBuildContextTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.deploy.container;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.clients.deploy.DeployConfiguration;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UploadDockerImagesResolveBuildContextTest extends DockerImagesTestBase {
+
+    @Test
+    void shouldResolveBaseImageBuildContextFromDefaultDirectoryWhenNoOverrideSet() {
+        // Given
+        UploadDockerImages uploader = uploaderBuilder(DeployConfiguration.fromLocalBuild()).build();
+
+        // When
+        Path context = uploader.resolveBuildContext(baseImage());
+
+        // Then
+        assertThat(context).isEqualTo(Path.of("./docker/base"));
+    }
+
+    @Test
+    void shouldResolveBaseImageBuildContextFromOverrideDirectoryWhenSet() {
+        // Given
+        UploadDockerImages uploader = uploaderBuilder(
+                DeployConfiguration.fromLocalBuildWithOverrideBaseImageDir("./custom/base"))
+                .build();
+
+        // When
+        Path context = uploader.resolveBuildContext(baseImage());
+
+        // Then
+        assertThat(context).isEqualTo(Path.of("./custom/base"));
+    }
+
+    @Test
+    void shouldResolveNonBaseImageBuildContextFromDefaultDirectoryEvenWhenOverrideSet() {
+        // Given
+        UploadDockerImages uploader = uploaderBuilder(
+                DeployConfiguration.fromLocalBuildWithOverrideBaseImageDir("./custom/base"))
+                .build();
+        StackDockerImage ingest = StackDockerImage.dockerBuildImage("ingest");
+
+        // When
+        Path context = uploader.resolveBuildContext(ingest);
+
+        // Then
+        assertThat(context).isEqualTo(Path.of("./docker/ingest"));
+    }
+
+    private UploadDockerImages.Builder uploaderBuilder(DeployConfiguration deployConfig) {
+        return UploadDockerImages.builder()
+                .commandRunner(commandRunner)
+                .deployConfig(deployConfig)
+                .baseDockerDirectory(Path.of("./docker"))
+                .jarsDirectory(Path.of("./jars"))
+                .baseImage(baseImage())
+                .version("1.0.0");
+    }
+}

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
@@ -600,6 +600,32 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
     }
 
     @Nested
+    @DisplayName("Override base image directory")
+    class OverrideBaseImageDir {
+
+        @Test
+        void shouldBuildBaseImageFromOverrideDirectoryWhenSet() throws Exception {
+            // Given
+            deployConfig = DeployConfiguration.fromLocalBuildWithOverrideBaseImageDir("./custom/base");
+            properties.setEnum(OPTIONAL_STACKS, OptionalStack.IngestStack);
+
+            // When
+            uploadForDeployment(dockerDeploymentImageConfig());
+
+            // Then
+            String expectedBaseTag = "123.dkr.ecr.test-region.amazonaws.com/test-instance/base:1.0.0";
+            String expectedTag = "123.dkr.ecr.test-region.amazonaws.com/test-instance/ingest:1.0.0";
+            assertThat(commandsThatRan).containsExactly(
+                    dockerLoginToEcrCommand(),
+                    createBuildxBuilderInstanceCommand(),
+                    useBuildxBuilderInstanceCommand(),
+                    buildAndPushMultiplatformImageCommand(expectedBaseTag, "custom/base", expectedBaseTag),
+                    buildImageCommand(expectedTag, "./docker/ingest", expectedBaseTag),
+                    pushImageCommand(expectedTag));
+        }
+    }
+
+    @Nested
     @DisplayName("Upload a specific image")
     class SpecificImage {
 

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrTest.java
@@ -619,7 +619,7 @@ public class UploadDockerImagesToEcrTest extends UploadDockerImagesToEcrTestBase
                     dockerLoginToEcrCommand(),
                     createBuildxBuilderInstanceCommand(),
                     useBuildxBuilderInstanceCommand(),
-                    buildAndPushMultiplatformImageCommand(expectedBaseTag, "custom/base", expectedBaseTag),
+                    buildAndPushMultiplatformImageCommand(expectedBaseTag, "./custom/base", expectedBaseTag),
                     buildImageCommand(expectedTag, "./docker/ingest", expectedBaseTag),
                     pushImageCommand(expectedTag));
         }

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
@@ -169,6 +169,39 @@ public class UploadDockerImagesToRepositoryTest extends DockerImagesTestBase {
     }
 
     @Test
+    void shouldBuildBaseImageFromOverrideDirectoryWhenSet() throws Exception {
+        // Given
+        DockerImageConfiguration dockerImageConfiguration = dockerDeploymentImageConfig();
+        UploadDockerImages uploader = uploaderBuilder()
+                .deployConfig(DeployConfiguration.fromLocalBuildWithOverrideBaseImageDir("./custom/base"))
+                .build();
+
+        // When
+        uploadAllImages(dockerImageConfiguration, uploader);
+
+        // Then
+        String expectedBaseTag = "www.somedocker.com/prefix/base:1.0.0";
+        String expectedCommitterTag = "www.somedocker.com/prefix/statestore-committer:1.0.0";
+        String expectedIngestTag = "www.somedocker.com/prefix/ingest:1.0.0";
+        String expectedBulkImportTag = "www.somedocker.com/prefix/bulk-import-runner:1.0.0";
+        String expectedCompactionTag = "www.somedocker.com/prefix/compaction:1.0.0";
+        String expectedEmrTag = "www.somedocker.com/prefix/bulk-import-runner-emr-serverless:1.0.0";
+        assertThat(commandsThatRan).containsExactly(
+                createBuildxBuilderInstanceCommand(),
+                useBuildxBuilderInstanceCommand(),
+                buildAndPushMultiplatformImageCommand(expectedBaseTag, "custom/base", expectedBaseTag),
+                buildImageCommand(expectedCommitterTag, "./docker/statestore-committer", expectedBaseTag),
+                pushImageCommand(expectedCommitterTag),
+                buildImageCommand(expectedIngestTag, "./docker/ingest", expectedBaseTag),
+                pushImageCommand(expectedIngestTag),
+                buildImageCommand(expectedBulkImportTag, "./docker/bulk-import-runner", expectedBaseTag),
+                pushImageCommand(expectedBulkImportTag),
+                buildAndPushMultiplatformImageCommand(expectedCompactionTag, "./docker/compaction", expectedBaseTag),
+                buildImageCommand(expectedEmrTag, "./docker/bulk-import-runner-emr-serverless", expectedBaseTag),
+                pushImageCommand(expectedEmrTag));
+    }
+
+    @Test
     void shouldFailWhenDockerBuildFails() {
         // Given
         DockerImageConfiguration dockerImageConfiguration = dockerDeploymentImageConfig();

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/UploadDockerImagesToRepositoryTest.java
@@ -189,7 +189,7 @@ public class UploadDockerImagesToRepositoryTest extends DockerImagesTestBase {
         assertThat(commandsThatRan).containsExactly(
                 createBuildxBuilderInstanceCommand(),
                 useBuildxBuilderInstanceCommand(),
-                buildAndPushMultiplatformImageCommand(expectedBaseTag, "custom/base", expectedBaseTag),
+                buildAndPushMultiplatformImageCommand(expectedBaseTag, "./custom/base", expectedBaseTag),
                 buildImageCommand(expectedCommitterTag, "./docker/statestore-committer", expectedBaseTag),
                 pushImageCommand(expectedCommitterTag),
                 buildImageCommand(expectedIngestTag, "./docker/ingest", expectedBaseTag),

--- a/scripts/dev/publishDocker.sh
+++ b/scripts/dev/publishDocker.sh
@@ -16,8 +16,8 @@
 set -e
 unset CDPATH
 
-if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
-  echo "Usage: $0 <repository-prefix-path> <optional-create-buildx-builder-true-or-false>"
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+  echo "Usage: $0 <repository-prefix-path> <optional-create-buildx-builder-true-or-false> <optional-override-base-image-dir>"
   exit 1
 fi
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7318

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - UploadDockerImagesResolveBuildContextTest.java

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
