### PR TITLE
7189: Make Compaction Tasks exit loop when experiencing interrupt exc…

### DIFF
--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
@@ -157,6 +157,10 @@ public class CompactionTask {
                     processCompactionMessage(jobRunId, taskFinishedBuilder, message, idleTimeTracker, consecutiveFailuresTracker);
                 }
             }
+            if (Thread.currentThread().isInterrupted()) {
+                LOGGER.warn("Compaction task interrupted, terminating");
+                break;
+            }
         }
         return timeSupplier.get();
     }
@@ -177,10 +181,10 @@ public class CompactionTask {
             LOGGER.error("Found invalid job while waiting for input file assignment, deleting from queue", e);
             message.deleteFromQueue();
             return false;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
         } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             LOGGER.error("Failed preparing compaction job, putting job back on queue", e);
             failureTracker.incrementConsecutiveFailures();
             message.returnToQueue();
@@ -201,10 +205,6 @@ public class CompactionTask {
                 message.deleteFromQueue();
                 throw e;
             } catch (Exception e) {
-                if (Thread.currentThread().isInterrupted()) {
-                    LOGGER.warn("Compaction task interrupted, terminating");
-                    throw e;
-                }
                 LOGGER.error("Failed processing compaction job, putting job back on queue", e);
                 failureTracker.incrementConsecutiveFailures();
                 message.returnToQueue();
@@ -215,9 +215,6 @@ public class CompactionTask {
             jobTracker.jobFailed(message.getJob()
                     .failedEventBuilder(timeSupplier.get())
                     .failure(e).taskId(taskId).jobRunId(jobRunId).build());
-            if (Thread.currentThread().isInterrupted()) {
-                throw new RuntimeException(e);
-            }
         }
     }
 
@@ -233,9 +230,6 @@ public class CompactionTask {
             failureTracker.resetConsecutiveFailures();
             idleTimeTracker.setLastActiveTime(summary.getFinishTime());
         } catch (Exception e) {
-            if (Thread.currentThread().isInterrupted()) {
-                throw e;
-            }
             if (e.getCause() instanceof FileNotFoundException || e.getCause() instanceof FileReferenceNotAssignedToJobException) {
                 LOGGER.error("Found invalid job while committing to state store, deleting from queue", e);
                 message.deleteFromQueue();

--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
@@ -178,6 +178,10 @@ public class CompactionTask {
             message.deleteFromQueue();
             return false;
         } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
             LOGGER.error("Failed preparing compaction job, putting job back on queue", e);
             failureTracker.incrementConsecutiveFailures();
             message.returnToQueue();
@@ -198,6 +202,9 @@ public class CompactionTask {
                 message.deleteFromQueue();
                 throw e;
             } catch (Exception e) {
+                if (Thread.currentThread().isInterrupted()) {
+                    throw new RuntimeException(e);
+                }
                 LOGGER.error("Failed processing compaction job, putting job back on queue", e);
                 failureTracker.incrementConsecutiveFailures();
                 message.returnToQueue();
@@ -208,6 +215,9 @@ public class CompactionTask {
             jobTracker.jobFailed(message.getJob()
                     .failedEventBuilder(timeSupplier.get())
                     .failure(e).taskId(taskId).jobRunId(jobRunId).build());
+            if (Thread.currentThread().isInterrupted()) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -223,6 +233,9 @@ public class CompactionTask {
             failureTracker.resetConsecutiveFailures();
             idleTimeTracker.setLastActiveTime(summary.getFinishTime());
         } catch (Exception e) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw e;
+            }
             if (e.getCause() instanceof FileNotFoundException || e.getCause() instanceof FileReferenceNotAssignedToJobException) {
                 LOGGER.error("Found invalid job while committing to state store, deleting from queue", e);
                 message.deleteFromQueue();

--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
@@ -203,6 +203,7 @@ public class CompactionTask {
                 throw e;
             } catch (Exception e) {
                 if (Thread.currentThread().isInterrupted()) {
+                    LOGGER.warn("Compaction task interrupted, terminating");
                     throw new RuntimeException(e);
                 }
                 LOGGER.error("Failed processing compaction job, putting job back on queue", e);

--- a/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
+++ b/java/compaction/compaction-core/src/main/java/sleeper/compaction/core/task/CompactionTask.java
@@ -177,11 +177,10 @@ public class CompactionTask {
             LOGGER.error("Found invalid job while waiting for input file assignment, deleting from queue", e);
             message.deleteFromQueue();
             return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
         } catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
             LOGGER.error("Failed preparing compaction job, putting job back on queue", e);
             failureTracker.incrementConsecutiveFailures();
             message.returnToQueue();
@@ -204,7 +203,7 @@ public class CompactionTask {
             } catch (Exception e) {
                 if (Thread.currentThread().isInterrupted()) {
                     LOGGER.warn("Compaction task interrupted, terminating");
-                    throw new RuntimeException(e);
+                    throw e;
                 }
                 LOGGER.error("Failed processing compaction job, putting job back on queue", e);
                 failureTracker.incrementConsecutiveFailures();

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
@@ -224,7 +224,7 @@ public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
             assertThat(jobsReturnedToQueue).as("interrupted job should be put back on queue").containsExactly(job1);
             assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
             assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
-            Thread.interrupted(); // clear interrupt flag set during test
+            assertThat(Thread.interrupted()).isTrue(); // clear interrupt flag set during test
         }
 
         @Test
@@ -241,7 +241,7 @@ public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
             assertThat(consumedJobs).as("interrupted job should be committed and deleted from queue").containsExactly(job1);
             assertThat(jobsReturnedToQueue).isEmpty();
             assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
-            Thread.interrupted(); // clear interrupt flag set during test
+            assertThat(Thread.interrupted()).isTrue(); // clear interrupt flag set during test
         }
     }
 

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
@@ -34,6 +34,8 @@ import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TAS
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_ALIVE_TIME_IN_MINUTES;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_CONSECUTIVE_FAILURES;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_IDLE_TIME_IN_SECONDS;
+import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT;
+import static sleeper.core.statestore.testutils.StateStoreUpdatesWrapper.update;
 import static sleeper.core.testutils.SupplierTestHelper.supplyTimes;
 
 public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
@@ -214,6 +216,50 @@ public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(new InterruptedException());
             })).isInstanceOf(RuntimeException.class);
+            assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
+            assertThat(jobsReturnedToQueue).as("interrupted job should not be explicitly returned to queue").isEmpty();
+            assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
+            Thread.interrupted(); // clear interrupt flag set during test
+        }
+
+        @Test
+        void shouldTerminateIfInterruptedDuringFileAssignment() throws Exception {
+            // Given
+            instanceProperties.set(COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT, "true");
+            createJobOnQueue("job1");
+            CompactionJob job2 = createJobOnQueue("job2");
+
+            // When / Then
+            assertThatThrownBy(() -> runTaskCheckingFiles(
+                    new StateStoreWaitForFiles(0, null, null, null, null, null, null, null) {
+                        @Override
+                        public void wait(CompactionJob job, String taskId, String jobRunId) throws InterruptedException {
+                            Thread.currentThread().interrupt();
+                            throw new InterruptedException();
+                        }
+                    },
+                    processNoJobs()))
+                    .isInstanceOf(RuntimeException.class);
+            assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
+            assertThat(jobsReturnedToQueue).as("interrupted job should not be explicitly returned to queue").isEmpty();
+            assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
+            Thread.interrupted(); // clear interrupt flag set during test
+        }
+
+        @Test
+        void shouldTerminateIfInterruptedDuringCommit() throws Exception {
+            // Given
+            setSyncCommit(tableProperties);
+            createJobOnQueue("job1");
+            CompactionJob job2 = createJobOnQueue("job2");
+
+            // When / Then
+            assertThatThrownBy(() -> runTask(
+                    processJobs(jobSucceeds().withAction(() -> {
+                        Thread.currentThread().interrupt();
+                        update(stateStore).clearFileData();
+                    }))))
+                    .isInstanceOf(RuntimeException.class);
             assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
             assertThat(jobsReturnedToQueue).as("interrupted job should not be explicitly returned to queue").isEmpty();
             assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
@@ -28,14 +28,12 @@ import java.util.List;
 import java.util.function.DoubleSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_DELAY_BEFORE_RETRY_IN_SECONDS;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_ALIVE_JITTER_IN_MINUTES;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_ALIVE_TIME_IN_MINUTES;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_CONSECUTIVE_FAILURES;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_IDLE_TIME_IN_SECONDS;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT;
-import static sleeper.core.statestore.testutils.StateStoreUpdatesWrapper.update;
 import static sleeper.core.testutils.SupplierTestHelper.supplyTimes;
 
 public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
@@ -206,42 +204,25 @@ public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
     class StopIfInterrupted {
 
         @Test
-        void shouldTerminateIfInterruptedDuringCompaction() throws Exception {
-            // Given
-            createJobOnQueue("job1");
-            CompactionJob job2 = createJobOnQueue("job2");
-
-            // When / Then
-            assertThatThrownBy(() -> runTask(request -> {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(new InterruptedException());
-            })).isInstanceOf(RuntimeException.class);
-            assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
-            assertThat(jobsReturnedToQueue).as("interrupted job should not be explicitly returned to queue").isEmpty();
-            assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
-            Thread.interrupted(); // clear interrupt flag set during test
-        }
-
-        @Test
         void shouldTerminateIfInterruptedDuringFileAssignment() throws Exception {
             // Given
             instanceProperties.set(COMPACTION_TASK_WAIT_FOR_INPUT_FILE_ASSIGNMENT, "true");
-            createJobOnQueue("job1");
+            CompactionJob job1 = createJobOnQueue("job1");
             CompactionJob job2 = createJobOnQueue("job2");
 
-            // When / Then
-            assertThatThrownBy(() -> runTaskCheckingFiles(
+            // When
+            runTaskCheckingFiles(
                     new StateStoreWaitForFiles(0, null, null, null, null, null, null, null) {
                         @Override
                         public void wait(CompactionJob job, String taskId, String jobRunId) throws InterruptedException {
-                            Thread.currentThread().interrupt();
                             throw new InterruptedException();
                         }
                     },
-                    processNoJobs()))
-                    .isInstanceOf(RuntimeException.class);
+                    processNoJobs());
+
+            // Then
+            assertThat(jobsReturnedToQueue).as("interrupted job should be put back on queue").containsExactly(job1);
             assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
-            assertThat(jobsReturnedToQueue).as("interrupted job should not be explicitly returned to queue").isEmpty();
             assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
             Thread.interrupted(); // clear interrupt flag set during test
         }
@@ -250,18 +231,15 @@ public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
         void shouldTerminateIfInterruptedDuringCommit() throws Exception {
             // Given
             setSyncCommit(tableProperties);
-            createJobOnQueue("job1");
+            CompactionJob job1 = createJobOnQueue("job1");
             CompactionJob job2 = createJobOnQueue("job2");
 
-            // When / Then
-            assertThatThrownBy(() -> runTask(
-                    processJobs(jobSucceeds().withAction(() -> {
-                        Thread.currentThread().interrupt();
-                        update(stateStore).clearFileData();
-                    }))))
-                    .isInstanceOf(RuntimeException.class);
-            assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
-            assertThat(jobsReturnedToQueue).as("interrupted job should not be explicitly returned to queue").isEmpty();
+            // When
+            runTask(processJobs(jobSucceeds().withAction(Thread.currentThread()::interrupt)));
+
+            // Then
+            assertThat(consumedJobs).as("interrupted job should be committed and deleted from queue").containsExactly(job1);
+            assertThat(jobsReturnedToQueue).isEmpty();
             assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
             Thread.interrupted(); // clear interrupt flag set during test
         }

--- a/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
+++ b/java/compaction/compaction-core/src/test/java/sleeper/compaction/core/task/CompactionTaskTerminateTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.function.DoubleSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_DELAY_BEFORE_RETRY_IN_SECONDS;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_ALIVE_JITTER_IN_MINUTES;
 import static sleeper.core.properties.instance.CompactionProperty.COMPACTION_TASK_MAX_ALIVE_TIME_IN_MINUTES;
@@ -195,6 +196,28 @@ public class CompactionTaskTerminateTest extends CompactionTaskTestBase {
             // Then
             assertThat(supplier.getRemainingTimes()).isEmpty();
             assertThat(sleeps).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Stop if interrupted")
+    class StopIfInterrupted {
+
+        @Test
+        void shouldTerminateIfInterruptedDuringCompaction() throws Exception {
+            // Given
+            createJobOnQueue("job1");
+            CompactionJob job2 = createJobOnQueue("job2");
+
+            // When / Then
+            assertThatThrownBy(() -> runTask(request -> {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(new InterruptedException());
+            })).isInstanceOf(RuntimeException.class);
+            assertThat(consumedJobs).as("interrupted job should not be deleted from queue").isEmpty();
+            assertThat(jobsReturnedToQueue).as("interrupted job should not be explicitly returned to queue").isEmpty();
+            assertThat(jobsOnQueue).as("second job should not be processed").containsExactly(job2);
+            Thread.interrupted(); // clear interrupt flag set during test
         }
     }
 


### PR DESCRIPTION
…eption

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7189

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - CompactionTaskTerminateTest

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
