### PR TITLE
Issue 7794 - Add support for SQL querying to PerCall DataFusion retriever

### DIFF
--- a/java/query/query-datafusion/src/main/java/sleeper/query/datafusion/PerCallDataFusionRowRetrieverProvider.java
+++ b/java/query/query-datafusion/src/main/java/sleeper/query/datafusion/PerCallDataFusionRowRetrieverProvider.java
@@ -84,6 +84,11 @@ public class PerCallDataFusionRowRetrieverProvider implements LeafPartitionRowRe
         public boolean supportsFiltersAndAggregations() {
             return true;
         }
+
+        @Override
+        public boolean supportsSqlFiltering() {
+            return true;
+        }
     }
 
     private static void closeQuietly(AutoCloseable closeable, String description) {

--- a/java/query/query-datafusion/src/test/java/sleeper/query/datafusion/PerCallDataFusionRowRetrieverProviderTest.java
+++ b/java/query/query-datafusion/src/test/java/sleeper/query/datafusion/PerCallDataFusionRowRetrieverProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.query.datafusion;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.foreign.datafusion.DataFusionAwsConfig;
+import sleeper.query.core.rowretrieval.LeafPartitionRowRetriever;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PerCallDataFusionRowRetrieverProviderTest {
+    @Test
+    void shouldSupportFiltersAndAggregations() {
+        // Given
+        DataFusionAwsConfig awsConfig = DataFusionAwsConfig.overrideEndpoint("dummy");
+        PerCallDataFusionRowRetrieverProvider provider = new PerCallDataFusionRowRetrieverProvider(awsConfig);
+
+        // When
+        LeafPartitionRowRetriever retriever = provider.getRowRetriever(null);
+
+        // Then
+        assertThat(retriever.supportsFiltersAndAggregations()).isTrue();
+    }
+
+    @Test
+    void shouldSupportSqlFiltering() {
+        // Given
+        DataFusionAwsConfig awsConfig = DataFusionAwsConfig.overrideEndpoint("dummy");
+        PerCallDataFusionRowRetrieverProvider provider = new PerCallDataFusionRowRetrieverProvider(awsConfig);
+
+        // When
+        LeafPartitionRowRetriever retriever = provider.getRowRetriever(null);
+
+        // Then
+        assertThat(retriever.supportsSqlFiltering()).isTrue();
+    }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7794

### Tests

- [X] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Test added

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
