### PR TITLE
Issue 7380 - Avoid timeouts calling Kubernetes API in EKS system tests

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/EksAuthTokenGenerator.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/EksAuthTokenGenerator.java
@@ -16,6 +16,8 @@
 
 package sleeper.systemtest.drivers.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.awssdk.http.SdkHttpRequest;
@@ -36,11 +38,13 @@ import java.util.Base64;
  * x-k8s-aws-id header is part of the signed canonical request, which is what binds the token to a specific cluster.
  */
 public class EksAuthTokenGenerator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EksAuthTokenGenerator.class);
 
     private EksAuthTokenGenerator() {
     }
 
     public static String generateToken(String clusterName, Region region, AwsCredentialsProvider credentialsProvider) {
+        LOGGER.info("Generating token for cluster {}", clusterName);
         PartitionMetadata partitionMetadata = PartitionMetadata.of(region);
         SdkHttpRequest request = SdkHttpRequest.builder()
                 .method(SdkHttpMethod.GET)
@@ -53,7 +57,7 @@ public class EksAuthTokenGenerator {
                 .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "sts")
                 .putProperty(AwsV4HttpSigner.REGION_NAME, region.id())
                 .putProperty(AwsV4HttpSigner.AUTH_LOCATION, AwsV4HttpSigner.AuthLocation.QUERY_STRING)
-                .putProperty(AwsV4HttpSigner.EXPIRATION_DURATION, Duration.ofSeconds(60))
+                .putProperty(AwsV4HttpSigner.EXPIRATION_DURATION, Duration.ofMinutes(15))
                 .request(request)
                 .build());
         String presignedUrl = signed.request().getUri().toString();

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/SystemTestClients.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/util/SystemTestClients.java
@@ -284,6 +284,8 @@ public class SystemTestClients {
                 .withCaCertData(instanceProperties.get(BULK_IMPORT_EKS_CLUSTER_CA_DATA))
                 .withOauthTokenProvider(() -> EksAuthTokenGenerator.generateToken(
                         instanceProperties.get(BULK_IMPORT_EKS_CLUSTER_NAME), region, credentialsProvider))
+                .withConnectionTimeout(30 * 1000)
+                .withRequestTimeout(60 * 1000)
                 .build();
         return new KubernetesClientBuilder().withConfig(config).build();
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7380

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Ran EksBulkImportST in AWS

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
