### PR TITLE
Issue 7575 - Init color_eyre once only

### DIFF
--- a/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
+++ b/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
@@ -164,12 +164,14 @@ public class DataFusionCompactionRunner implements CompactionRunner {
             jnr.ffi.Runtime runtime, FFIContext<DataFusionCompactionFunctions> context, Consumer<Long> progressCallback) throws IOException {
         // Create object to hold the result (in native memory)
         FFIFileResult compactionData = new FFIFileResult(runtime);
+
         // Perform compaction
-        ObjectReferenceManager ofm = runtime.newObjectReferenceManager();
-        DataFusionCompactionFunctions.ProgressCallback javaCallback = rows -> progressCallback.accept(rows);
-        Pointer key = ofm.add(javaCallback);
+        ObjectReferenceManager<Object> ofm = runtime.newObjectReferenceManager();
+        DataFusionCompactionFunctions.ProgressCallback callbackWrapper = rows -> progressCallback.accept(rows);
+        Pointer key = ofm.add(callbackWrapper);
+
         try {
-            int result = context.getFunctions().compact(context, compactionParams, compactionData, javaCallback);
+            int result = context.getFunctions().compact(context, compactionParams, compactionData, callbackWrapper);
             // Check result
             if (result != 0) {
                 LOGGER.error("DataFusion compaction failed, return code: {}", result);

--- a/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
+++ b/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
@@ -16,6 +16,8 @@
 package sleeper.compaction.datafusion;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jnr.ffi.ObjectReferenceManager;
+import jnr.ffi.Pointer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -163,12 +165,18 @@ public class DataFusionCompactionRunner implements CompactionRunner {
         // Create object to hold the result (in native memory)
         FFIFileResult compactionData = new FFIFileResult(runtime);
         // Perform compaction
-
-        int result = context.getFunctions().compact(context, compactionParams, compactionData, rows -> progressCallback.accept(rows));
-        // Check result
-        if (result != 0) {
-            LOGGER.error("DataFusion compaction failed, return code: {}", result);
-            throw new IOException("DataFusion compaction failed with return code " + result);
+        ObjectReferenceManager ofm = runtime.newObjectReferenceManager();
+        DataFusionCompactionFunctions.ProgressCallback javaCallback = rows -> progressCallback.accept(rows);
+        Pointer key = ofm.add(javaCallback);
+        try {
+            int result = context.getFunctions().compact(context, compactionParams, compactionData, javaCallback);
+            // Check result
+            if (result != 0) {
+                LOGGER.error("DataFusion compaction failed, return code: {}", result);
+                throw new IOException("DataFusion compaction failed with return code " + result);
+            }
+        } finally {
+            ofm.remove(key);
         }
 
         long totalNumberOfRowsRead = compactionData.rows_read.get();

--- a/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
+++ b/java/compaction/compaction-datafusion/src/main/java/sleeper/compaction/datafusion/DataFusionCompactionRunner.java
@@ -166,9 +166,9 @@ public class DataFusionCompactionRunner implements CompactionRunner {
         FFIFileResult compactionData = new FFIFileResult(runtime);
 
         // Perform compaction
-        ObjectReferenceManager<Object> ofm = runtime.newObjectReferenceManager();
+        ObjectReferenceManager<Object> objectRefManager = runtime.newObjectReferenceManager();
         DataFusionCompactionFunctions.ProgressCallback callbackWrapper = rows -> progressCallback.accept(rows);
-        Pointer key = ofm.add(callbackWrapper);
+        Pointer key = objectRefManager.add(callbackWrapper);
 
         try {
             int result = context.getFunctions().compact(context, compactionParams, compactionData, callbackWrapper);
@@ -178,7 +178,7 @@ public class DataFusionCompactionRunner implements CompactionRunner {
                 throw new IOException("DataFusion compaction failed with return code " + result);
             }
         } finally {
-            ofm.remove(key);
+            objectRefManager.remove(key);
         }
 
         long totalNumberOfRowsRead = compactionData.rows_read.get();

--- a/java/compaction/compaction-datafusion/src/test/java/sleeper/compaction/datafusion/DataFusionCompactionRunnerLocalStackIT.java
+++ b/java/compaction/compaction-datafusion/src/test/java/sleeper/compaction/datafusion/DataFusionCompactionRunnerLocalStackIT.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.localstack.LocalStackContainer;
@@ -85,23 +86,9 @@ public class DataFusionCompactionRunnerLocalStackIT extends LocalStackTestBase {
     @BeforeEach
     void setUp() {
         createBucket(instanceProperties.get(DATA_BUCKET));
-        var t = new Thread(() -> {
-            while (true) {
-                try {
-                    Thread.sleep(10);
-                } catch (InterruptedException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
-                }
-                System.gc();
-                System.runFinalization();
-            }
-        });
-        t.setDaemon(true);
-        t.start();
     }
 
-    // @Disabled("Expensive long running test only used for manual debugging")
+    @Disabled("Expensive long running test only used for manual debugging")
     @Test
     void shouldRunManyCompactionsInSerialWithoutCrashing() throws Exception {
         // Given
@@ -131,9 +118,7 @@ public class DataFusionCompactionRunnerLocalStackIT extends LocalStackTestBase {
                 CompactionTaskTestHelper iterationHelper = new CompactionTaskTestHelper(
                         instanceProperties, new FixedTablePropertiesProvider(tableProperties),
                         FixedStateStoreProvider.singleTable(tableProperties, iterationStateStore), jobTracker);
-                iterationHelper.runTask(runner, p -> {
-                    System.out.println("FOOO " + p);
-                }, List.of(job));
+                iterationHelper.runTask(runner, null, List.of(job));
             }
         }
     }

--- a/java/compaction/compaction-datafusion/src/test/java/sleeper/compaction/datafusion/DataFusionCompactionRunnerLocalStackIT.java
+++ b/java/compaction/compaction-datafusion/src/test/java/sleeper/compaction/datafusion/DataFusionCompactionRunnerLocalStackIT.java
@@ -19,7 +19,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.localstack.LocalStackContainer;
@@ -86,9 +85,23 @@ public class DataFusionCompactionRunnerLocalStackIT extends LocalStackTestBase {
     @BeforeEach
     void setUp() {
         createBucket(instanceProperties.get(DATA_BUCKET));
+        var t = new Thread(() -> {
+            while (true) {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+                System.gc();
+                System.runFinalization();
+            }
+        });
+        t.setDaemon(true);
+        t.start();
     }
 
-    @Disabled("Expensive long running test only used for manual debugging")
+    // @Disabled("Expensive long running test only used for manual debugging")
     @Test
     void shouldRunManyCompactionsInSerialWithoutCrashing() throws Exception {
         // Given
@@ -118,7 +131,9 @@ public class DataFusionCompactionRunnerLocalStackIT extends LocalStackTestBase {
                 CompactionTaskTestHelper iterationHelper = new CompactionTaskTestHelper(
                         instanceProperties, new FixedTablePropertiesProvider(tableProperties),
                         FixedStateStoreProvider.singleTable(tableProperties, iterationStateStore), jobTracker);
-                iterationHelper.runTask(runner, null, List.of(job));
+                iterationHelper.runTask(runner, p -> {
+                    System.out.println("FOOO " + p);
+                }, List.of(job));
             }
         }
     }

--- a/java/query/query-datafusion/src/main/java/sleeper/query/datafusion/DataFusionLeafPartitionRowRetriever.java
+++ b/java/query/query-datafusion/src/main/java/sleeper/query/datafusion/DataFusionLeafPartitionRowRetriever.java
@@ -68,7 +68,6 @@ import static sleeper.core.properties.table.TableProperty.STATISTICS_TRUNCATE_LE
  */
 public class DataFusionLeafPartitionRowRetriever implements LeafPartitionRowRetriever {
     private static final Logger LOGGER = LoggerFactory.getLogger(DataFusionLeafPartitionRowRetriever.class);
-    private static final Object LOCK = new Object();
 
     private final DataFusionAwsConfig awsConfig;
     private final BufferAllocator allocator;
@@ -116,16 +115,15 @@ public class DataFusionLeafPartitionRowRetriever implements LeafPartitionRowRetr
         // result retrieval happening in parallel, once the query planning step has finished.
         int nativeCallResult;
         FFIQueryResults queryResults;
-        synchronized (LOCK) {
-            jnr.ffi.Runtime runtime = jnr.ffi.Runtime.getRuntime(functions);
-            FFILeafPartitionQueryConfig params = createFFIQueryData(leafPartitionQuery, dataReadSchema, tableProperties, awsConfig, runtime);
+        jnr.ffi.Runtime runtime = jnr.ffi.Runtime.getRuntime(functions);
+        FFILeafPartitionQueryConfig params = createFFIQueryData(leafPartitionQuery, dataReadSchema, tableProperties, awsConfig, runtime);
 
-            // Create NULL pointer which will be set by the FFI call upon return
-            queryResults = new FFIQueryResults(runtime);
+        // Create NULL pointer which will be set by the FFI call upon return
+        queryResults = new FFIQueryResults(runtime);
 
-            // Perform native query
-            nativeCallResult = functions.query_stream(context, params, queryResults);
-        }
+        // Perform native query
+        nativeCallResult = functions.query_stream(context, params, queryResults);
+
         // Check result
         if (nativeCallResult != 0) {
             LOGGER.error("DataFusion query failed, return code: {}", nativeCallResult);
@@ -162,16 +160,15 @@ public class DataFusionLeafPartitionRowRetriever implements LeafPartitionRowRetr
         // result retrieval happening in parallel, once the query planning step has finished.
         int nativeCallResult;
         FFIFileResult fileResults;
-        synchronized (LOCK) {
-            jnr.ffi.Runtime runtime = jnr.ffi.Runtime.getRuntime(functions);
-            FFILeafPartitionQueryConfig params = createFFIQueryData(leafPartitionQuery, outputFile, dataReadSchema, tableProperties, awsConfig, runtime);
+        jnr.ffi.Runtime runtime = jnr.ffi.Runtime.getRuntime(functions);
+        FFILeafPartitionQueryConfig params = createFFIQueryData(leafPartitionQuery, outputFile, dataReadSchema, tableProperties, awsConfig, runtime);
 
-            // Create NULL pointer which will be set by the FFI call upon return
-            fileResults = new FFIFileResult(runtime);
+        // Create NULL pointer which will be set by the FFI call upon return
+        fileResults = new FFIFileResult(runtime);
 
-            // Perform native query
-            nativeCallResult = functions.query_file(context, params, fileResults);
-        }
+        // Perform native query
+        nativeCallResult = functions.query_file(context, params, fileResults);
+
         // Check result
         if (nativeCallResult != 0) {
             LOGGER.error("DataFusion query failed, return code: {}", nativeCallResult);

--- a/java/query/query-datafusion/src/test/java/sleeper/query/datafusion/DataFusionLeafPartitionRowRetrieverIT.java
+++ b/java/query/query-datafusion/src/test/java/sleeper/query/datafusion/DataFusionLeafPartitionRowRetrieverIT.java
@@ -143,7 +143,7 @@ public class DataFusionLeafPartitionRowRetrieverIT {
 
         public static final int ROW_COUNT = 10_00;
         public static final int TASK_COUNT = 50;
-        public static final int QUERY_COUNT = 30;
+        public static final int QUERY_COUNT = 50;
 
         private List<Row> makeRows() {
             List<Row> rows = new ArrayList<>();

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "query_sql"
-version = "0.36.1-SNAPSHOT"
+version = "0.36.2-SNAPSHOT"
 dependencies = [
  "datafusion",
  "tokio",

--- a/rust/sleeper_df/src/lib.rs
+++ b/rust/sleeper_df/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{
         query::{FFILeafPartitionQueryConfig, FFIQueryResults},
     },
 };
-use ::log::{error, warn};
+use ::log::error;
 #[cfg(doc)]
 use datafusion::arrow::{ffi_stream::FFI_ArrowArrayStream, record_batch::RecordBatch};
 use libc::{EFAULT, EINVAL};

--- a/rust/sleeper_df/src/lib.rs
+++ b/rust/sleeper_df/src/lib.rs
@@ -80,9 +80,6 @@ pub extern "C" fn native_compact(
     callback: ProgressCallback,
 ) -> c_int {
     maybe_cfg_log();
-    if let Err(e) = color_eyre::install() {
-        warn!("Couldn't install color_eyre error handler {e}");
-    }
 
     // Null check the context pointer
     let Some(context) = (unsafe { ctx_ptr.as_ref() }) else {
@@ -185,9 +182,6 @@ pub extern "C" fn native_query_stream(
     query_results_ptr: *mut FFIQueryResults,
 ) -> c_int {
     maybe_cfg_log();
-    if let Err(e) = color_eyre::install() {
-        warn!("Couldn't install color_eyre error handler {e}");
-    }
 
     // Null check the context pointer
     let Some(context) = (unsafe { ctx_ptr.as_ref() }) else {
@@ -288,9 +282,6 @@ pub extern "C" fn native_query_file(
     output_ptr: *mut FFIFileResult,
 ) -> c_int {
     maybe_cfg_log();
-    if let Err(e) = color_eyre::install() {
-        warn!("Couldn't install color_eyre error handler {e}");
-    }
 
     // Null check the context pointer
     let Some(context) = (unsafe { ctx_ptr.as_ref() }) else {

--- a/rust/sleeper_df/src/log.rs
+++ b/rust/sleeper_df/src/log.rs
@@ -16,6 +16,7 @@
  */
 use chrono::Local;
 use env_logger::Env;
+use log::warn;
 use std::{io::Write, sync::Once};
 
 /// An object guaranteed to only initialise once. Thread safe.
@@ -44,5 +45,8 @@ pub fn maybe_cfg_log() {
             .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
             .format_target(false)
             .init();
+        if let Err(e) = color_eyre::install() {
+            warn!("Couldn't install color_eyre error handler {e}");
+        }
     });
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7575

### Tests

- [X] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Multi-thread query test already present

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
