### PR TITLE
Issue 7801 - FFI query extension array pointer should be optional if length is zero

### DIFF
--- a/rust/sleeper_df/src/objects.rs
+++ b/rust/sleeper_df/src/objects.rs
@@ -47,10 +47,15 @@ pub struct FFIFileResult {
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub enum FFIRowKeyValueType {
+    /// 32-bit signed integer row key type.
     Int32 = 1,
+    /// 64-bit signed integer row key type.
     Int64 = 2,
+    /// String row key type.
     String = 3,
+    /// Byte array row key type.
     ByteArray = 4,
+    /// Unbounded row key type.
     Empty = 5,
 }
 
@@ -95,9 +100,13 @@ impl Display for FFIRowKeyValueType {
 /// The order and types of the fields must match exactly.
 #[repr(C)]
 pub union FFIRowKeyValueData {
+    /// 32-bit signed integer value.
     int32: i32,
+    /// 64-bit signed integer value.
     int64: i64,
+    /// String value as [`FFIBytes`].
     string: *const FFIBytes,
+    /// Byte array value as [`FFIBytes`].
     bytes: *const FFIBytes,
 }
 
@@ -145,7 +154,9 @@ impl TryFrom<&FFIRowKeyValue> for PartitionBound<'_> {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct FFIBytes {
+    /// Length of the byte array.
     pub length: usize,
+    /// Pointer to the byte array data. May be NULL if and only if length is zero.
     pub buffer: *const c_uchar,
 }
 

--- a/rust/sleeper_df/src/objects/aws_config.rs
+++ b/rust/sleeper_df/src/objects/aws_config.rs
@@ -34,11 +34,17 @@ pub fn unpack_aws_config(params: &FFICommonConfig) -> Option<AwsConfig> {
 /// The order and types of the fields must match exactly.
 #[repr(C)]
 pub struct FFIAwsConfig {
+    /// AWS region name.
     pub region: *const c_char,
+    /// AWS endpoint URL.
     pub endpoint: *const c_char,
+    /// AWS access key ID.
     pub access_key_id: *const c_char,
+    /// AWS secret access key.
     pub secret_access_key: *const c_char,
+    /// AWS session token.
     pub session_token: *const c_char,
+    /// Whether to allow HTTP (non-HTTPS) connections.
     pub allow_http: bool,
 }
 

--- a/rust/sleeper_df/src/objects/extensions.rs
+++ b/rust/sleeper_df/src/objects/extensions.rs
@@ -121,6 +121,9 @@ pub fn find_extensions_type<'a>(
     extensions: *const FFIExtension,
     extensions_len: usize,
 ) -> Vec<&'a FFIExtension> {
+    if extensions_len == 0 {
+        return Vec::new();
+    }
     unsafe { slice::from_raw_parts(extensions, extensions_len) }
         .iter()
         // only keep instances that match the given extension type
@@ -136,6 +139,11 @@ pub fn validate_extensions(
     extensions: *const FFIExtension,
     extensions_len: usize,
 ) -> Result<(), color_eyre::Report> {
+    // If length is zero, extensions array may be NULL
+    if extensions_len == 0 {
+        return Ok(());
+    }
+
     let Some(_) = (unsafe { extensions.as_ref() }) else {
         bail!("FFIExtension array is NULL");
     };
@@ -176,12 +184,24 @@ mod tests {
     }
 
     #[test]
-    pub fn should_fail_on_null_pointer() {
+    pub fn should_succeed_with_null_pointer_when_length_is_zero() {
         // Given
         let null_ptr: *const FFIExtension = std::ptr::null();
 
         // When
         let result = validate_extensions(null_ptr, 0);
+
+        // Then
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    pub fn should_fail_on_null_pointer_when_length_is_nonzero() {
+        // Given
+        let null_ptr: *const FFIExtension = std::ptr::null();
+
+        // When
+        let result = validate_extensions(null_ptr, 1);
 
         // Then
         assert!(result.is_err());
@@ -291,6 +311,22 @@ mod tests {
         );
 
         // Then - should find nothing
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    pub fn find_extensions_type_returns_empty_for_null_pointer_with_zero_length() {
+        // Given - NULL pointer with zero length
+        let null_ptr: *const FFIExtension = std::ptr::null();
+
+        // When
+        let result = find_extensions_type(
+            FFIExtensionVariant::SQL,
+            null_ptr,
+            0,
+        );
+
+        // Then - should find nothing without panicking
         assert!(result.is_empty());
     }
 

--- a/rust/sleeper_df/src/objects/extensions.rs
+++ b/rust/sleeper_df/src/objects/extensions.rs
@@ -27,6 +27,7 @@ use std::{collections::HashMap, fmt::Display, mem::discriminant, slice};
 #[derive(Debug, Copy, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum FFIExtensionVariant {
+    /// SQL query extension for filtering during execution.
     SQL = 1,
 }
 
@@ -79,6 +80,7 @@ impl Display for FFIExtensionVariant {
 /// The order and types of the fields must match exactly.
 #[repr(C)]
 pub union FFIExtensionData {
+    /// SQL query extension data.
     pub sql: *const FFISQLExtension,
 }
 
@@ -116,6 +118,8 @@ impl FFIExtension {
 }
 
 /// Get all instances of a given extension type from an array.
+///
+/// If `extensions_len` is 0, then `extensions` may be NULL.
 pub fn find_extensions_type<'a>(
     variant: FFIExtensionVariant,
     extensions: *const FFIExtension,
@@ -133,6 +137,7 @@ pub fn find_extensions_type<'a>(
 
 /// Checks the extension array and ensures all extensions are permitted.
 ///
+/// If `extensions_len` is 0, then `extensions` may be NULL.
 /// # Errors
 /// Error will occur if any extension is type is contained more than its permitted maximum.
 pub fn validate_extensions(
@@ -320,11 +325,7 @@ mod tests {
         let null_ptr: *const FFIExtension = std::ptr::null();
 
         // When
-        let result = find_extensions_type(
-            FFIExtensionVariant::SQL,
-            null_ptr,
-            0,
-        );
+        let result = find_extensions_type(FFIExtensionVariant::SQL, null_ptr, 0);
 
         // Then - should find nothing without panicking
         assert!(result.is_empty());

--- a/rust/sleeper_df/src/objects/ffi_common_config.rs
+++ b/rust/sleeper_df/src/objects/ffi_common_config.rs
@@ -39,23 +39,37 @@ use url::Url;
 /// The order and types of the fields must match exactly.
 #[repr(C)]
 pub struct FFICommonConfig {
+    /// Job ID for this operation.
     pub job_id: *const c_char,
-    // If this field is NULL use defaults.
+    /// AWS configuration. May be NULL to use defaults.
     pub aws_config: *const FFIAwsConfig,
+    /// Length of input files array.
     pub input_files_len: usize,
+    /// Input file paths (S3 URLs or local paths).
     pub input_files: *const FFIBytes,
+    /// Whether input files are pre-sorted.
     pub input_files_sorted: bool,
+    /// Output file path (S3 URL or local path). Only used when writing output to file.
     pub output_file: *const c_char,
+    /// Whether to write a sketch file alongside output. Only applies to file output.
     pub write_sketch_file: bool,
+    /// Whether to use readahead store to reduce object store GET requests.
     pub use_readahead_store: bool,
+    /// Length of row key columns array.
     pub row_key_cols_len: usize,
+    /// Row key column names.
     pub row_key_cols: *const FFIBytes,
+    /// Length of sort key columns array.
     pub sort_key_cols_len: usize,
+    /// Sort key column names.
     pub sort_key_cols: *const FFIBytes,
+    /// Query or compaction region.
     pub region: *const FFISleeperRegion,
+    /// Aggregation configuration JSON. See docs/usage/data-retrieval.md for format details.
     pub aggregation_config: *const c_char,
+    /// Filtering configuration JSON. See docs/usage/data-retrieval.md for format details.
     pub filtering_config: *const c_char,
-    // If this field is NULL, then use defaults
+    /// Parquet options. May be NULL to use defaults.
     pub parquet_options: *const FFIParquetOptions,
 }
 

--- a/rust/sleeper_df/src/objects/ffi_parquet_options.rs
+++ b/rust/sleeper_df/src/objects/ffi_parquet_options.rs
@@ -37,15 +37,25 @@ pub const DICT_ENCODE_VALUES: bool = false;
 #[repr(C)]
 #[derive(Debug)]
 pub struct FFIParquetOptions {
+    /// Whether to read page indexes from Parquet files.
     pub read_page_indexes: bool,
+    /// Maximum number of rows per Parquet row group.
     pub max_row_group_size: usize,
+    /// Maximum size in bytes for Parquet pages.
     pub max_page_size: usize,
+    /// Parquet compression codec name.
     pub compression: *const c_char,
+    /// Parquet writer version (e.g., "v2").
     pub writer_version: *const c_char,
+    /// Maximum length to truncate column names in statistics.
     pub column_truncate_length: usize,
+    /// Maximum length to truncate statistics values.
     pub stats_truncate_length: usize,
+    /// Whether to dictionary-encode row key fields.
     pub dict_enc_row_keys: bool,
+    /// Whether to dictionary-encode sort key fields.
     pub dict_enc_sort_keys: bool,
+    /// Whether to dictionary-encode value fields.
     pub dict_enc_values: bool,
 }
 

--- a/rust/sleeper_df/src/objects/query.rs
+++ b/rust/sleeper_df/src/objects/query.rs
@@ -52,7 +52,7 @@ pub struct FFILeafPartitionQueryConfig {
     pub explain_plans: bool,
     /// Length of extension array
     pub extensions_len: usize,
-    /// Array of optional extensions. Maybe NULL if and only if extensions_len is zero.
+    /// Array of optional extensions. Maybe NULL if and only if `extensions_len` is zero.
     pub extensions: *const FFIExtension,
 }
 

--- a/rust/sleeper_df/src/objects/query.rs
+++ b/rust/sleeper_df/src/objects/query.rs
@@ -52,7 +52,7 @@ pub struct FFILeafPartitionQueryConfig {
     pub explain_plans: bool,
     /// Length of extension array
     pub extensions_len: usize,
-    /// Array of optional extensions
+    /// Array of optional extensions. Maybe NULL if and only if extensions_len is zero.
     pub extensions: *const FFIExtension,
 }
 

--- a/rust/sleeper_df/src/objects/sleeper_region.rs
+++ b/rust/sleeper_df/src/objects/sleeper_region.rs
@@ -29,14 +29,17 @@ use std::{borrow::Borrow, collections::HashMap, slice};
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct FFISleeperRegion {
-    // Length of all other arrays in struct.
+    /// Length of all other arrays in this struct.
     pub number_of_dimensions: usize,
-    // The mins array may NOT contain null pointers
+    /// Minimum boundary values. May not contain NULL pointers.
     pub mins: *const FFIRowKeyValue,
-    // The maxs array may contain null pointers!!
+    /// Maximum boundary values. May contain NULL pointers.
     pub maxs: *const FFIRowKeyValue,
+    /// Whether minimum boundaries are inclusive (true) or exclusive (false).
     pub mins_inclusive: *const bool,
+    /// Whether maximum boundaries are inclusive (true) or exclusive (false).
     pub maxs_inclusive: *const bool,
+    /// Array of dimension indexes in the row key.
     pub dimension_indexes: *const usize,
 }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [X] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7801

### Tests

- [X] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated unit tests for extensions

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [X] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [X] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
