### PR TITLE
Issue 7290: removed duplicate tableProperties instance

### DIFF
--- a/java/core/src/test/java/sleeper/core/iterator/AggregationFilteringIteratorTest.java
+++ b/java/core/src/test/java/sleeper/core/iterator/AggregationFilteringIteratorTest.java
@@ -68,7 +68,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "test2", "value", 9999999999999999L)));
 
             // When
-            List<Row> filtered = applyIterator(rows, tableProperties);
+            List<Row> filtered = applyIterator(rows);
 
             // Then
             assertThat(filtered).containsExactly(new Row(Map.of("key", "test2", "value", 9999999999999999L)));
@@ -92,7 +92,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> rows = List.of(row1, row2, row3);
 
             // When
-            List<Row> filtered = applyIterator(rows, tableProperties);
+            List<Row> filtered = applyIterator(rows);
 
             // Then
             assertThat(filtered).containsExactly(new Row(Map.of("key", "test2", "value", 9999999999999999L)));
@@ -113,8 +113,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> resultList = applyIterator(List.of(
                     new Row(Map.of("key", "test", "value", 2214L)),
                     new Row(Map.of("key", "test", "value", 87L)),
-                    new Row(Map.of("key", "test", "value", 7841L))),
-                    tableProperties);
+                    new Row(Map.of("key", "test", "value", 7841L))));
 
             // Then
             assertThat(resultList).containsExactlyElementsOf(List.of(new Row(Map.of("key", "test", "value", 10142L))));
@@ -130,8 +129,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> resultList = applyIterator(List.of(
                     new Row(Map.of("key", "test", "value", 619L)),
                     new Row(Map.of("key", "test", "value", 321L)),
-                    new Row(Map.of("key", "test", "value", 97L))),
-                    tableProperties);
+                    new Row(Map.of("key", "test", "value", 97L))));
 
             // Then
             assertThat(resultList).containsExactlyElementsOf(List.of(new Row(Map.of("key", "test", "value", 97L))));
@@ -147,8 +145,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> resultList = applyIterator(List.of(
                     new Row(Map.of("key", "test", "value", 458498L)),
                     new Row(Map.of("key", "test", "value", 87L)),
-                    new Row(Map.of("key", "test", "value", 222474L))),
-                    tableProperties);
+                    new Row(Map.of("key", "test", "value", 222474L))));
 
             // Then
             assertThat(resultList).containsExactlyElementsOf(List.of(new Row(Map.of("key", "test", "value", 458498L))));
@@ -178,8 +175,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "a",
                             "map_value", Map.of("map_key1", 1L, "map_key2", 3L))),
                     new Row(Map.of("key", "a",
-                            "map_value", Map.of("map_key1", 3L, "map_key2", 4L)))),
-                    tableProperties);
+                            "map_value", Map.of("map_key1", 3L, "map_key2", 4L)))));
 
             assertThat(resultList).containsExactly(
                     new Row(Map.of("key", "a",
@@ -197,8 +193,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "a",
                             "map_value", Map.of("map_key1", 17L, "map_key2", 112L))),
                     new Row(Map.of("key", "a",
-                            "map_value", Map.of("map_key1", 9L, "map_key2", 2489L)))),
-                    tableProperties);
+                            "map_value", Map.of("map_key1", 9L, "map_key2", 2489L)))));
 
             assertThat(resultList).containsExactly(
                     new Row(Map.of("key", "a",
@@ -216,8 +211,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "a",
                             "map_value", Map.of("map_key1", 666L, "map_key2", 11L))),
                     new Row(Map.of("key", "a",
-                            "map_value", Map.of("map_key1", 245L, "map_key2", 2L)))),
-                    tableProperties);
+                            "map_value", Map.of("map_key1", 245L, "map_key2", 2L)))));
 
             assertThat(resultList).containsExactly(
                     new Row(Map.of("key", "a",
@@ -248,8 +242,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key1", "test", "value1", 4217L,
                             "key2", "test", "value2", 367L)),
                     new Row(Map.of("key1", "test", "value1", 214L,
-                            "key2", "test", "value2", 88818L))),
-                    tableProperties);
+                            "key2", "test", "value2", 88818L))));
 
             // Then
             assertThat(resultList).containsExactly(
@@ -277,8 +270,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "C", "timestamp", 100L, "count", 10L)), // Filtered out due to age
                     new Row(Map.of("key", "C", "timestamp", 100L, "count", 20L)), // Filtered out due to age
                     new Row(Map.of("key", "D", "timestamp", 9999999999999999L, "count", 10L)),
-                    new Row(Map.of("key", "D", "timestamp", 9999999999999999L, "count", 20L))),
-                    tableProperties);
+                    new Row(Map.of("key", "D", "timestamp", 9999999999999999L, "count", 20L))));
 
             // Then
             assertThat(resultList).containsExactly(
@@ -299,7 +291,7 @@ public class AggregationFilteringIteratorTest {
         @Test
         void shouldAggregateZeroRows() throws Exception {
             // When / Then
-            assertThat(applyIterator(List.of(), tableProperties)).isEmpty();
+            assertThat(applyIterator(List.of())).isEmpty();
         }
 
         @Test
@@ -308,7 +300,7 @@ public class AggregationFilteringIteratorTest {
             Row testRow = new Row(Map.of("key", "A", "value", 525L));
 
             // When
-            List<Row> resultList = applyIterator(List.of(testRow), tableProperties);
+            List<Row> resultList = applyIterator(List.of(testRow));
 
             // Then
             assertThat(resultList).containsExactly(testRow);
@@ -322,7 +314,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "B", "value", 1000L)));
 
             // When
-            List<Row> resultList = applyIterator(testRows, tableProperties);
+            List<Row> resultList = applyIterator(testRows);
 
             // Then
             assertThat(resultList).isEqualTo(testRows);
@@ -334,8 +326,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> resultList = applyIterator(List.of(
                     new Row(Map.of("key", "A", "value", 100L)),
                     new Row(Map.of("key", "A", "value", 1000L)),
-                    new Row(Map.of("key", "B", "value", 500L))),
-                    tableProperties);
+                    new Row(Map.of("key", "B", "value", 500L))));
 
             // Then
             assertThat(resultList).isEqualTo(List.of(
@@ -349,8 +340,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> resultList = applyIterator(List.of(
                     new Row(Map.of("key", "A", "value", 100L)),
                     new Row(Map.of("key", "B", "value", 1000L)),
-                    new Row(Map.of("key", "B", "value", 500L))),
-                    tableProperties);
+                    new Row(Map.of("key", "B", "value", 500L))));
 
             // Then
             assertThat(resultList).isEqualTo(List.of(
@@ -366,8 +356,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "A", "value", 1000L)),
                     new Row(Map.of("key", "B", "value", 500L)),
                     new Row(Map.of("key", "C", "value", 70L)),
-                    new Row(Map.of("key", "C", "value", 230L))),
-                    tableProperties);
+                    new Row(Map.of("key", "C", "value", 230L))));
 
             // Then
             assertThat(resultList).isEqualTo(List.of(
@@ -383,8 +372,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "A", "value", 100L)),
                     new Row(Map.of("key", "B", "value", 1000L)),
                     new Row(Map.of("key", "B", "value", 500L)),
-                    new Row(Map.of("key", "C", "value", 70L))),
-                    tableProperties);
+                    new Row(Map.of("key", "C", "value", 70L))));
 
             // Then
             assertThat(resultList).isEqualTo(List.of(
@@ -407,8 +395,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> resultList = applyIterator(List.of(
                     new Row(Map.of("key", "A", "sortKey", 1, "value", 100L)),
                     new Row(Map.of("key", "A", "sortKey", 1, "value", 1000L)),
-                    new Row(Map.of("key", "A", "sortKey", 2, "value", 500L))),
-                    tableProperties);
+                    new Row(Map.of("key", "A", "sortKey", 2, "value", 500L))));
 
             // Then
             assertThat(resultList).containsExactly(
@@ -432,7 +419,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(FILTERING_CONFIG, "ageOff(value,1000)");
 
             // When / Then
-            assertThat(createIterator(tableProperties).getRequiredValueFields()).containsExactly("value");
+            assertThat(createIterator().getRequiredValueFields()).containsExactly("value");
         }
 
         @Test
@@ -446,7 +433,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(FILTERING_CONFIG, "ageOff(sortKey, 1000)");
 
             // When / Then
-            assertThat(createIterator(tableProperties).getRequiredValueFields()).isEmpty();
+            assertThat(createIterator().getRequiredValueFields()).isEmpty();
         }
 
         @Test
@@ -463,7 +450,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(AGGREGATION_CONFIG, "sum(value1), min(value2), max(value3)");
 
             // When / Then
-            assertThat(createIterator(tableProperties).getRequiredValueFields()).isEmpty();
+            assertThat(createIterator().getRequiredValueFields()).isEmpty();
         }
     }
 
@@ -480,7 +467,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(FILTERING_CONFIG, "someother(value,1000)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Sleeper table filter not set to match ageOff(column,age), was: someother");
         }
@@ -495,7 +482,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(FILTERING_CONFIG, "ageOff(value,oops)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(NumberFormatException.class);
         }
     }
@@ -510,7 +497,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(AGGREGATION_CONFIG, "bop(VALUE)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Unable to parse operand. Operand: bop");
         }
@@ -525,7 +512,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(AGGREGATION_CONFIG, "SUM(value),SUM(abc)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Not all aggregated fields are declared in the schema. Missing fields: abc");
         }
@@ -541,7 +528,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(AGGREGATION_CONFIG, "MIN(failKey),MIN(sortKey),SUM(value)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Column for aggregation not allowed to be a Row Key or Sort Key. Column names: failKey, sortKey");
         }
@@ -556,7 +543,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(AGGREGATION_CONFIG, "MIN(doubleValue),SUM(doubleValue)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(java.lang.IllegalArgumentException.class)
                     .hasMessage("Not allowed duplicate columns for aggregation. Column name: doubleValue");
         }
@@ -571,7 +558,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(AGGREGATION_CONFIG, "MIN(existsValue)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(java.lang.IllegalArgumentException.class)
                     .hasMessage("Not all value fields have aggregation declared. Missing columns: ignoredValue");
         }
@@ -586,7 +573,7 @@ public class AggregationFilteringIteratorTest {
             tableProperties.set(AGGREGATION_CONFIG, "SUM(value)");
 
             // When / Then
-            assertThatThrownBy(() -> createIterator(tableProperties))
+            assertThatThrownBy(() -> createIterator())
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Aggregation is not supported for nullable value fields. Nullable fields: value");
         }
@@ -606,7 +593,7 @@ public class AggregationFilteringIteratorTest {
                     new Row(Map.of("key", "test2", "value", 9999999999999999L)));
 
             // When
-            List<Row> filtered = applyIterator(rows, tableProperties);
+            List<Row> filtered = applyIterator(rows);
 
             // Then
             assertThat(filtered).containsExactly(new Row(Map.of("key", "test2", "value", 9999999999999999L)));
@@ -624,8 +611,7 @@ public class AggregationFilteringIteratorTest {
             // When
             List<Row> resultList = applyIterator(List.of(
                     new Row(Map.of("key", "A", "value", 100L, "value2", 10L)),
-                    new Row(Map.of("key", "A", "value", 1000L, "value2", 20L))),
-                    tableProperties);
+                    new Row(Map.of("key", "A", "value", 1000L, "value2", 20L))));
 
             // Then
             assertThat(resultList).isEqualTo(List.of(
@@ -633,11 +619,11 @@ public class AggregationFilteringIteratorTest {
         }
     }
 
-    private List<Row> applyIterator(List<Row> rows, TableProperties tableProperties) throws Exception {
-        return SortedRowIteratorTestHelper.apply(createIterator(tableProperties), rows);
+    private List<Row> applyIterator(List<Row> rows) throws Exception {
+        return SortedRowIteratorTestHelper.apply(createIterator(), rows);
     }
 
-    private SortedRowIterator createIterator(TableProperties tableProperties) throws Exception {
+    private SortedRowIterator createIterator() throws Exception {
         return IteratorFactoryTestHelper.createIterator(tableProperties);
     }
 }

--- a/java/core/src/test/java/sleeper/core/iterator/AggregationFilteringIteratorTest.java
+++ b/java/core/src/test/java/sleeper/core/iterator/AggregationFilteringIteratorTest.java
@@ -52,11 +52,6 @@ public class AggregationFilteringIteratorTest {
                     .rowKeyFields(new Field("key", new StringType()))
                     .valueFields(new Field("value", new LongType()))
                     .build());
-    TableProperties tablePropertiesNullableValueField = createTestTableProperties(instanceProperties,
-            Schema.builder()
-                    .rowKeyFields(new Field("key", new StringType()))
-                    .valueFields(new Field("value", new LongType(), true))
-                    .build());
 
     @Nested
     @DisplayName("Apply filters")
@@ -83,7 +78,11 @@ public class AggregationFilteringIteratorTest {
         @CsvSource({"ageoff", "AGEOFF", "ageOff"})
         public void shouldApplyAgeOffFilterFromPropertiesAndNullValuesShouldBeExcluded(String ageOff) throws Exception {
             // Given
-            tablePropertiesNullableValueField.set(FILTERING_CONFIG, ageOff + "(value,1000)");
+            tableProperties.setSchema(Schema.builder()
+                    .rowKeyFields(new Field("key", new StringType()))
+                    .valueFields(new Field("value", new LongType(), true))
+                    .build());
+            tableProperties.set(FILTERING_CONFIG, ageOff + "(value,1000)");
 
             Row row1 = new Row(Map.of("key", "test", "value", 10L));
             Row row2 = new Row(Map.of("key", "test2", "value", 9999999999999999L));
@@ -93,7 +92,7 @@ public class AggregationFilteringIteratorTest {
             List<Row> rows = List.of(row1, row2, row3);
 
             // When
-            List<Row> filtered = applyIterator(rows, tablePropertiesNullableValueField);
+            List<Row> filtered = applyIterator(rows, tableProperties);
 
             // Then
             assertThat(filtered).containsExactly(new Row(Map.of("key", "test2", "value", 9999999999999999L)));


### PR DESCRIPTION
### Issue
    
- [x] My PR fully resolves issue #7290 by removing the duplicate tableProperties instance.
     - Resolves https://github.com/gchq/sleeper/issues/7290

### Tests

- [x] My PR does not add any tests, as it is a small PR to edit a singular test

### Documentation

- [x] My PR does not add any documentation, as it is a small change that, in my opinion, does not need any documentation.
     - If anyone disagrees with this assertion, I am happy to review and add any necessary documentation.
