### PR TITLE
7835: Improve usability of file status report

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
+++ b/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
@@ -113,6 +113,12 @@ public class FilesStatusReport {
                     "Output format. One of STANDARD, JSON, CSV. Defaults to STANDARD.")
             .build();
 
+    /**
+     * Reads the arguments from the command line.
+     *
+     * @param  arguments the parsed command line arguments
+     * @return           the arguments
+     */
     public static Arguments readArguments(CommandArguments arguments) {
         return new Arguments(
                 arguments.getString("instance-id"),
@@ -124,6 +130,15 @@ public class FilesStatusReport {
                         .orElse(DEFAULT_STATUS_REPORTER));
     }
 
+    /**
+     * Holds the arguments for the files status report command.
+     *
+     * @param instanceId    the Sleeper instance ID
+     * @param tableName     the name of the table to report on
+     * @param maxNoRefFiles the maximum number of files with no references to count
+     * @param verbose       if true, the report will include detailed file information
+     * @param reporterType  the output format, one of STANDARD, JSON, CSV
+     */
     public record Arguments(
             String instanceId,
             String tableName,

--- a/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
+++ b/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
@@ -106,11 +106,11 @@ public class FilesStatusReport {
                     "--max-no-ref-files <number>\n" +
                     "Maximum number of files with no references to count. Defaults to 1000.\n" +
                     "\n" +
-                    "--verbose\n" +
-                    "If set, the report will include detailed file information.\n" +
-                    "\n" +
                     "--report-type <type>\n" +
-                    "Output format. One of STANDARD, JSON, CSV. Defaults to STANDARD.")
+                    "Output format. One of STANDARD, JSON, CSV. Defaults to STANDARD.\n" +
+                    "\n" +
+                    "--verbose\n" +
+                    "If set, the report will include detailed file information.")
             .build();
 
     /**
@@ -148,8 +148,7 @@ public class FilesStatusReport {
 
         public Arguments {
             if (!FILE_STATUS_REPORTERS.containsKey(reporterType)) {
-                throw new CommandArgumentsException("Report type not supported: " + reporterType +
-                        ". Valid types: " + String.join(", ", FILE_STATUS_REPORTERS.keySet()));
+                throw new CommandArgumentsException("Report type not supported: " + reporterType + ". Valid types: " + String.join(", ", FILE_STATUS_REPORTERS.keySet()));
             }
         }
     }

--- a/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
+++ b/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
@@ -30,9 +30,14 @@ import sleeper.configuration.properties.S3TableProperties;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.table.TablePropertiesProvider;
 import sleeper.core.statestore.StateStore;
+import sleeper.core.util.cli.CommandArguments;
+import sleeper.core.util.cli.CommandArgumentsException;
+import sleeper.core.util.cli.CommandLineUsage;
+import sleeper.core.util.cli.CommandOption;
 import sleeper.statestore.StateStoreFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -89,40 +94,63 @@ public class FilesStatusReport {
         fileStatusReporter.report(tableStatus, verbose);
     }
 
-    public static void main(String[] args) {
-        if (!(args.length >= 2 && args.length <= 5)) {
-            throw new IllegalArgumentException(
-                    "Usage: <instance-id> <table-name> <optional-max-num-files-with-no-references-to-count> " +
-                            "<optional-verbose-true-or-false> <optional-report-type-standard-or-csv-or-json>");
-        }
+    public static final CommandLineUsage USAGE = CommandLineUsage.builder()
+            .positionalArguments(List.of("instance-id", "table-name"))
+            .options(List.of(
+                    CommandOption.longOption("max-no-ref-files"),
+                    CommandOption.longFlag("verbose"),
+                    CommandOption.longOption("report-type")))
+            .helpSummary("" +
+                    "Creates a report on the status of files in a Sleeper table.\n" +
+                    "\n" +
+                    "--max-no-ref-files <number>\n" +
+                    "Maximum number of files with no references to count. Defaults to 1000.\n" +
+                    "\n" +
+                    "--verbose\n" +
+                    "If set, the report will include detailed file information.\n" +
+                    "\n" +
+                    "--report-type <type>\n" +
+                    "Output format. One of STANDARD, JSON, CSV. Defaults to STANDARD.")
+            .build();
 
-        boolean verbose = false;
-        int maxFilesWithNoReferences = 1000;
-        String instanceId = args[0];
-        String tableName = args[1];
-        String reporterType = DEFAULT_STATUS_REPORTER;
+    public static Arguments readArguments(CommandArguments arguments) {
+        return new Arguments(
+                arguments.getString("instance-id"),
+                arguments.getString("table-name"),
+                arguments.getIntegerOrDefault("max-no-ref-files", 1000),
+                arguments.isFlagSet("verbose"),
+                arguments.getOptionalString("report-type")
+                        .map(s -> s.toUpperCase(Locale.ROOT))
+                        .orElse(DEFAULT_STATUS_REPORTER));
+    }
 
-        if (args.length >= 3) {
-            maxFilesWithNoReferences = Integer.parseInt(args[2]);
-        }
+    public record Arguments(
+            String instanceId,
+            String tableName,
+            int maxNoRefFiles,
+            boolean verbose,
+            String reporterType) {
 
-        if (args.length >= 4) {
-            verbose = Boolean.parseBoolean(args[3]);
+        public Arguments {
+            if (!FILE_STATUS_REPORTERS.containsKey(reporterType)) {
+                throw new CommandArgumentsException("Report type not supported: " + reporterType +
+                        ". Valid types: " + String.join(", ", FILE_STATUS_REPORTERS.keySet()));
+            }
         }
+    }
 
-        if (args.length >= 5) {
-            reporterType = args[4].toUpperCase(Locale.ROOT);
-        }
+    public static void main(String[] rawArgs) {
+        Arguments args = CommandArguments.parseAndValidateOrExit(USAGE, rawArgs, FilesStatusReport::readArguments);
 
         try (S3Client s3Client = buildAwsV2Client(S3Client.builder());
                 DynamoDbClient dynamoClient = buildAwsV2Client(DynamoDbClient.builder());
                 StsClient stsClient = buildAwsV2Client(StsClient.builder())) {
             String accountName = stsClient.getCallerIdentity().account();
-            InstanceProperties instanceProperties = S3InstanceProperties.loadGivenAccountAndInstanceId(s3Client, accountName, instanceId);
+            InstanceProperties instanceProperties = S3InstanceProperties.loadGivenAccountAndInstanceId(s3Client, accountName, args.instanceId());
             TablePropertiesProvider tablePropertiesProvider = S3TableProperties.createProvider(instanceProperties, s3Client, dynamoClient);
             StateStoreFactory stateStoreFactory = new StateStoreFactory(instanceProperties, s3Client, dynamoClient);
-            StateStore stateStore = stateStoreFactory.getStateStore(tablePropertiesProvider.getByName(tableName));
-            new FilesStatusReport(stateStore, maxFilesWithNoReferences, verbose, reporterType).run();
+            StateStore stateStore = stateStoreFactory.getStateStore(tablePropertiesProvider.getByName(args.tableName()));
+            new FilesStatusReport(stateStore, args.maxNoRefFiles(), args.verbose(), args.reporterType()).run();
         }
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/report/FilesStatusReportMainTest.java
+++ b/java/clients/src/test/java/sleeper/clients/report/FilesStatusReportMainTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.report;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import sleeper.clients.report.FilesStatusReport.Arguments;
+import sleeper.core.util.cli.CommandArgumentReader;
+import sleeper.core.util.cli.CommandArgumentsException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class FilesStatusReportMainTest {
+
+    @Nested
+    class ParseArguments {
+
+        @Test
+        void shouldReadDefaultsWhenOnlyRequiredArgsGiven() {
+            Arguments args = readArguments("my-instance", "my-table");
+
+            assertThat(args.instanceId()).isEqualTo("my-instance");
+            assertThat(args.tableName()).isEqualTo("my-table");
+            assertThat(args.maxNoRefFiles()).isEqualTo(1000);
+            assertThat(args.verbose()).isFalse();
+            assertThat(args.reporterType()).isEqualTo("STANDARD");
+        }
+
+        @Test
+        void shouldReadMaxNoRefFiles() {
+            Arguments args = readArguments("my-instance", "my-table", "--max-no-ref-files", "500");
+
+            assertThat(args.maxNoRefFiles()).isEqualTo(500);
+        }
+
+        @Test
+        void shouldReadVerboseFlag() {
+            Arguments args = readArguments("my-instance", "my-table", "--verbose");
+
+            assertThat(args.verbose()).isTrue();
+        }
+
+        @Test
+        void shouldReadReportType() {
+            Arguments args = readArguments("my-instance", "my-table", "--report-type", "json");
+
+            assertThat(args.reporterType()).isEqualTo("JSON");
+        }
+    }
+
+    @Nested
+    class ArgumentsValidation {
+
+        @Test
+        void shouldRejectUnknownReportType() {
+            assertThatThrownBy(() -> readArguments("my-instance", "my-table", "--report-type", "unknown"))
+                    .isInstanceOf(CommandArgumentsException.class)
+                    .hasMessageContaining("Report type not supported");
+        }
+    }
+
+    private static Arguments readArguments(String... args) {
+        return FilesStatusReport.readArguments(CommandArgumentReader.parse(FilesStatusReport.USAGE, args));
+    }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7835

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - FileStatusReportMainTest
    - Manually testing

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
