### PR TITLE
Issue 7637 - Default to local build when deploy config file is not present

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployConfiguration.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployConfiguration.java
@@ -20,6 +20,7 @@ import sleeper.container.images.ContainerRegistryCredentials;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
@@ -76,9 +77,17 @@ public record DeployConfiguration(
     }
 
     public static DeployConfiguration fromScriptsDirectory(Path scriptsDirectory) throws IOException {
-        Path deployConfigFile = scriptsDirectory.resolve("templates").resolve("deployConfig.json");
-        String deployConfigJson = Files.readString(deployConfigFile);
-        return new DeployConfigurationSerDe().fromJson(deployConfigJson);
+        Path deployConfigFile = configFileInScriptsDirectory(scriptsDirectory);
+        try {
+            String deployConfigJson = Files.readString(deployConfigFile);
+            return new DeployConfigurationSerDe().fromJson(deployConfigJson);
+        } catch (NoSuchFileException e) {
+            return DeployConfiguration.fromLocalBuild();
+        }
+    }
+
+    public static Path configFileInScriptsDirectory(Path scriptsDirectory) {
+        return scriptsDirectory.resolve("templates").resolve("deployConfig.json");
     }
 
     public static DeployConfiguration fromLocalBuild() {

--- a/java/clients/src/main/java/sleeper/clients/deploy/SetDeployConfiguration.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/SetDeployConfiguration.java
@@ -113,7 +113,7 @@ public class SetDeployConfiguration {
 
     public static void writeConfigurationFile(FileWriter fileWriter, Arguments arguments) throws IOException {
         fileWriter.writeString(
-                arguments.scriptsDirectory().resolve("templates").resolve("deployConfig.json"),
+                DeployConfiguration.configFileInScriptsDirectory(arguments.scriptsDirectory()),
                 new DeployConfigurationSerDe().toJson(arguments.configuration()));
     }
 

--- a/java/clients/src/test/java/sleeper/clients/deploy/DeployConfigurationIT.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/DeployConfigurationIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.deploy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeployConfigurationIT {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Files.createDirectory(tempDir.resolve("templates"));
+    }
+
+    @Test
+    void shouldReadConfigFile() throws Exception {
+        // Given
+        DeployConfiguration config = DeployConfiguration.fromLocalBuild()
+                .withOverrideBaseImageDir(tempDir.resolve("base-image").toString());
+        Files.writeString(DeployConfiguration.configFileInScriptsDirectory(tempDir),
+                new DeployConfigurationSerDe().toJson(config));
+
+        // When / Then
+        assertThat(DeployConfiguration.fromScriptsDirectory(tempDir)).isEqualTo(config);
+    }
+
+    @Test
+    void shouldDefaultToLocalBuildWhenConfigFileIsNotPresent() throws Exception {
+        assertThat(DeployConfiguration.fromScriptsDirectory(tempDir))
+                .isEqualTo(DeployConfiguration.fromLocalBuild());
+    }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7637

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - DeployConfigurationIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
