### PR TITLE
7488: Revert changes to VpcCheckLambda

### DIFF
--- a/java/deployment/cdk-custom-resources/src/main/java/sleeper/cdk/custom/VpcCheckLambda.java
+++ b/java/deployment/cdk-custom-resources/src/main/java/sleeper/cdk/custom/VpcCheckLambda.java
@@ -17,16 +17,12 @@ package sleeper.cdk.custom;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.CloudFormationCustomResourceEvent;
-import software.amazon.awssdk.regions.PartitionMetadata;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.Filter;
 import software.amazon.awssdk.services.ec2.model.VpcEndpoint;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class VpcCheckLambda {
     private final Ec2Client vpcClient;
@@ -59,7 +55,7 @@ public class VpcCheckLambda {
     private void validateVpc(String vpcId, String region) {
         List<VpcEndpoint> vpcEndpoints = vpcClient.describeVpcEndpoints(builder -> builder
                 .filters(Filter.builder().name("vpc-id").values(vpcId).build(),
-                        Filter.builder().name("service-name").values(s3VpcEndpointServiceName(region)).build()))
+                        Filter.builder().name("service-name").values("com.amazonaws." + region + ".s3").build()))
                 .vpcEndpoints();
 
         if (vpcEndpoints.size() != 1) {
@@ -67,14 +63,5 @@ public class VpcCheckLambda {
                     + "for reading and writing data to your data buckets. We strongly encourage you to add an S3 endpoint to your"
                     + " VPC. To disable this check, set the instance property 'sleeper.vpc.endpoint.check' to false.");
         }
-    }
-
-    private static String s3VpcEndpointServiceName(String region) {
-        PartitionMetadata partitionMetadata = PartitionMetadata.of(Region.of(region));
-        String[] suffixParts = partitionMetadata.dnsSuffix().split("\\.");
-        String reversedSuffix = IntStream.range(0, suffixParts.length)
-                .mapToObj(i -> suffixParts[suffixParts.length - 1 - i])
-                .collect(Collectors.joining("."));
-        return reversedSuffix + "." + region + ".s3";
     }
 }

--- a/java/deployment/cdk-custom-resources/src/test/java/sleeper/cdk/custom/VpcCheckLambdaIT.java
+++ b/java/deployment/cdk-custom-resources/src/test/java/sleeper/cdk/custom/VpcCheckLambdaIT.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -32,6 +33,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.localstack.test.WiremockAwsV2ClientHelper.wiremockAwsV2Client;
 
@@ -39,16 +41,50 @@ import static sleeper.localstack.test.WiremockAwsV2ClientHelper.wiremockAwsV2Cli
 class VpcCheckLambdaIT {
 
     @Test
-    void shouldFindVpcEndpointIsPresent(WireMockRuntimeInfo runtimeInfo) {
+    void shouldThrowExceptionWhenVpcRequestReturnsNoMatchingEndpoints(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        stubFor(describeVpcEndpoints().willReturn(noVpcEndpointsResponse()));
+
+        // When
+        VpcCheckLambda vpcCheckLambda = new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
+        CloudFormationCustomResourceEvent event = CloudFormationCustomResourceEvent.builder()
+                .withRequestType("Create")
+                .withResourceProperties(new HashMap<>()).build();
+
+        // Then
+        assertThatThrownBy(() -> vpcCheckLambda.handleEvent(event, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("endpoint");
+    }
+
+    @Test
+    void shouldNotThrowExceptionWhenVpcRequestReturnsMatchingEndpoints(WireMockRuntimeInfo runtimeInfo) {
         // Given
         stubFor(describeVpcEndpoints().willReturn(singleVpcEndpointResponse()));
 
-        Map<String, Object> properties = Map.of(
-                "vpcId", "myVpc",
-                "region", "eu-west-2");
+        // When
+        VpcCheckLambda vpcCheckLambda = new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
+        CloudFormationCustomResourceEvent event = CloudFormationCustomResourceEvent.builder()
+                .withRequestType("Create")
+                .withResourceProperties(new HashMap<>()).build();
+
+        // Then
+        assertThatCode(() -> vpcCheckLambda.handleEvent(event, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldPassVpcIdAndRegionFromThePropertiesToTheRequest(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        stubFor(describeVpcEndpoints().willReturn(singleVpcEndpointResponse()));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("vpcId", "myVpc");
+        properties.put("region", "my-region-1");
 
         // When
-        lambda(runtimeInfo).handleEvent(CloudFormationCustomResourceEvent.builder()
+        VpcCheckLambda vpcCheckLambda = new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
+        vpcCheckLambda.handleEvent(CloudFormationCustomResourceEvent.builder()
                 .withRequestType("Create")
                 .withResourceProperties(properties).build(), null);
 
@@ -57,52 +93,7 @@ class VpcCheckLambdaIT {
                 .withRequestBody(containing("Filter.1.Name=vpc-id")
                         .and(containing("Filter.1.Value.1=myVpc"))
                         .and(containing("Filter.2.Name=service-name"))
-                        .and(containing("Filter.2.Value.1=com.amazonaws.eu-west-2.s3"))));
-    }
-
-    @Test
-    void shouldFindVpcEndpointInNonStandardAWSPartition(WireMockRuntimeInfo runtimeInfo) {
-        // Given
-        stubFor(describeVpcEndpoints().willReturn(singleVpcEndpointResponse()));
-
-        Map<String, Object> properties = Map.of(
-                "vpcId", "myVpc",
-                "region", "eusc-de-east-1");
-
-        // When
-        lambda(runtimeInfo).handleEvent(CloudFormationCustomResourceEvent.builder()
-                .withRequestType("Create")
-                .withResourceProperties(properties).build(), null);
-
-        // Then
-        verify(1, postRequestedFor(urlEqualTo("/"))
-                .withRequestBody(containing("Filter.2.Name=service-name")
-                        .and(containing("Filter.2.Value.1=eu.amazonaws.eusc-de-east-1.s3"))));
-    }
-
-    @Test
-    void shouldFailWhenVpcEndpointIsNotPresent(WireMockRuntimeInfo runtimeInfo) {
-        // Given
-        stubFor(describeVpcEndpoints().willReturn(noVpcEndpointsResponse()));
-
-        Map<String, Object> properties = Map.of(
-                "vpcId", "myVpc",
-                "region", "eu-west-2");
-
-        // When
-        VpcCheckLambda vpcCheckLambda = lambda(runtimeInfo);
-        CloudFormationCustomResourceEvent event = CloudFormationCustomResourceEvent.builder()
-                .withRequestType("Create")
-                .withResourceProperties(properties).build();
-
-        // Then
-        assertThatThrownBy(() -> vpcCheckLambda.handleEvent(event, null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("endpoint");
-    }
-
-    private VpcCheckLambda lambda(WireMockRuntimeInfo runtimeInfo) {
-        return new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
+                        .and(containing("Filter.2.Value.1=com.amazonaws.my-region-1.s3"))));
     }
 
     private static MappingBuilder describeVpcEndpoints() {

--- a/java/deployment/cdk-custom-resources/src/test/java/sleeper/cdk/custom/VpcCheckLambdaIT.java
+++ b/java/deployment/cdk-custom-resources/src/test/java/sleeper/cdk/custom/VpcCheckLambdaIT.java
@@ -61,6 +61,26 @@ class VpcCheckLambdaIT {
     }
 
     @Test
+    void shouldFindVpcEndpointInNonStandardAWSPartition(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        stubFor(describeVpcEndpoints().willReturn(singleVpcEndpointResponse()));
+
+        Map<String, Object> properties = Map.of(
+                "vpcId", "myVpc",
+                "region", "eusc-de-east-1");
+
+        // When
+        lambda(runtimeInfo).handleEvent(CloudFormationCustomResourceEvent.builder()
+                .withRequestType("Create")
+                .withResourceProperties(properties).build(), null);
+
+        // Then
+        verify(1, postRequestedFor(urlEqualTo("/"))
+                .withRequestBody(containing("Filter.2.Name=service-name")
+                        .and(containing("Filter.2.Value.1=com.amazonaws.eusc-de-east-1.s3"))));
+    }
+
+    @Test
     void shouldFailWhenVpcEndpointIsNotPresent(WireMockRuntimeInfo runtimeInfo) {
         // Given
         stubFor(describeVpcEndpoints().willReturn(noVpcEndpointsResponse()));

--- a/java/deployment/cdk-custom-resources/src/test/java/sleeper/cdk/custom/VpcCheckLambdaIT.java
+++ b/java/deployment/cdk-custom-resources/src/test/java/sleeper/cdk/custom/VpcCheckLambdaIT.java
@@ -23,7 +23,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -33,7 +32,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static sleeper.localstack.test.WiremockAwsV2ClientHelper.wiremockAwsV2Client;
 
@@ -41,50 +39,16 @@ import static sleeper.localstack.test.WiremockAwsV2ClientHelper.wiremockAwsV2Cli
 class VpcCheckLambdaIT {
 
     @Test
-    void shouldThrowExceptionWhenVpcRequestReturnsNoMatchingEndpoints(WireMockRuntimeInfo runtimeInfo) {
-        // Given
-        stubFor(describeVpcEndpoints().willReturn(noVpcEndpointsResponse()));
-
-        // When
-        VpcCheckLambda vpcCheckLambda = new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
-        CloudFormationCustomResourceEvent event = CloudFormationCustomResourceEvent.builder()
-                .withRequestType("Create")
-                .withResourceProperties(new HashMap<>()).build();
-
-        // Then
-        assertThatThrownBy(() -> vpcCheckLambda.handleEvent(event, null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("endpoint");
-    }
-
-    @Test
-    void shouldNotThrowExceptionWhenVpcRequestReturnsMatchingEndpoints(WireMockRuntimeInfo runtimeInfo) {
+    void shouldFindVpcEndpointIsPresent(WireMockRuntimeInfo runtimeInfo) {
         // Given
         stubFor(describeVpcEndpoints().willReturn(singleVpcEndpointResponse()));
 
-        // When
-        VpcCheckLambda vpcCheckLambda = new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
-        CloudFormationCustomResourceEvent event = CloudFormationCustomResourceEvent.builder()
-                .withRequestType("Create")
-                .withResourceProperties(new HashMap<>()).build();
-
-        // Then
-        assertThatCode(() -> vpcCheckLambda.handleEvent(event, null))
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    void shouldPassVpcIdAndRegionFromThePropertiesToTheRequest(WireMockRuntimeInfo runtimeInfo) {
-        // Given
-        stubFor(describeVpcEndpoints().willReturn(singleVpcEndpointResponse()));
-
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("vpcId", "myVpc");
-        properties.put("region", "my-region-1");
+        Map<String, Object> properties = Map.of(
+                "vpcId", "myVpc",
+                "region", "eu-west-2");
 
         // When
-        VpcCheckLambda vpcCheckLambda = new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
-        vpcCheckLambda.handleEvent(CloudFormationCustomResourceEvent.builder()
+        lambda(runtimeInfo).handleEvent(CloudFormationCustomResourceEvent.builder()
                 .withRequestType("Create")
                 .withResourceProperties(properties).build(), null);
 
@@ -93,7 +57,32 @@ class VpcCheckLambdaIT {
                 .withRequestBody(containing("Filter.1.Name=vpc-id")
                         .and(containing("Filter.1.Value.1=myVpc"))
                         .and(containing("Filter.2.Name=service-name"))
-                        .and(containing("Filter.2.Value.1=com.amazonaws.my-region-1.s3"))));
+                        .and(containing("Filter.2.Value.1=com.amazonaws.eu-west-2.s3"))));
+    }
+
+    @Test
+    void shouldFailWhenVpcEndpointIsNotPresent(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        stubFor(describeVpcEndpoints().willReturn(noVpcEndpointsResponse()));
+
+        Map<String, Object> properties = Map.of(
+                "vpcId", "myVpc",
+                "region", "eu-west-2");
+
+        // When
+        VpcCheckLambda vpcCheckLambda = lambda(runtimeInfo);
+        CloudFormationCustomResourceEvent event = CloudFormationCustomResourceEvent.builder()
+                .withRequestType("Create")
+                .withResourceProperties(properties).build();
+
+        // Then
+        assertThatThrownBy(() -> vpcCheckLambda.handleEvent(event, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("endpoint");
+    }
+
+    private VpcCheckLambda lambda(WireMockRuntimeInfo runtimeInfo) {
+        return new VpcCheckLambda(wiremockAwsV2Client(runtimeInfo, Ec2Client.builder()));
     }
 
     private static MappingBuilder describeVpcEndpoints() {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7488
### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - VpcCheckLambdaIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
