### PR TITLE
Issue 7363 - Sudo to clear Rust target directory in nightly tests

### DIFF
--- a/scripts/test/nightly/startNightlyTestsFromHost.sh
+++ b/scripts/test/nightly/startNightlyTestsFromHost.sh
@@ -49,7 +49,7 @@ cleanDisk() {
     mkdir -p "$CACHE_DIR_HOST"
     rm -rf "$CACHE_DIR_HOST"/*
     mkdir -p "$RUST_TARGET_DIR_HOST"
-    rm -rf "$RUST_TARGET_DIR_HOST"/*
+    sudo rm -rf "$RUST_TARGET_DIR_HOST"/*
     echo "Finding old logs to delete under $LOGS_DIR_HOST"
     find "$LOGS_DIR_HOST"/* -maxdepth 0 -type d -daystart -mtime +7 -exec echo "Deleting directory:" {} \; -exec rm -rf {} \;
     find "$LOGS_DIR_HOST"/* -maxdepth 0 -type f -daystart -mtime +7 -exec echo "Deleting file:" {} \; -exec rm -f {} \;


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7363

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Ran in nightly test build EC2: `scripts/test/nightly/startNightlyTestsFromHost.sh ubuntu performance`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
