### PR TITLE
Issue 7644 - Make age-off test portable and document local Rust validation

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -140,6 +140,8 @@ Sleeper.
 See the [test strategy](development/test-strategy.md) and [test design](development/test-design.md) for how and when to
 write tests, as well as information on the testing tools used in the project.
 
+For local Rust contributor checks, see the [Rust local validation guide](development/rust-local-validation.md).
+
 ### IDE setup
 
 Configuration is available for various development environments.

--- a/docs/development/rust-local-validation.md
+++ b/docs/development/rust-local-validation.md
@@ -3,6 +3,16 @@ Rust local validation
 
 The Rust workspace is under `rust/`.
 
+The workspace uses the Rust toolchain version declared in `rust/Cargo.toml`. Before running the validation commands,
+ensure your local toolchain matches the version declared there.
+
+You can verify the active toolchain with:
+
+```bash
+rustc --version
+cargo --version
+```
+
 The Rust workspace can be developed locally on Linux, WSL or macOS, or in the repository development container. These
 environments use the same Rust toolchain workflow.
 

--- a/docs/development/rust-local-validation.md
+++ b/docs/development/rust-local-validation.md
@@ -3,9 +3,8 @@ Rust local validation
 
 The Rust workspace is under `rust/`.
 
-For general Rust development, use WSL/Linux or the repository development container. These are the recommended local
-environments. Native Windows can still be useful for targeted portability checks, but it is not a generally supported
-development environment.
+The Rust workspace can be developed locally on Linux, WSL or macOS, or in the repository development container. These
+environments use the same Rust toolchain workflow.
 
 A useful focused integration test for the Rust data-processing path is:
 
@@ -13,12 +12,12 @@ A useful focused integration test for the Rust data-processing path is:
 cargo test -p sleeper_core --test compaction_test
 ```
 
-This runs without Docker or AWS. It writes small local Parquet inputs, runs DataFusion compaction, and checks output
-rows, row counts, filtering, aggregation, progress callback behaviour, and sketch output.
+This runs locally without AWS. It writes small local Parquet inputs, runs DataFusion compaction, and checks output rows,
+row counts, filtering, aggregation, progress callback behaviour, and sketch output.
 
-## Recommended local environments
+## Rust toolchain
 
-### WSL or Linux
+### Linux, WSL and macOS
 
 Run the following commands from `rust/`.
 
@@ -49,8 +48,8 @@ For full workspace validation:
 cargo test
 ```
 
-Full workspace validation can put substantial pressure on some systems during parallel compilation, before any tests
-begin. If memory use or system responsiveness becomes a problem, reduce Cargo build parallelism:
+On lower-spec systems, full workspace compilation may consume substantial CPU and memory before any tests begin. If
+required, reduce Cargo build parallelism:
 
 ```bash
 cargo test -j 1
@@ -70,69 +69,13 @@ being treated as actionable problems.
 
 ### Development container
 
-The repository development container provides a consistent local environment for Rust development. It is configured
-in `.devcontainer/devcontainer.json`; see the [Developer Guide](../developer-guide.md) for the VS Code dev-container
-workflow.
-
-Once the repository is open inside the container, run the same validation commands described in the WSL or Linux
-section from `rust/`.
-
-## Native Windows, targeted validation only
-
-Native Windows is not the recommended environment for general Sleeper development. It can still be useful for focused
-Rust validation and for identifying portability issues.
-
-Run commands from `rust/` in PowerShell or another Windows shell. Use the Rust version declared by the repository and
-install a working MSVC C++ build toolchain, because the workspace builds the DataSketches C++ bridge used by
-`rust_sketch`.
-
-Useful targeted checks include:
-
-```powershell
-cargo audit
-cargo tree -d
-cargo fmt --all -- --check
-cargo clippy --no-deps --all-targets -- -W clippy::pedantic -D warnings
-
-cargo test -p rust_sketch
-cargo test -p filter_udfs
-cargo test -p sleeper_core
-cargo test -p sleeper_df
-cargo test -p objectstore_ext
-cargo test -p apps --test compact_cli --test query_cli
-```
-
-For a focused integration check of the Rust data-processing path:
-
-```powershell
-cargo test -p sleeper_core --test compaction_test
-```
-
-A full workspace run on native Windows may place significant pressure on the system during parallel compilation. When
-necessary, reduce Cargo build parallelism:
-
-```powershell
-cargo test -j 1
-```
-
-Treat native Windows results as targeted portability evidence. Confirm broader development and validation behaviour in
-WSL/Linux or the repository development container.
-
-## Docker
-
-Docker validation is a broader tier after the local Rust path is working. Run these commands from the repository root:
-
-```bash
-./rust/build-in-docker.sh x86_64 cargo test
-./rust/build-in-docker.sh x86_64 cargo test -p sleeper_core --test compaction_test
-./scripts/test/docker/testCompactionDockerImage.sh
-```
-
-The Docker image test builds and checks the compaction job execution image. This is broader than the Rust-only local
-path and requires Docker.
+The repository development container provides the supported toolchain environment. It is configured in
+`.devcontainer/devcontainer.json`; see the [Developer Guide](../developer-guide.md) for the VS Code dev-container
+workflow. Once the repository is open inside the container, run the same validation commands described above from
+`rust/`.
 
 ## AWS or deployed instance
 
-Deployed-instance validation is covered by the system test suite and manual testing flows. Use it for behaviour that
-cannot be proved locally, including IAM, AWS networking, S3, deployed state stores, Lambda, ECS, EMR, and full Sleeper
-orchestration.
+Deployed-instance validation is covered by the [system testing documentation](system-tests.md) and manual testing flows.
+Use it for behaviour that cannot be proved locally, including IAM, AWS networking, S3, deployed state stores, Lambda,
+ECS, EMR, and full Sleeper orchestration.

--- a/docs/development/rust-local-validation.md
+++ b/docs/development/rust-local-validation.md
@@ -1,0 +1,138 @@
+Rust local validation
+=====================
+
+The Rust workspace is under `rust/`.
+
+For general Rust development, use WSL/Linux or the repository development container. These are the recommended local
+environments. Native Windows can still be useful for targeted portability checks, but it is not a generally supported
+development environment.
+
+A useful focused integration test for the Rust data-processing path is:
+
+```bash
+cargo test -p sleeper_core --test compaction_test
+```
+
+This runs without Docker or AWS. It writes small local Parquet inputs, runs DataFusion compaction, and checks output
+rows, row counts, filtering, aggregation, progress callback behaviour, and sketch output.
+
+## Recommended local environments
+
+### WSL or Linux
+
+Run the following commands from `rust/`.
+
+The workspace includes the DataSketches C++ bridge used by `rust_sketch`, so the environment must provide a working
+C/C++ build toolchain. CMake and `pkg-config` may also be required.
+
+For formatting, linting, and dependency advisory checks:
+
+```bash
+cargo audit
+cargo fmt --all -- --check
+cargo clippy --no-deps --all-targets -- -W clippy::pedantic -D warnings
+```
+
+For focused package validation:
+
+```bash
+cargo test -p rust_sketch
+cargo test -p filter_udfs
+cargo test -p sleeper_core
+cargo test -p sleeper_df
+cargo test -p objectstore_ext
+```
+
+For full workspace validation:
+
+```bash
+cargo test
+```
+
+Full workspace validation can put substantial pressure on some systems during parallel compilation, before any tests
+begin. If memory use or system responsiveness becomes a problem, reduce Cargo build parallelism:
+
+```bash
+cargo test -j 1
+```
+
+This limits Cargo to one build job at a time. It makes compilation slower, but reduces the number of compiler and
+linker processes running concurrently. It does not force tests within each test binary to run serially.
+
+`cargo audit` is the dependency advisory check used by CI. To inspect duplicate dependency versions, run:
+
+```bash
+cargo tree -d
+```
+
+Duplicates introduced by the DataFusion, Arrow, AWS SDK, or build-tool dependency graphs should be reviewed before
+being treated as actionable problems.
+
+### Development container
+
+The repository development container provides a consistent local environment for Rust development. It is configured
+in `.devcontainer/devcontainer.json`; see the [Developer Guide](../developer-guide.md) for the VS Code dev-container
+workflow.
+
+Once the repository is open inside the container, run the same validation commands described in the WSL or Linux
+section from `rust/`.
+
+## Native Windows, targeted validation only
+
+Native Windows is not the recommended environment for general Sleeper development. It can still be useful for focused
+Rust validation and for identifying portability issues.
+
+Run commands from `rust/` in PowerShell or another Windows shell. Use the Rust version declared by the repository and
+install a working MSVC C++ build toolchain, because the workspace builds the DataSketches C++ bridge used by
+`rust_sketch`.
+
+Useful targeted checks include:
+
+```powershell
+cargo audit
+cargo tree -d
+cargo fmt --all -- --check
+cargo clippy --no-deps --all-targets -- -W clippy::pedantic -D warnings
+
+cargo test -p rust_sketch
+cargo test -p filter_udfs
+cargo test -p sleeper_core
+cargo test -p sleeper_df
+cargo test -p objectstore_ext
+cargo test -p apps --test compact_cli --test query_cli
+```
+
+For a focused integration check of the Rust data-processing path:
+
+```powershell
+cargo test -p sleeper_core --test compaction_test
+```
+
+A full workspace run on native Windows may place significant pressure on the system during parallel compilation. When
+necessary, reduce Cargo build parallelism:
+
+```powershell
+cargo test -j 1
+```
+
+Treat native Windows results as targeted portability evidence. Confirm broader development and validation behaviour in
+WSL/Linux or the repository development container.
+
+## Docker
+
+Docker validation is a broader tier after the local Rust path is working. Run these commands from the repository root:
+
+```bash
+./rust/build-in-docker.sh x86_64 cargo test
+./rust/build-in-docker.sh x86_64 cargo test -p sleeper_core --test compaction_test
+./scripts/test/docker/testCompactionDockerImage.sh
+```
+
+The Docker image test builds and checks the compaction job execution image. This is broader than the Rust-only local
+path and requires Docker.
+
+## AWS or deployed instance
+
+Deployed-instance validation is covered by the system test suite and manual testing flows. Use it for behaviour that
+cannot be proved locally, including IAM, AWS networking, S3, deployed state stores, Lambda, ECS, EMR, and full Sleeper
+orchestration.

--- a/rust/filter_udfs/src/ageoff.rs
+++ b/rust/filter_udfs/src/ageoff.rs
@@ -271,12 +271,18 @@ mod tests {
     }
 
     #[test]
-    fn try_from_should_work_on_large_timestamp() {
+    fn try_from_should_work_on_large_representable_timestamp() -> Result<(), DataFusionError> {
+        // This is large enough to exercise millisecond timestamps beyond 32-bit
+        // ranges while staying representable on Windows.
+        const LARGE_REPRESENTABLE_MILLIS: i64 = 10_000_000_000_000;
+
         // When
-        let result = AgeOff::try_from(i64::MAX);
+        let filter =
+            AgeOff::try_from_relative_to(LARGE_REPRESENTABLE_MILLIS, SystemTime::UNIX_EPOCH)?;
 
         // Then
-        assert!(result.is_ok());
+        assert_eq!(filter.threshold, -LARGE_REPRESENTABLE_MILLIS);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue for your progress.
  - Resolves https://github.com/gchq/sleeper/issues/7644

---

## Summary

This PR resolves the native Windows Rust validation portability issue described in #7644 and adds a documented local
Rust validation workflow for contributors.

### Test portability

The test:

```text
filter_udfs::ageoff::tests::try_from_should_work_on_large_timestamp
```

previously called:

```rust
AgeOff::try_from(i64::MAX)
```

which derives its behaviour relative to `SystemTime::now()`.

On native Windows this extreme timestamp is not representable, causing the test to fail during local Rust validation.

This PR replaces that test with a deterministic equivalent that uses a large representable timestamp relative to an
explicit `SystemTime::UNIX_EPOCH`, preserving the original behaviour being tested while making the test portable across
platforms.

### Rust local validation

This PR also adds a local Rust validation guide describing practical contributor workflows for:

- WSL/Linux (recommended)
- Development container
- Native Windows (targeted portability validation)
- Docker
- AWS/deployed instance validation

The guide documents a focused local integration test for the Rust data-processing path:

```bash
cargo test -p sleeper_core --test compaction_test
```

along with formatting, linting and package-level validation commands.

The documentation reflects the recommended contributor environments while documenting native Windows as a targeted
validation environment rather than a generally supported development platform.

During local validation I also observed that the largest resource pressure on my Windows contributor environment
occurred during parallel workspace compilation before any tests had started. The guide therefore notes that full
workspace validation may be resource-intensive on some systems and mentions reducing Cargo build parallelism:

```bash
cargo test -j 1
```

as an optional mitigation when contributors encounter resource pressure during full workspace validation.

This change does not alter production behaviour.

---

## Validation

### Native Windows

Validated using the repository Rust toolchain:

```powershell
cargo fmt --all -- --check
cargo clippy --no-deps --all-targets -- -W clippy::pedantic -D warnings

cargo test -p filter_udfs
cargo test -p sleeper_core --test compaction_test
```

Additional validation confirmed that the updated age-off test passes on native Windows.

### WSL

Validated successfully from a fresh WSL environment using the repository Rust toolchain:

```bash
cargo test -p filter_udfs
cargo fmt --all -- --check
cargo clippy --no-deps --all-targets -- -W clippy::pedantic -D warnings
```

During investigation I also verified that:

```bash
cargo test -j 1
```

completed successfully after identifying that the primary resource pressure on my Windows contributor environment
occurred during parallel workspace compilation rather than test execution.

---

## Tests

- [x] My PR adds or updates tests based on the test strategy.

Updated:

- `filter_udfs::ageoff::tests::try_from_should_work_on_large_representable_timestamp`

Validated on:

- Native Windows
- WSL

---

## Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - Added `docs/development/rust-local-validation.md`.

- [ ] If I have added new Java code, I have added Javadoc that explains it following our conventions and style.
  - Not applicable (no Java changes).

- [ ] If I have added or removed any dependencies from the project, I have updated the `NOTICES` file.
  - Not applicable (no dependency changes).