### PR TITLE
Issue 7355 - Document the places where extra custom environment hook points exist

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -13,6 +13,8 @@ If you just want a local instance for testing, see the documentation
 on [deploying to localstack](deployment/deploy-to-localstack.md). This has very limited functionality compared to a
 deployed instance.
 
+If your build environment needs to substitute the default container base image, route `cargo` or `rustup` traffic through internal mirrors, or trust a private certificate authority, see [building in a custom environment](development/custom-environment.md) for the available hooks.
+
 ## Deployment
 
 Sleeper is deployed using the AWS CDK. You can invoke the CDK to do this either using the automated scripts or by using

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -218,3 +218,7 @@ See the [release process guide](development/release-process.md) for instructions
 ## Development scripts
 
 See [development scripts](development/dev-scripts.md) for scripts that can assist you while working on Sleeper.
+
+## Building in a custom environment
+
+If your build environment needs to substitute the default container base image, route `cargo` or `rustup` traffic through internal mirrors, or trust a private certificate authority, see [building in a custom environment](development/custom-environment.md) for the available hooks and environment variables.

--- a/docs/development/custom-environment.md
+++ b/docs/development/custom-environment.md
@@ -1,0 +1,90 @@
+Building Sleeper in a custom environment
+========================================
+
+Sleeper's build and deployment scripts have a small set of hooks for users whose environments need to substitute the default build inputs. This page lists every such hook in one place: what it does, and a worked example.
+
+None of these are needed for a default build.
+
+## Container images
+
+### `--override-base-image-dir` (on `setDeployConfig.sh` and `publishDocker.sh`)
+
+Overrides the directory used as the Docker build context for the Sleeper base image. By default the base image is built from `scripts/docker/base`. Pass a different directory containing your own `Dockerfile` to substitute a custom base image.
+
+The override only applies to local builds — it cannot be combined with `--image-location repository`.
+
+Example — `setDeployConfig.sh` (persists the override in `scripts/templates/deployConfig.json`, so it is picked up by `deployNew.sh` and `deployExisting.sh`):
+
+```bash
+./scripts/deploy/setDeployConfig.sh \
+    --image-location localBuild \
+    --override-base-image-dir /path/to/my/base
+```
+
+Example — `publishDocker.sh` (override at publish time only; saved config is not consulted):
+
+```bash
+./scripts/dev/publishDocker.sh my.registry.com/path true /path/to/my/base
+```
+
+See [publishing artefacts](publishing.md) for the full publish flow.
+
+## Rust build
+
+The Rust components are built inside Docker containers via `rust/build-in-docker.sh`, with the builder images themselves produced by `rust/builders/buildAll.sh` (or `buildAllSccache.sh`). The hooks below affect either the building of those builder images or how the Rust workload runs inside them.
+
+### `RUSTUP_DIST_SERVER` and `RUSTUP_UPDATE_ROOT`
+
+Override the upstream servers used by `rustup` when installing the Rust toolchain into the builder images.
+
+Example:
+
+```bash
+export RUSTUP_DIST_SERVER=https://rustup.internal.example.com
+export RUSTUP_UPDATE_ROOT=https://rustup.internal.example.com/rustup
+./rust/builders/buildAll.sh
+```
+
+Either variable can be set independently. If both are unset, the builder images are built against the public rustup servers.
+
+### `EXTRA_CARGO_CONFIG`
+
+Appends arbitrary TOML to the `cargo` config used for the current Rust build, without modifying the checked-in `rust/.cargo/config.toml`. The value must be valid TOML; multi-line values are supported via `\n` escapes.
+
+Use this to point `cargo` at an internal `crates.io` mirror, configure a private registry, set source replacement rules, or any other per-environment `cargo` setting that should not be committed.
+
+Example — replace the default `crates.io` source with an internal mirror:
+
+```bash
+export EXTRA_CARGO_CONFIG='[source.crates-io]\nreplace-with = "internal-mirror"\n\n[source.internal-mirror]\nregistry = "https://crates.internal.example.com/index"'
+./rust/build-in-docker.sh x86_64
+```
+
+### `SKIP_DOCKER_PULL`
+
+When set to any non-empty value, `rust/build-in-docker.sh` does not run `docker pull` against the builder image before running the build. The build still uses whatever image is locally tagged.
+
+Useful when you have built the builder image locally and do not want it overwritten by a pull, or when the public registry is unreachable and the image has been loaded by some other means.
+
+Example:
+
+```bash
+./rust/builders/buildAll.sh                # builds and tags the image locally
+export SKIP_DOCKER_PULL=true
+./rust/build-in-docker.sh x86_64           # uses the local image, no pull
+```
+
+### `certs/` directory
+
+Drop PEM-encoded CA certificate files into the `certs/` directory at the repository root if the Rust builder image needs to trust a private certificate authority. Any file extension may be used — `.crt`, `.pem`, `.cer`, etc.
+
+Files placed here (other than the placeholder `README.md`) are picked up by `rust/builders/buildAll.sh` and `rust/builders/buildAllSccache.sh` and installed as trusted CA certificates **inside the builder container**. Nothing is installed on the host.
+
+If `certs/` only contains the placeholder `README.md`, the builder images are built without any custom CA trust changes.
+
+Example:
+
+```bash
+cp my-corporate-root-ca.crt certs/
+./rust/builders/buildAll.sh
+```

--- a/docs/development/dev-scripts.md
+++ b/docs/development/dev-scripts.md
@@ -70,7 +70,7 @@ grouping, etc.
 
 #### `publishDocker.sh`
 
-Publishes Docker images to a remote repository, see [publishing artefacts](publishing.md).
+Publishes Docker images to a remote repository, see [publishing artefacts](publishing.md). For hooks that adjust how the images are built (e.g. substituting a custom base image), see [building in a custom environment](custom-environment.md).
 
 #### `publishMaven.sh`
 

--- a/docs/development/publishing.md
+++ b/docs/development/publishing.md
@@ -57,6 +57,8 @@ By default the base image is built from `scripts/docker/base`. Pass a different 
 
 This is intended for non-standard setups only. Every other image is still built from the standard Sleeper Dockerfiles, and they will use your custom base image as their `BASE_IMAGE` build arg. The same override is available on `setDeployConfig.sh` via `--override-base-image-dir <dir>`, so it is also picked up when deploying with `scripts/deploy/deployNew.sh` or `scripts/deploy/deployExisting.sh`. It cannot be combined with `--image-location repository`, because the override only applies when images are built locally.
 
+For the full list of hooks and environment variables that support building Sleeper in restricted network environments, see [building in a custom environment](custom-environment.md).
+
 ### Installing published artefacts
 
 We have scripts to install Sleeper from published artefacts. We have not yet published Sleeper to Maven Central or

--- a/rust/builders/base-sccache/.dockerignore
+++ b/rust/builders/base-sccache/.dockerignore
@@ -1,0 +1,1 @@
+certs/README.md

--- a/rust/builders/base/.dockerignore
+++ b/rust/builders/base/.dockerignore
@@ -1,0 +1,1 @@
+certs/README.md

--- a/rust/builders/buildAll.sh
+++ b/rust/builders/buildAll.sh
@@ -26,9 +26,12 @@ BUILD_ARGS="${RUSTUP_DIST_SERVER:+--build-arg RUSTUP_DIST_SERVER=${RUSTUP_DIST_S
 
 pushd "$THIS_DIR"/base
 rm -rf certs
-# Copy custom CA certs into build context if present at repo root
-if [ -n "$(ls -A "$BASE_DIR/certs" 2>/dev/null)" ]; then
+# Copy custom CA certs into build context if present at repo root.
+# Ignore README.md — the certs directory is checked into Git via a placeholder README,
+# so we only treat the directory as populated when it contains at least one other file.
+if [ -n "$(ls -A "$BASE_DIR/certs" 2>/dev/null | grep -v '^README\.md$')" ]; then
   cp -r "$BASE_DIR/certs" certs
+  rm -f certs/README.md
 fi
 docker build -t sleeper-rust-builder-base:current .
 popd

--- a/rust/builders/buildAllSccache.sh
+++ b/rust/builders/buildAllSccache.sh
@@ -26,18 +26,24 @@ BUILD_ARGS="${RUSTUP_DIST_SERVER:+--build-arg RUSTUP_DIST_SERVER=${RUSTUP_DIST_S
 
 pushd "$THIS_DIR"/base
 rm -rf certs
-# Copy custom CA certs into build context if present at repo root
-if [ -n "$(ls -A "$BASE_DIR/certs" 2>/dev/null)" ]; then
+# Copy custom CA certs into build context if present at repo root.
+# Ignore README.md — the certs directory is checked into Git via a placeholder README,
+# so we only treat the directory as populated when it contains at least one other file.
+if [ -n "$(ls -A "$BASE_DIR/certs" 2>/dev/null | grep -v '^README\.md$')" ]; then
   cp -r "$BASE_DIR/certs" certs
+  rm -f certs/README.md
 fi
 docker build -t sleeper-rust-builder-base:current .
 popd
 
 pushd "$THIS_DIR"/base-sccache
 rm -rf certs
-# Copy custom CA certs into build context if present at repo root
-if [ -n "$(ls -A "$BASE_DIR/certs" 2>/dev/null)" ]; then
+# Copy custom CA certs into build context if present at repo root.
+# Ignore README.md — the certs directory is checked into Git via a placeholder README,
+# so we only treat the directory as populated when it contains at least one other file.
+if [ -n "$(ls -A "$BASE_DIR/certs" 2>/dev/null | grep -v '^README\.md$')" ]; then
   cp -r "$BASE_DIR/certs" certs
+  rm -f certs/README.md
 fi
 docker build -t sleeper-rust-builder-sccache:current .
 popd


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7355

### Tests

- [X] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
