### PR TITLE
Issue 7569 - Document web socket query throttling config

### DIFF
--- a/docs/usage/data-retrieval.md
+++ b/docs/usage/data-retrieval.md
@@ -65,9 +65,9 @@ java -cp scripts/jars/clients-*-utility.jar sleeper.clients.query.QueryResultsSQ
 
 This will print the results to standard out as they appear on the queue.
 
-## Using WebSocket to submit queries to be executed via lambda
+## Using a WebSocket to submit queries to be executed via lambda
 
-If you have the `WebSocketQueryStack` optional stack deployed, you can also submit queries to be executed using
+If you have the `WebSocketQueryStack` optional stack deployed, you can also submit queries to be executed using a
 WebSocket. This uses the Java class `QueryWebSocketClient`, which you can also use directly. These queries will then be
 executed in a lambda and the results returned directly through the WebSocket. This can be done using:
 

--- a/docs/usage/data-retrieval.md
+++ b/docs/usage/data-retrieval.md
@@ -65,18 +65,31 @@ java -cp scripts/jars/clients-*-utility.jar sleeper.clients.query.QueryResultsSQ
 
 This will print the results to standard out as they appear on the queue.
 
-## Using websockets to submit queries to be executed via lambda
+## Using WebSocket to submit queries to be executed via lambda
 
-If you have the `WebSocketQueryStack` optional stack deployed, you can also submit queries to be executed using websockets.
-These queries will then be executed using lambda and the results returned directly to the websocket client.
-This can be done using:
+If you have the `WebSocketQueryStack` optional stack deployed, you can also submit queries to be executed using
+WebSocket. This uses the Java class `QueryWebSocketClient`, which you can also use directly. These queries will then be
+executed in a lambda and the results returned directly through the WebSocket. This can be done using:
 
 ```bash
 INSTANCE_ID=myInstanceId
 ./scripts/utility/webSocketQuery.sh ${INSTANCE_ID}
 ```
 
-The results will be returned directly to the client.
+This will print the results to standard out. If you use `QueryWebSocketClient` directly you can set extra processing
+configuration on the query. This includes a `resultsPublisherConfig` map, which lets you set the following additional
+options:
+
+| Name                                  | Description                                                                                                   |
+|---------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| webSocketPublishMaxAttempts           | The maximum number of times the lambda will attempt to publish to the web socket before giving up.            |
+| webSocketThrottlingRetryBaseDelaySecs | The minimum time in seconds the lambda will wait before retrying publishing to the web socket when throttled. |
+| webSocketThrottlingRetryMaxDelaySecs  | The maximum time in seconds the lambda will wait before retrying publishing to the web socket when throttled. |
+
+The usual case where publishing to a web socket is throttled is when results are produced faster than either the client,
+or API Gateway, can consume them. These options let you adjust the AWS SDK retry settings for throttling, including
+exponential backoff with half jitter. By default, they're set to wait for at least 10 seconds for the data to be
+consumed. In general a web socket may not be appropriate for longer running queries.
 
 ## Send messages via SQS
 

--- a/docs/usage/data-retrieval.md
+++ b/docs/usage/data-retrieval.md
@@ -68,7 +68,7 @@ This will print the results to standard out as they appear on the queue.
 ## Using a WebSocket to submit queries to be executed via lambda
 
 If you have the `WebSocketQueryStack` optional stack deployed, you can also submit queries to be executed using a
-WebSocket. This uses the Java class `QueryWebSocketClient`, which you can also use directly. These queries will then be
+WebSocket. This uses the Java class `QueryWebSocketClient`. These queries will then be
 executed in a lambda and the results returned directly through the WebSocket. This can be done using:
 
 ```bash
@@ -76,9 +76,15 @@ INSTANCE_ID=myInstanceId
 ./scripts/utility/webSocketQuery.sh ${INSTANCE_ID}
 ```
 
-This will print the results to standard out. If you use `QueryWebSocketClient` directly you can set extra processing
-configuration on the query. This includes a `resultsPublisherConfig` map, which lets you set the following additional
-options:
+This will print the results to standard out.
+
+You can also use `QueryWebSocketClient` directly, although there's an issue which will change the method signature
+on this class:
+
+[Receive queried rows through CloseableIterator as they come from web socket](https://github.com/gchq/sleeper/issues/6463)
+
+If you use `QueryWebSocketClient` directly you can set extra processing configuration on the query. This includes
+a `resultsPublisherConfig` map, which lets you set the following additional options:
 
 | Name                                  | Description                                                                                                   |
 |---------------------------------------|---------------------------------------------------------------------------------------------------------------|

--- a/java/query/query-runner/src/main/java/sleeper/query/runner/output/WebSocketOutput.java
+++ b/java/query/query-runner/src/main/java/sleeper/query/runner/output/WebSocketOutput.java
@@ -23,7 +23,7 @@ public class WebSocketOutput {
     public static final String ACCESS_KEY = "awsAccessKey";
     public static final String SECRET_KEY = "awsSecretKey";
     public static final String MAX_BATCH_SIZE = "maxBatchSize";
-    public static final String MAX_ATTEMPTS = "maxAttempts";
+    public static final String MAX_ATTEMPTS = "publishMaxAttempts";
     public static final String THROTTLING_RETRY_BASE_DELAY_SECS = "throttlingRetryBaseDelaySecs";
     public static final String THROTTLING_RETRY_MAX_DELAY_SECS = "throttlingRetryMaxDelaySecs";
 

--- a/java/query/query-runner/src/main/java/sleeper/query/runner/output/WebSocketOutput.java
+++ b/java/query/query-runner/src/main/java/sleeper/query/runner/output/WebSocketOutput.java
@@ -23,9 +23,9 @@ public class WebSocketOutput {
     public static final String ACCESS_KEY = "awsAccessKey";
     public static final String SECRET_KEY = "awsSecretKey";
     public static final String MAX_BATCH_SIZE = "maxBatchSize";
-    public static final String MAX_ATTEMPTS = "publishMaxAttempts";
-    public static final String THROTTLING_RETRY_BASE_DELAY_SECS = "throttlingRetryBaseDelaySecs";
-    public static final String THROTTLING_RETRY_MAX_DELAY_SECS = "throttlingRetryMaxDelaySecs";
+    public static final String MAX_ATTEMPTS = "webSocketPublishMaxAttempts";
+    public static final String THROTTLING_RETRY_BASE_DELAY_SECS = "webSocketThrottlingRetryBaseDelaySecs";
+    public static final String THROTTLING_RETRY_MAX_DELAY_SECS = "webSocketThrottlingRetryMaxDelaySecs";
 
     private WebSocketOutput() {
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7569

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Just documentation

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
