### PR TITLE
Issue 7368 - Upgrade aquasecurity/trivy-action to 0.36.0

### DIFF
--- a/.github/workflows/docker-cli-image.yaml
+++ b/.github/workflows/docker-cli-image.yaml
@@ -111,14 +111,13 @@ jobs:
         if: ${{ inputs.runTrivy }}
         run: docker pull ${{ env.TEMP_IMAGE }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@0.36.0
         if: ${{ inputs.runTrivy }}
         with:
           image-ref: ${{ env.TEMP_IMAGE }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
-          version: latest
       - name: Push image to GitHub
         if: ${{ inputs.pushImages }}
         uses: docker/build-push-action@v7

--- a/.github/workflows/docker-cli-image.yaml
+++ b/.github/workflows/docker-cli-image.yaml
@@ -111,7 +111,7 @@ jobs:
         if: ${{ inputs.runTrivy }}
         run: docker pull ${{ env.TEMP_IMAGE }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         if: ${{ inputs.runTrivy }}
         with:
           image-ref: ${{ env.TEMP_IMAGE }}

--- a/.github/workflows/docker-cli.yaml
+++ b/.github/workflows/docker-cli.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Pull dependencies image from registry
         run: docker pull ${{ env.DEPENDENCIES_IMAGE }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.DEPENDENCIES_IMAGE }}
           format: 'table'

--- a/.github/workflows/docker-cli.yaml
+++ b/.github/workflows/docker-cli.yaml
@@ -51,13 +51,12 @@ jobs:
       - name: Pull dependencies image from registry
         run: docker pull ${{ env.DEPENDENCIES_IMAGE }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: ${{ env.DEPENDENCIES_IMAGE }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
-          version: latest
       - name: Save dependencies image to tarball
         run: docker save ${{ env.DEPENDENCIES_IMAGE }} --output /tmp/dependencies-image.tar
       - name: Upload dependencies image as artifact

--- a/.github/workflows/docker-image-test.yaml
+++ b/.github/workflows/docker-image-test.yaml
@@ -90,7 +90,7 @@ jobs:
         env:
           TRIVY_IGNOREFILE: ${{ inputs.trivyIgnore }}
           TRIVY_SHOW_SUPPRESSED: true
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ inputs.imageName }}:test'
           format: 'table'

--- a/.github/workflows/docker-image-test.yaml
+++ b/.github/workflows/docker-image-test.yaml
@@ -90,10 +90,9 @@ jobs:
         env:
           TRIVY_IGNOREFILE: ${{ inputs.trivyIgnore }}
           TRIVY_SHOW_SUPPRESSED: true
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           image-ref: '${{ inputs.imageName }}:test'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
-          version: latest


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7368

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Running in GitHub Actions

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
