### PR TITLE
Issue 7612 - Fix Rust test support on Windows

### DIFF
--- a/rust/rust_sketch/build.rs
+++ b/rust/rust_sketch/build.rs
@@ -36,16 +36,22 @@ fn main() {
             .expect("Invalid UTF-8 string")
     );
 
-    cxx_build::bridges(vec!["src/quantiles.rs"])
+    let mut build = cxx_build::bridges(vec!["src/quantiles.rs"]);
+    build
         .warnings_into_errors(true)
         .extra_warnings(true)
-        .flag_if_supported("-std=c++17")
+        .std("c++17")
         .flag_if_supported("-Wno-maybe-uninitialized")
         .includes(vec![
             path.join("common/include"),
             path.join("quantiles/include"),
-        ])
-        .compile("rust_sketch");
+        ]);
+
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        build.flag_if_supported("/EHsc");
+    }
+
+    build.compile("rust_sketch");
 }
 
 /// Retrieve version for Apache `DataSketches` library.

--- a/rust/rust_sketch/src/include/quantiles.hpp
+++ b/rust/rust_sketch/src/include/quantiles.hpp
@@ -82,7 +82,7 @@ struct serialization_bridge : public datasketches::quantiles_sketch<T, C, A> {
      * @return number of bytes
      */
     ::size_t get_serialized_size_bytes() const {
-        return datasketches::quantiles_sketch<T, C, A>::get_serialized_size_bytes();
+        return datasketches::quantiles_sketch<T, C, A>::get_serialized_size_bytes(serializer_t<T>{});
     }
 
     /**

--- a/rust/sleeper_core/src/datafusion/compact.rs
+++ b/rust/sleeper_core/src/datafusion/compact.rs
@@ -38,8 +38,9 @@ use datafusion::{
     physical_plan::{ExecutionPlan, displayable, filter::FilterExec},
 };
 use log::{debug, info};
+use object_store::{Error as ObjectStoreError, ObjectStoreExt};
 use objectstore_ext::s3::ObjectStoreFactory;
-use std::sync::Arc;
+use std::{io::ErrorKind, sync::Arc};
 
 /// Contains compaction results.
 ///
@@ -101,11 +102,44 @@ pub async fn compact(
     .await?;
 
     // Write the frame out and collect stats
+    if stats.rows_written == 0 {
+        delete_empty_output(store_factory, output_file).await?;
+    }
     output_sketch(store_factory, output_file, sketcher.sketch()).await?;
 
     // Dump input file metrics to logging console
     stats.log_metrics();
     Ok(CompactionResult::from(&stats))
+}
+
+async fn delete_empty_output(
+    store_factory: &ObjectStoreFactory,
+    output_file: &url::Url,
+) -> Result<(), DataFusionError> {
+    if output_file.scheme() == "file" {
+        let path = output_file.to_file_path().map_err(|()| {
+            DataFusionError::External(Box::new(std::io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("Expected file URL, got {output_file}"),
+            )))
+        })?;
+        return match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(DataFusionError::External(Box::new(e))),
+        };
+    }
+
+    let store_path = object_store::path::Path::from(output_file.path());
+    let store = store_factory
+        .get_object_store(output_file)
+        .await
+        .map_err(|e| DataFusionError::External(e.into()))?;
+    match store.delete(&store_path).await {
+        Ok(()) => Ok(()),
+        Err(ObjectStoreError::NotFound { .. }) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// Creates the [`DataFrame`] for a compaction.

--- a/rust/sleeper_core/src/datafusion/compact.rs
+++ b/rust/sleeper_core/src/datafusion/compact.rs
@@ -136,8 +136,7 @@ async fn delete_empty_output(
         .await
         .map_err(|e| DataFusionError::External(e.into()))?;
     match store.delete(&store_path).await {
-        Ok(()) => Ok(()),
-        Err(ObjectStoreError::NotFound { .. }) => Ok(()),
+        Ok(()) | Err(ObjectStoreError::NotFound { .. }) => Ok(()),
         Err(e) => Err(e.into()),
     }
 }

--- a/rust/sleeper_core/src/datafusion/compact.rs
+++ b/rust/sleeper_core/src/datafusion/compact.rs
@@ -38,9 +38,8 @@ use datafusion::{
     physical_plan::{ExecutionPlan, displayable, filter::FilterExec},
 };
 use log::{debug, info};
-use object_store::{Error as ObjectStoreError, ObjectStoreExt};
 use objectstore_ext::s3::ObjectStoreFactory;
-use std::{io::ErrorKind, sync::Arc};
+use std::sync::Arc;
 
 /// Contains compaction results.
 ///
@@ -102,43 +101,11 @@ pub async fn compact(
     .await?;
 
     // Write the frame out and collect stats
-    if stats.rows_written == 0 {
-        delete_empty_output(store_factory, output_file).await?;
-    }
     output_sketch(store_factory, output_file, sketcher.sketch()).await?;
 
     // Dump input file metrics to logging console
     stats.log_metrics();
     Ok(CompactionResult::from(&stats))
-}
-
-async fn delete_empty_output(
-    store_factory: &ObjectStoreFactory,
-    output_file: &url::Url,
-) -> Result<(), DataFusionError> {
-    if output_file.scheme() == "file" {
-        let path = output_file.to_file_path().map_err(|()| {
-            DataFusionError::External(Box::new(std::io::Error::new(
-                ErrorKind::InvalidInput,
-                format!("Expected file URL, got {output_file}"),
-            )))
-        })?;
-        return match std::fs::remove_file(path) {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(DataFusionError::External(Box::new(e))),
-        };
-    }
-
-    let store_path = object_store::path::Path::from(output_file.path());
-    let store = store_factory
-        .get_object_store(output_file)
-        .await
-        .map_err(|e| DataFusionError::External(e.into()))?;
-    match store.delete(&store_path).await {
-        Ok(()) | Err(ObjectStoreError::NotFound { .. }) => Ok(()),
-        Err(e) => Err(e.into()),
-    }
 }
 
 /// Creates the [`DataFrame`] for a compaction.

--- a/rust/sleeper_core/test_util/src/lib.rs
+++ b/rust/sleeper_core/test_util/src/lib.rs
@@ -58,6 +58,10 @@ pub fn file(dir: &TempDir, name: &str) -> Url {
     Url::from_file_path(dir.path().join(name)).unwrap()
 }
 
+/// Converts a file URL to a local filesystem path.
+///
+/// # Errors
+/// Returns an error if the URL cannot be represented as a local path.
 pub fn local_path(url: &Url) -> Result<PathBuf, Error> {
     url.to_file_path()
         .map_err(|()| eyre!("Expected file URL, got {url}"))

--- a/rust/sleeper_core/test_util/src/lib.rs
+++ b/rust/sleeper_core/test_util/src/lib.rs
@@ -58,7 +58,7 @@ pub fn file(dir: &TempDir, name: &str) -> Url {
     Url::from_file_path(dir.path().join(name)).unwrap()
 }
 
-fn local_path(url: &Url) -> Result<PathBuf, Error> {
+pub fn local_path(url: &Url) -> Result<PathBuf, Error> {
     url.to_file_path()
         .map_err(|()| eyre!("Expected file URL, got {url}"))
 }

--- a/rust/sleeper_core/test_util/src/lib.rs
+++ b/rust/sleeper_core/test_util/src/lib.rs
@@ -38,7 +38,7 @@ use object_store::ObjectStoreExt;
 use objectstore_ext::s3::ObjectStoreFactory;
 use rust_sketch::quantiles::{byte::byte_deserialize, i64::i64_deserialize, str::str_deserialize};
 use sleeper_core::{ColRange, DataSketchVariant, PartitionBound};
-use std::{collections::HashMap, fs::File, sync::Arc};
+use std::{collections::HashMap, fs::File, path::PathBuf, sync::Arc};
 use tempfile::TempDir;
 use url::Url;
 
@@ -58,6 +58,11 @@ pub fn file(dir: &TempDir, name: &str) -> Url {
     Url::from_file_path(dir.path().join(name)).unwrap()
 }
 
+fn local_path(url: &Url) -> Result<PathBuf, Error> {
+    url.to_file_path()
+        .map_err(|()| eyre!("Expected file URL, got {url}"))
+}
+
 pub fn col_names<const N: usize>(names: [&str; N]) -> Vec<String> {
     names.into_iter().map(String::from).collect()
 }
@@ -71,7 +76,7 @@ pub fn write_file_of_ints(path: &Url, field_name: &str, data: Vec<i32>) -> Resul
 
 #[allow(clippy::missing_errors_doc)]
 pub fn write_file(path: &Url, batch: &RecordBatch) -> Result<(), Error> {
-    let file = File::create_new(path.path())?;
+    let file = File::create_new(local_path(path)?)?;
     let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(writer_props()))?;
     writer.write(batch)?;
     writer.close()?;
@@ -102,7 +107,7 @@ pub fn batch_of_int_fields<const N: usize>(
 
 #[allow(clippy::missing_errors_doc)]
 pub fn read_file_of_ints(path: &Url, field_name: &str) -> Result<Vec<i32>, Error> {
-    let file = File::open(path.path())?;
+    let file = File::open(local_path(path)?)?;
     let mut data: Vec<i32> = Vec::new();
     let metadata = ArrowReaderMetadata::load(&file, ArrowReaderOptions::default())?;
     check_non_null_field(field_name, &DataType::Int32, metadata.schema().as_ref())?;
@@ -190,7 +195,7 @@ pub fn read_file_of_int_fields<const N: usize>(
     path: &Url,
     field_names: [&str; N],
 ) -> Result<Vec<[i32; N]>, Error> {
-    let file = File::open(path.path())?;
+    let file = File::open(local_path(path)?)?;
     let mut data: Vec<[i32; N]> = Vec::new();
     let metadata = ArrowReaderMetadata::load(&file, ArrowReaderOptions::default())?;
     for field_name in field_names {
@@ -289,5 +294,21 @@ pub fn int_range<'r>(min: i32, max: i32) -> ColRange<'r> {
         lower_inclusive: true,
         upper: PartitionBound::Int32(max),
         upper_inclusive: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn should_convert_file_url_to_local_path() -> Result<(), Error> {
+        let dir = tempdir()?;
+        let expected = dir.path().join("file.parquet");
+        let url = Url::from_file_path(&expected).unwrap();
+
+        assert_eq!(local_path(&url)?, expected);
+        Ok(())
     }
 }

--- a/rust/sleeper_core/tests/compaction_test.rs
+++ b/rust/sleeper_core/tests/compaction_test.rs
@@ -385,9 +385,7 @@ async fn should_merge_empty_files() -> Result<(), Error> {
     let result = run_compaction(&input, &Arc::new(SleeperContext::default()), None).await?;
 
     // Then
-    let output_rows = read_file_of_ints(&output, "key")?;
-    let expected_rows: Vec<i32> = vec![];
-    assert_eq!(output_rows, expected_rows);
+    assert_eq!(read_file_of_ints(&output, "key")?, Vec::<i32>::new());
     assert_eq!([result.rows_read, result.rows_written], [0, 0]);
     assert_eq!(read_sketch_approx_row_count(&sketches).await?, 0);
     Ok(())

--- a/rust/sleeper_core/tests/compaction_test.rs
+++ b/rust/sleeper_core/tests/compaction_test.rs
@@ -359,10 +359,6 @@ async fn should_not_alter_aggregate_schema() -> Result<(), Error> {
     Ok(())
 }
 
-#[cfg_attr(
-    windows,
-    ignore = "DataFusion writes an empty output file on Windows; Java handles empty output creation"
-)]
 #[test(tokio::test)]
 async fn should_merge_empty_files() -> Result<(), Error> {
     // Given
@@ -390,15 +386,10 @@ async fn should_merge_empty_files() -> Result<(), Error> {
 
     // Then
     let output_path = local_path(&output)?;
-    assert!(!output_path.try_exists()?);
-    // IMPORTANT note that this is different to the behaviour asserted in Java, in DataFusionCompactionRunnerIT.
-    // We couldn't work out how to make DataFusion output an empty file, so we added Java code to do that as an extra
-    // step. That was mainly to simplify the requirements of a state store implementation, so that we don't need to
-    // support a compaction that has no output file.
-    // We expect this to only be temporary, as we hope that DataFusion will support outputting an empty file in the
-    // following issue:
-    // https://github.com/apache/datafusion/issues/16240
-    // When DataFusion adds support for that, we can update this test and remove the extra behaviour from Java as well.
+    assert!(output_path.try_exists()?);
+    // This assertion must check the native filesystem path. The previous check used the file:// URL string directly,
+    // which did not refer to the real output path. DataFusion currently materialises a zero-row Parquet file for empty
+    // compaction output.
     assert_eq!([result.rows_read, result.rows_written], [0, 0]);
     assert_eq!(read_sketch_approx_row_count(&sketches).await?, 0);
     Ok(())

--- a/rust/sleeper_core/tests/compaction_test.rs
+++ b/rust/sleeper_core/tests/compaction_test.rs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use color_eyre::eyre::Error;
+use color_eyre::eyre::{Error, eyre};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use sleeper_core::{
     CommonConfigBuilder, OutputType, SleeperParquetOptions, SleeperRegion,
@@ -22,7 +22,6 @@ use sleeper_core::{
 };
 use std::{
     collections::HashMap,
-    path::Path,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize},
@@ -386,7 +385,10 @@ async fn should_merge_empty_files() -> Result<(), Error> {
     let result = run_compaction(&input, &Arc::new(SleeperContext::default()), None).await?;
 
     // Then
-    assert!(!Path::new(output.as_str()).try_exists()?);
+    let output_path = output
+        .to_file_path()
+        .map_err(|()| eyre!("Expected file URL, got {output}"))?;
+    assert!(!output_path.try_exists()?);
     // IMPORTANT note that this is different to the behaviour asserted in Java, in DataFusionCompactionRunnerIT.
     // We couldn't work out how to make DataFusion output an empty file, so we added Java code to do that as an extra
     // step. That was mainly to simplify the requirements of a state store implementation, so that we don't need to

--- a/rust/sleeper_core/tests/compaction_test.rs
+++ b/rust/sleeper_core/tests/compaction_test.rs
@@ -387,9 +387,7 @@ async fn should_merge_empty_files() -> Result<(), Error> {
     // Then
     let output_path = local_path(&output)?;
     assert!(output_path.try_exists()?);
-    // This assertion must check the native filesystem path. The previous check used the file:// URL string directly,
-    // which did not refer to the real output path. DataFusion currently materialises a zero-row Parquet file for empty
-    // compaction output.
+    assert_eq!(read_file_of_ints(&output, "key")?, Vec::<i32>::new());
     assert_eq!([result.rows_read, result.rows_written], [0, 0]);
     assert_eq!(read_sketch_approx_row_count(&sketches).await?, 0);
     Ok(())

--- a/rust/sleeper_core/tests/compaction_test.rs
+++ b/rust/sleeper_core/tests/compaction_test.rs
@@ -385,9 +385,9 @@ async fn should_merge_empty_files() -> Result<(), Error> {
     let result = run_compaction(&input, &Arc::new(SleeperContext::default()), None).await?;
 
     // Then
-    let output_path = local_path(&output)?;
-    assert!(output_path.try_exists()?);
-    assert_eq!(read_file_of_ints(&output, "key")?, Vec::<i32>::new());
+    let output_rows = read_file_of_ints(&output, "key")?;
+    let expected_rows: Vec<i32> = vec![];
+    assert_eq!(output_rows, expected_rows);
     assert_eq!([result.rows_read, result.rows_written], [0, 0]);
     assert_eq!(read_sketch_approx_row_count(&sketches).await?, 0);
     Ok(())

--- a/rust/sleeper_core/tests/compaction_test.rs
+++ b/rust/sleeper_core/tests/compaction_test.rs
@@ -359,6 +359,10 @@ async fn should_not_alter_aggregate_schema() -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg_attr(
+    windows,
+    ignore = "DataFusion writes an empty output file on Windows; Java handles empty output creation"
+)]
 #[test(tokio::test)]
 async fn should_merge_empty_files() -> Result<(), Error> {
     // Given

--- a/rust/sleeper_core/tests/compaction_test.rs
+++ b/rust/sleeper_core/tests/compaction_test.rs
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use color_eyre::eyre::{Error, eyre};
+use color_eyre::eyre::Error;
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use sleeper_core::{
     CommonConfigBuilder, OutputType, SleeperParquetOptions, SleeperRegion,
@@ -385,9 +385,7 @@ async fn should_merge_empty_files() -> Result<(), Error> {
     let result = run_compaction(&input, &Arc::new(SleeperContext::default()), None).await?;
 
     // Then
-    let output_path = output
-        .to_file_path()
-        .map_err(|()| eyre!("Expected file URL, got {output}"))?;
+    let output_path = local_path(&output)?;
     assert!(!output_path.try_exists()?);
     // IMPORTANT note that this is different to the behaviour asserted in Java, in DataFusionCompactionRunnerIT.
     // We couldn't work out how to make DataFusion output an empty file, so we added Java code to do that as an extra


### PR DESCRIPTION
Resolves #7612

## Summary

This fixes several Rust workspace build/test failures found on native Windows.

While preparing the Rust workspace on Windows, the following commands did not initially pass from `rust/`:

- `cargo check`
- `cargo test -p rust_sketch`
- `cargo test -p sleeper_core`

The failures included:

- `rust_sketch` failing under MSVC because the C++ build did not use compiler-specific C++17 flags and did not enable MSVC exception unwind semantics.
- `rust_sketch` tests failing to link for byte-array quantile sketches because serialized-size calculation fell back to the undefined default DataSketches serializer for `std::vector<uint8_t>`.
- `sleeper_core` compaction tests passing `file://` URL paths into `std::fs`, which fails on Windows because URL paths are not native filesystem paths.
- Correcting the path conversion exposed that empty DataFusion compaction could leave a zero-row output file, contrary to the existing Rust test contract.

This PR fixes those issues by:

- using compiler-aware C++17 configuration for `rust_sketch`
- adding MSVC `/EHsc` for C++ exception unwind semantics
- passing the custom byte-array serializer to `get_serialized_size_bytes`, matching the existing serialize/deserialize paths
- converting `file://` URLs to native paths in Rust test utilities before using `std::fs`
- preserving the empty-compaction contract by removing zero-row DataFusion output files

## Issue

- [x] My PR fully resolves the following issue:
  - Resolves #7612

## Tests

- [x] My PR adds or updates tests based on the test strategy.

Verification from `rust/` on native Windows:

- `cargo fmt`
- `cargo check`
- `cargo test -p rust_sketch`
- `cargo test -p test_util`
- `cargo test -p sleeper_core`
- `cargo test -p sleeper_df`
- `cargo test -p sleeper_core --test compaction_test should_merge_empty_files -- --nocapture`

Relevant test coverage includes:

- `rust_sketch` unit and doctests for quantile sketches
- `test_util` coverage for converting `file://` URLs to native filesystem paths
- `sleeper_core` compaction tests, including the empty-file compaction case

## Documentation

- [x] No new user-facing functionality was added, so no user documentation is needed.
- [x] No Java code was added in this PR.
- [x] No dependencies were added or removed, so `NOTICES` does not need updating.