### PR TITLE
7402: Bulk import on EKS logs don't include Sleeper classes

### DIFF
--- a/java/bulk-import/bulk-import-eks/pom.xml
+++ b/java/bulk-import/bulk-import-eks/pom.xml
@@ -43,6 +43,63 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spark ships with Log4j 2 (including log4j-1.2-api, which re-implements org.apache.log4j.* -->
+            <!-- and so collides with reload4j on the classpath). bulk-import-runner binds SLF4J to Log4j 2 -->
+            <!-- instead, so reload4j and slf4j-reload4j must be kept out of every path that pulls them in: -->
+            <!--   - core declares them as runtime deps for the rest of the project. -->
+            <dependency>
+                <groupId>sleeper</groupId>
+                <artifactId>core</artifactId>
+                <version>${project.parent.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.reload4j</groupId>
+                        <artifactId>reload4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-reload4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>sleeper</groupId>
+                <artifactId>core</artifactId>
+                <version>${project.parent.version}</version>
+                <type>test-jar</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>ch.qos.reload4j</groupId>
+                        <artifactId>reload4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-reload4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <!-- The log4j and netty-all exclusions are inherited from the parent pom but must be repeated -->
+            <!-- here, since a child dependencyManagement entry replaces the parent's rather than merging. -->
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-sql_${scala.version}</artifactId>
+                <version>${spark.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-all</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7402

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
