### PR TITLE
Issue 7638 - Only set default base image for images that use it

### DIFF
--- a/.github/workflows/docker-image-test.yaml
+++ b/.github/workflows/docker-image-test.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Build base image
         run: ./scripts/dev/buildDockerImage.sh base ${{ env.BASE_IMAGE }} ${{ inputs.dockerOptions }} --builder sleeper --push
       - name: Build Docker image ${{ inputs.imageName }}
-        run: ./scripts/dev/buildDockerImage.sh ${{ inputs.imageName }} ${{ inputs.imageName }}:test --lambda=${{ inputs.isLambda }} ${{ inputs.dockerOptions }} --builder sleeper --load --build-arg BASE_IMAGE=${{ env.BASE_IMAGE }}
+        run: ./scripts/dev/buildDockerImage.sh ${{ inputs.imageName }} ${{ inputs.imageName }}:test --lambda=${{ inputs.isLambda }} --default-base-image ${{ env.BASE_IMAGE }} ${{ inputs.dockerOptions }} --builder sleeper --load
       - name: Delete build output to free disk space
         run: |
           rm -rf ./scripts/docker

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.joining;
 
@@ -46,15 +47,20 @@ public class BuildDockerImage {
         CommandLineUsage usage = CommandLineUsage.builder()
                 .positionalArguments(List.of("scripts directory", "image name", "tag"))
                 .systemArguments(List.of("scripts directory"))
-                .options(List.of(CommandOption.longFlag("lambda"), CommandOption.longFlag("multiplatform")))
+                .options(List.of(
+                        CommandOption.longFlag("lambda"),
+                        CommandOption.longFlag("multiplatform"),
+                        CommandOption.longFlag("default-base-image")))
                 .helpSummary("Available Docker deployment image names: " +
                         DockerDeployment.all().stream().map(DockerDeployment::getDeploymentName).collect(joining(", ")) + "\n\n" +
                         "Available lambda image names: " +
                         LambdaJar.all().stream().map(LambdaJar::getImageName).collect(joining(", ")) + "\n\n" +
                         "The --lambda flag specifies that the image is one of the lambda options. The --multiplatform " +
                         "flag specifies to build a multiplatform image if it's configured to be built that way. By " +
-                        "default an image is only built for the default platform. Other arguments will be passed " +
-                        "through to Docker as options when specified at the end.")
+                        "default an image is only built for the default platform. If you pass " +
+                        "--default-base-image <image>, it will be set in the BASE_IMAGE build argument, but only if " +
+                        "the image uses the default base image. Other arguments will be passed through to Docker as " +
+                        "options when specified at the end.")
                 .passThroughExtraArguments(true)
                 .build();
         Arguments args = CommandArguments.parseAndValidateOrExit(usage, rawArgs, arguments -> new Arguments(
@@ -63,12 +69,14 @@ public class BuildDockerImage {
                 arguments.getString("tag"),
                 arguments.isFlagSet("lambda"),
                 arguments.isFlagSet("multiplatform"),
+                arguments.getOptionalString("default-base-image").orElse(null),
                 arguments.getPassthroughArguments()));
         DockerImageConfiguration configuration = DockerImageConfiguration.getDefault();
         CommandPipelineRunner commandRunner = CommandUtils::runCommandInheritIO;
 
         Path dockerfileDirectory;
         List<ContainerPlatform> platforms = List.of();
+        boolean useDefaultBaseImage = true;
         if (args.isLambda()) {
             dockerfileDirectory = args.dockerDir().resolve("lambda");
             LambdaJar jar = configuration.getLambdaJarByImageName(args.imageName()).orElseThrow();
@@ -79,6 +87,7 @@ public class BuildDockerImage {
             DockerDeployment deployment = configuration.getDockerDeploymentByName(args.imageName()).orElseThrow();
             dockerfileDirectory = args.dockerDir().resolve(deployment.getDeploymentName());
             platforms = deployment.getPlatforms();
+            useDefaultBaseImage = deployment.isUseDefaultBaseImage();
         }
 
         List<String> dockerCommand = new ArrayList<>();
@@ -89,12 +98,15 @@ public class BuildDockerImage {
         } else {
             dockerCommand.addAll(List.of("docker", "build", "-t", args.tag()));
         }
+        if (useDefaultBaseImage) {
+            args.defaultBaseImageOpt().ifPresent(image -> dockerCommand.addAll(List.of("--build-arg", "BASE_IMAGE=" + image)));
+        }
         dockerCommand.addAll(args.dockerOptions());
         dockerCommand.add(dockerfileDirectory.toString());
         commandRunner.runOrThrow(dockerCommand.toArray(String[]::new));
     }
 
-    private record Arguments(Path scriptsDir, String imageName, String tag, boolean isLambda, boolean isMultiplatform, List<String> dockerOptions) {
+    private record Arguments(Path scriptsDir, String imageName, String tag, boolean isLambda, boolean isMultiplatform, String defaultBaseImage, List<String> dockerOptions) {
 
         Path dockerDir() {
             return scriptsDir.resolve("docker");
@@ -102,6 +114,10 @@ public class BuildDockerImage {
 
         Path jarsDir() {
             return scriptsDir.resolve("jars");
+        }
+
+        Optional<String> defaultBaseImageOpt() {
+            return Optional.ofNullable(defaultBaseImage);
         }
     }
 

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
@@ -26,6 +26,7 @@ import sleeper.core.util.cli.CommandLineUsage;
 import sleeper.core.util.cli.CommandOption;
 
 import java.io.IOException;
+import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -43,37 +44,43 @@ public class BuildDockerImage {
     private BuildDockerImage() {
     }
 
-    public static void main(String[] rawArgs) throws IOException, InterruptedException {
-        CommandLineUsage usage = CommandLineUsage.builder()
-                .positionalArguments(List.of("scripts directory", "image name", "tag"))
-                .systemArguments(List.of("scripts directory"))
-                .options(List.of(
-                        CommandOption.longFlag("lambda"),
-                        CommandOption.longFlag("multiplatform"),
-                        CommandOption.longFlag("default-base-image")))
-                .helpSummary("Available Docker deployment image names: " +
-                        DockerDeployment.all().stream().map(DockerDeployment::getDeploymentName).collect(joining(", ")) + "\n\n" +
-                        "Available lambda image names: " +
-                        LambdaJar.all().stream().map(LambdaJar::getImageName).collect(joining(", ")) + "\n\n" +
-                        "The --lambda flag specifies that the image is one of the lambda options. The --multiplatform " +
-                        "flag specifies to build a multiplatform image if it's configured to be built that way. By " +
-                        "default an image is only built for the default platform. If you pass " +
-                        "--default-base-image <image>, it will be set in the BASE_IMAGE build argument, but only if " +
-                        "the image uses the default base image. Other arguments will be passed through to Docker as " +
-                        "options when specified at the end.")
-                .passThroughExtraArguments(true)
-                .build();
-        Arguments args = CommandArguments.parseAndValidateOrExit(usage, rawArgs, arguments -> new Arguments(
+    public static final CommandLineUsage USAGE = CommandLineUsage.builder()
+            .positionalArguments(List.of("scripts directory", "image name", "tag"))
+            .systemArguments(List.of("scripts directory"))
+            .options(List.of(
+                    CommandOption.longFlag("lambda"),
+                    CommandOption.longFlag("multiplatform"),
+                    CommandOption.longFlag("default-base-image")))
+            .helpSummary("Available Docker deployment image names: " +
+                    DockerDeployment.all().stream().map(DockerDeployment::getDeploymentName).collect(joining(", ")) + "\n\n" +
+                    "Available lambda image names: " +
+                    LambdaJar.all().stream().map(LambdaJar::getImageName).collect(joining(", ")) + "\n\n" +
+                    "The --lambda flag specifies that the image is one of the lambda options. The --multiplatform " +
+                    "flag specifies to build a multiplatform image if it's configured to be built that way. By " +
+                    "default an image is only built for the default platform. If you pass " +
+                    "--default-base-image <image>, it will be set in the BASE_IMAGE build argument, but only if " +
+                    "the image uses the default base image. Other arguments will be passed through to Docker as " +
+                    "options when specified at the end.")
+            .passThroughExtraArguments(true)
+            .build();
+
+    public static Arguments readArguments(CommandArguments arguments) {
+        return new Arguments(
                 Path.of(arguments.getString("scripts directory")),
                 arguments.getString("image name"),
                 arguments.getString("tag"),
                 arguments.isFlagSet("lambda"),
                 arguments.isFlagSet("multiplatform"),
                 arguments.getOptionalString("default-base-image").orElse(null),
-                arguments.getPassthroughArguments()));
-        DockerImageConfiguration configuration = DockerImageConfiguration.getDefault();
-        CommandPipelineRunner commandRunner = CommandUtils::runCommandInheritIO;
+                arguments.getPassthroughArguments());
+    }
 
+    public static void main(String[] rawArgs) throws IOException, InterruptedException {
+        Arguments args = CommandArguments.parseAndValidateOrExit(USAGE, rawArgs, arguments -> readArguments(arguments));
+        build(DockerImageConfiguration.getDefault(), CommandUtils::runCommandInheritIO, Files::copy, args);
+    }
+
+    public static void build(DockerImageConfiguration configuration, CommandPipelineRunner commandRunner, FileCopier fileCopier, Arguments args) throws IOException, InterruptedException {
         Path dockerfileDirectory;
         List<ContainerPlatform> platforms = List.of();
         boolean useDefaultBaseImage = true;
@@ -82,7 +89,7 @@ public class BuildDockerImage {
             LambdaJar jar = configuration.getLambdaJarByImageName(args.imageName()).orElseThrow();
             Path copyFrom = args.jarsDir().resolve(jar.getFilename(SleeperVersion.getVersion()));
             Path copyTo = dockerfileDirectory.resolve("lambda.jar");
-            Files.copy(copyFrom, copyTo, StandardCopyOption.REPLACE_EXISTING);
+            fileCopier.copy(copyFrom, copyTo, StandardCopyOption.REPLACE_EXISTING);
         } else {
             DockerDeployment deployment = configuration.getDockerDeploymentByName(args.imageName()).orElseThrow();
             dockerfileDirectory = args.dockerDir().resolve(deployment.getDeploymentName());
@@ -104,6 +111,11 @@ public class BuildDockerImage {
         dockerCommand.addAll(args.dockerOptions());
         dockerCommand.add(dockerfileDirectory.toString());
         commandRunner.runOrThrow(dockerCommand.toArray(String[]::new));
+    }
+
+    public interface FileCopier {
+
+        void copy(Path from, Path to, CopyOption... options) throws IOException;
     }
 
     private record Arguments(Path scriptsDir, String imageName, String tag, boolean isLambda, boolean isMultiplatform, String defaultBaseImage, List<String> dockerOptions) {

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
@@ -50,7 +50,7 @@ public class BuildDockerImage {
             .options(List.of(
                     CommandOption.longFlag("lambda"),
                     CommandOption.longFlag("multiplatform"),
-                    CommandOption.longFlag("default-base-image")))
+                    CommandOption.longOption("default-base-image")))
             .helpSummary("Available Docker deployment image names: " +
                     DockerDeployment.all().stream().map(DockerDeployment::getDeploymentName).collect(joining(", ")) + "\n\n" +
                     "Available lambda image names: " +
@@ -98,17 +98,21 @@ public class BuildDockerImage {
         }
 
         List<String> dockerCommand = new ArrayList<>();
+        List<String> dockerOptions = new ArrayList<>();
+        if (useDefaultBaseImage) {
+            args.defaultBaseImageOpt().ifPresent(image -> dockerOptions.addAll(List.of("--build-arg", "BASE_IMAGE=" + image)));
+        }
         if (args.isMultiplatform() && !platforms.isEmpty()) {
             UploadDockerImages.useBuildXBuilder(commandRunner);
             String platformList = ContainerPlatform.buildPlatformListArgument(platforms);
-            dockerCommand.addAll(List.of("docker", "buildx", "build", "--platform", platformList, "-t", args.tag(), "--load"));
+            dockerOptions.addAll(List.of("--platform", platformList, "--load"));
+            dockerCommand.addAll(List.of("docker", "buildx", "build"));
         } else {
-            dockerCommand.addAll(List.of("docker", "build", "-t", args.tag()));
+            dockerCommand.addAll(List.of("docker", "build"));
         }
-        if (useDefaultBaseImage) {
-            args.defaultBaseImageOpt().ifPresent(image -> dockerCommand.addAll(List.of("--build-arg", "BASE_IMAGE=" + image)));
-        }
-        dockerCommand.addAll(args.dockerOptions());
+        dockerOptions.addAll(List.of("-t", args.tag()));
+        dockerOptions.addAll(args.dockerOptions());
+        dockerCommand.addAll(dockerOptions);
         dockerCommand.add(dockerfileDirectory.toString());
         commandRunner.runOrThrow(dockerCommand.toArray(String[]::new));
     }

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImages.java
@@ -134,7 +134,7 @@ public class UploadDockerImages {
             String platformList = ContainerPlatform.buildPlatformListArgument(image.getPlatforms());
             commandRunner.runOrThrow(dockerBuild(
                     List.of("docker", "buildx", "build"),
-                    optionsWithBuildArgs(buildArgs, "--platform", platformList, "-t", tag, "--push"),
+                    optionsWithBuildArgs(buildArgs, "--platform", platformList, "--push", "-t", tag),
                     dockerfileDirectory));
         } else {
             if (image.getLambdaJar().isPresent()) {

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
@@ -88,6 +88,26 @@ public class BuildDockerImageTest extends DockerImagesTestBase {
                 "./scripts/docker/lambda/lambda.jar", "jar-content"));
     }
 
+    @Test
+    void shouldSetDefaultBaseImage() {
+        // When
+        buildImage(dockerDeploymentImageConfig(), "ingest", "test", "--default-base-image", "base:test");
+
+        // Then
+        assertThat(commandsThatRan).containsExactly(
+                buildImageCommand("test", "./scripts/docker/ingest", "base:test"));
+    }
+
+    @Test
+    void shouldNotApplyDefaultBaseImageWhenNotUsed() {
+        // When
+        buildImage(dockerDeploymentImageConfig(), "bulk-import-runner", "test", "--default-base-image", "base:test");
+
+        // Then
+        assertThat(commandsThatRan).containsExactly(
+                buildImageCommand("test", "./scripts/docker/bulk-import-runner"));
+    }
+
     private void buildImage(DockerImageConfiguration config, String... args) {
         String[] allArgs = Stream.concat(Stream.of("./scripts"), Stream.of(args)).toArray(String[]::new);
         var arguments = BuildDockerImage.readArguments(CommandArgumentReader.parse(BuildDockerImage.USAGE, allArgs));

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.deploy.container;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.core.util.cli.CommandArgumentReader;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.CopyOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildImageCommand;
+
+public class BuildDockerImageTest extends DockerImagesTestBase {
+    protected final Map<String, String> files = new HashMap<>();
+
+    @Test
+    void shouldBuildDockerDeploymentImage() {
+        // When
+        buildImage(dockerDeploymentImageConfig(), "ingest", "test");
+
+        // Then
+        assertThat(commandsThatRan).containsExactly(
+                buildImageCommand("test", "./scripts/docker/ingest"));
+    }
+
+    @Test
+    void shouldBuildLambdaImage() {
+        // Given
+        writeFile("./scripts/jars/statestore.jar", "jar-content");
+
+        // When
+        buildImage(lambdaImageConfig(), "statestore-lambda", "test", "--lambda");
+
+        // Then
+        assertThat(commandsThatRan).containsExactly(
+                buildImageCommand("test", "./scripts/docker/lambda"));
+        assertThat(files).isEqualTo(Map.of(
+                "./scripts/jars/statestore.jar", "jar-content",
+                "./scripts/docker/lambda/lambda.jar", "jar-content"));
+    }
+
+    private void buildImage(DockerImageConfiguration config, String... args) {
+        String[] allArgs = Stream.concat(Stream.of("./scripts"), Stream.of(args)).toArray(String[]::new);
+        var arguments = BuildDockerImage.readArguments(CommandArgumentReader.parse(BuildDockerImage.USAGE, allArgs));
+        try {
+            BuildDockerImage.build(config, commandRunner, this::copyFile, arguments);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void writeFile(String path, String content) {
+        files.put(path, content);
+    }
+
+    private void copyFile(Path source, Path target, CopyOption... options) throws IOException {
+        String sourceContent = files.get(source.toString());
+        if (sourceContent == null) {
+            throw new FileNotFoundException("File not found: " + source);
+        }
+        if (!List.of(options).equals(List.of(StandardCopyOption.REPLACE_EXISTING))) {
+            throw new IOException("Unexpected copy options: " + Arrays.toString(options));
+        }
+        files.put(target.toString(), sourceContent);
+    }
+}

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
@@ -32,7 +32,10 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildAndLoadMultiplatformImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildImageCommand;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.createBuildxBuilderInstanceCommand;
+import static sleeper.clients.deploy.container.DockerImageCommandTestData.useBuildxBuilderInstanceCommand;
 
 public class BuildDockerImageTest extends DockerImagesTestBase {
     protected final Map<String, String> files = new HashMap<>();
@@ -45,6 +48,28 @@ public class BuildDockerImageTest extends DockerImagesTestBase {
         // Then
         assertThat(commandsThatRan).containsExactly(
                 buildImageCommand("test", "./scripts/docker/ingest"));
+    }
+
+    @Test
+    void shouldBuildMultiplatformImage() {
+        // When
+        buildImage(dockerDeploymentImageConfig(), "compaction", "test", "--multiplatform");
+
+        // Then
+        assertThat(commandsThatRan).containsExactly(
+                createBuildxBuilderInstanceCommand(),
+                useBuildxBuilderInstanceCommand(),
+                buildAndLoadMultiplatformImageCommand("test", "./scripts/docker/compaction"));
+    }
+
+    @Test
+    void shouldBuildMultiplatformImageWithSinglePlatform() {
+        // When
+        buildImage(dockerDeploymentImageConfig(), "compaction", "test");
+
+        // Then
+        assertThat(commandsThatRan).containsExactly(
+                buildImageCommand("test", "./scripts/docker/compaction"));
     }
 
     @Test

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/BuildDockerImageTest.java
@@ -36,6 +36,8 @@ import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildA
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.buildImageCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.createBuildxBuilderInstanceCommand;
 import static sleeper.clients.deploy.container.DockerImageCommandTestData.useBuildxBuilderInstanceCommand;
+import static sleeper.clients.util.command.Command.command;
+import static sleeper.clients.util.command.CommandPipeline.pipeline;
 
 public class BuildDockerImageTest extends DockerImagesTestBase {
     protected final Map<String, String> files = new HashMap<>();
@@ -106,6 +108,16 @@ public class BuildDockerImageTest extends DockerImagesTestBase {
         // Then
         assertThat(commandsThatRan).containsExactly(
                 buildImageCommand("test", "./scripts/docker/bulk-import-runner"));
+    }
+
+    @Test
+    void shouldPassThroughOptionToDocker() {
+        // When
+        buildImage(dockerDeploymentImageConfig(), "ingest", "test", "--no-cache");
+
+        // Then
+        assertThat(commandsThatRan).containsExactly(
+                pipeline(command("docker", "build", "-t", "test", "--no-cache", "./scripts/docker/ingest")));
     }
 
     private void buildImage(DockerImageConfiguration config, String... args) {

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/DockerImageCommandTestData.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/DockerImageCommandTestData.java
@@ -106,17 +106,17 @@ public class DockerImageCommandTestData {
 
     public static CommandPipeline buildAndPushMultiplatformImageCommand(String tag, String dockerDirectory, String baseTag) {
         return pipeline(command("docker", "buildx", "build", "--build-arg", "BASE_IMAGE=" + baseTag, "--platform", "linux/amd64,linux/arm64",
-                "-t", tag, "--push", dockerDirectory));
+                "--push", "-t", tag, dockerDirectory));
     }
 
     public static CommandPipeline buildAndPushMultiplatformImageCommand(String tag, String dockerDirectory) {
         return pipeline(command("docker", "buildx", "build", "--platform", "linux/amd64,linux/arm64",
-                "-t", tag, "--push", dockerDirectory));
+                "--push", "-t", tag, dockerDirectory));
     }
 
     public static CommandPipeline buildAndLoadMultiplatformImageCommand(String tag, String dockerDirectory) {
         return pipeline(command("docker", "buildx", "build", "--platform", "linux/amd64,linux/arm64",
-                "-t", tag, "--load", dockerDirectory));
+                "--load", "-t", tag, dockerDirectory));
     }
 
 }

--- a/java/clients/src/test/java/sleeper/clients/deploy/container/DockerImageCommandTestData.java
+++ b/java/clients/src/test/java/sleeper/clients/deploy/container/DockerImageCommandTestData.java
@@ -114,4 +114,9 @@ public class DockerImageCommandTestData {
                 "-t", tag, "--push", dockerDirectory));
     }
 
+    public static CommandPipeline buildAndLoadMultiplatformImageCommand(String tag, String dockerDirectory) {
+        return pipeline(command("docker", "buildx", "build", "--platform", "linux/amd64,linux/arm64",
+                "-t", tag, "--load", dockerDirectory));
+    }
+
 }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7638

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - BuildDockerImageTest
    - Running in GitHub Actions - Docker Image Tests All / build / bulk-import-runner

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
