### PR TITLE
Issue 7387 - Allow propagating session tags when assuming admin role

### DIFF
--- a/java/deployment/cdk/src/main/java/sleeper/cdk/stack/core/ManagedPoliciesStack.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/stack/core/ManagedPoliciesStack.java
@@ -154,7 +154,7 @@ public class ManagedPoliciesStack extends NestedStack {
 
     private Role createAdminRole() {
         Role role = Role.Builder.create(this, "AdminRole")
-                .assumedBy(new AccountRootPrincipal())
+                .assumedBy(new AccountRootPrincipal().withSessionTags())
                 .roleName(getAdminRoleName(instanceProperties))
                 .build();
 

--- a/java/deployment/cdk/src/test/java/sleeper/cdk/default-instance.approved.json
+++ b/java/deployment/cdk/src/test/java/sleeper/cdk/default-instance.approved.json
@@ -6907,7 +6907,10 @@
               "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "sts:AssumeRole",
+                  "Action": [
+                    "sts:AssumeRole",
+                    "sts:TagSession"
+                  ],
                   "Effect": "Allow",
                   "Principal": {
                     "AWS": {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7387

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Covered by existing tests

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
