### PR TITLE
6290: Add javadoc for clients/query

### DIFF
--- a/code-style/checkstyle-idea/checkstyle-suppressions.xml
+++ b/code-style/checkstyle-idea/checkstyle-suppressions.xml
@@ -68,8 +68,6 @@
     <suppress files="[\\/]sleeper[\\/]clients[\\/]deploy[\\/].*" id="missingJavadocType"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]images[\\/].*" id="missingJavadocMethod"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]images[\\/].*" id="missingJavadocType"/>
-    <suppress files="[\\/]sleeper[\\/]clients[\\/]query[\\/].*" id="missingJavadocMethod"/>
-    <suppress files="[\\/]sleeper[\\/]clients[\\/]query[\\/].*" id="missingJavadocType"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]table[\\/].*" id="missingJavadocMethod"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]table[\\/].*" id="missingJavadocType"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]testutil[\\/].*" id="missingJavadocMethod"/>

--- a/code-style/checkstyle-suppressions.xml
+++ b/code-style/checkstyle-suppressions.xml
@@ -68,8 +68,6 @@
     <suppress files="[\\/]sleeper[\\/]clients[\\/]deploy[\\/].*" id="missingJavadocType"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]images[\\/].*" id="missingJavadocMethod"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]images[\\/].*" id="missingJavadocType"/>
-    <suppress files="[\\/]sleeper[\\/]clients[\\/]query[\\/].*" id="missingJavadocMethod"/>
-    <suppress files="[\\/]sleeper[\\/]clients[\\/]query[\\/].*" id="missingJavadocType"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]table[\\/].*" id="missingJavadocMethod"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]table[\\/].*" id="missingJavadocType"/>
     <suppress files="[\\/]sleeper[\\/]clients[\\/]testutil[\\/].*" id="missingJavadocMethod"/>

--- a/java/clients/src/main/java/sleeper/clients/query/QueryCommandLineClient.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryCommandLineClient.java
@@ -72,6 +72,11 @@ public abstract class QueryCommandLineClient {
         this.out = out;
     }
 
+    /**
+     * Runs an interactive query session, prompting the user to select a table and enter queries.
+     *
+     * @throws InterruptedException if the thread is interrupted
+     */
     public void run() throws InterruptedException {
         TableProperties tableProperties = getTableProperties();
         init(tableProperties);

--- a/java/clients/src/main/java/sleeper/clients/query/QueryLambdaClient.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryLambdaClient.java
@@ -138,6 +138,11 @@ public class QueryLambdaClient extends QueryCommandLineClient {
         super.runQueries(tableProperties);
     }
 
+    /**
+     * Sends a query to the query SQS queue.
+     *
+     * @param query the query to submit
+     */
     public void submitQuery(Query query) {
         querySender.sendQuery(query.withResultsPublisherConfig(resultsPublisherConfig));
     }

--- a/java/clients/src/main/java/sleeper/clients/query/QueryResultsSQSQueuePoller.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryResultsSQSQueuePoller.java
@@ -47,6 +47,9 @@ public class QueryResultsSQSQueuePoller {
         this.resultsSQSQueueUrl = resultsSQSQueueUrl;
     }
 
+    /**
+     * Polls the SQS results queue until no messages arrive for 15 consecutive polls.
+     */
     public void run() {
         int numConsecutiveNoMessages = 0;
         while (numConsecutiveNoMessages < 15) {

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketClient.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketClient.java
@@ -71,7 +71,7 @@ public class QueryWebSocketClient {
             throw new IllegalArgumentException("Use of this query client requires the WebSocket API to have been deployed as part of your Sleeper instance.");
         }
         TableProperties tableProperties = tablePropertiesProvider.getByName(query.getTableName());
-        QueryWebSocketFuture<List<Row>> future = new QueryWebSocketFuture<>();
+        QueryWebSocketFuture future = new QueryWebSocketFuture();
         QueryWebSocketListener listener = new QueryWebSocketListener(tableProperties.getSchema(), query, future);
         Connection connection = adapter.connect(instanceProperties, listener);
         try {
@@ -125,9 +125,9 @@ public class QueryWebSocketClient {
         /**
          * Opens a WebSocket connection and returns it.
          *
-         * @param  instanceProperties the instance properties containing the API URL
-         * @param  messageHandler     the listener that will receive messages from the API
-         * @return                    the open connection
+         * @param  instanceProperties   the instance properties containing the API URL
+         * @param  messageHandler       the listener that will receive messages from the API
+         * @return                      the open connection
          * @throws InterruptedException if the thread is interrupted while connecting
          */
         Connection connect(InstanceProperties instanceProperties, QueryWebSocketListener messageHandler) throws InterruptedException;

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketClient.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketClient.java
@@ -33,6 +33,9 @@ import java.util.concurrent.TimeUnit;
 
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.QUERY_WEBSOCKET_API_URL;
 
+/**
+ * Sends queries to Sleeper via the WebSocket API and collects the results.
+ */
 public class QueryWebSocketClient {
     public static final Logger LOGGER = LoggerFactory.getLogger(QueryWebSocketClient.class);
     public static final long DEFAULT_TIMEOUT_MS = 120000L;
@@ -55,6 +58,14 @@ public class QueryWebSocketClient {
         this.timeoutMs = timeoutMs;
     }
 
+    /**
+     * Submits a query via the WebSocket API and returns a future that completes with the results.
+     *
+     * @param  query                    the query to run
+     * @return                          a future completing with the rows returned by the query
+     * @throws InterruptedException     if the thread is interrupted while connecting
+     * @throws IllegalArgumentException if the WebSocket API URL is not set in the instance properties
+     */
     public CompletableFuture<List<Row>> submitQuery(Query query) throws InterruptedException {
         if (!instanceProperties.isSet(QUERY_WEBSOCKET_API_URL)) {
             throw new IllegalArgumentException("Use of this query client requires the WebSocket API to have been deployed as part of your Sleeper instance.");
@@ -82,16 +93,43 @@ public class QueryWebSocketClient {
         }
     }
 
+    /**
+     * A live WebSocket connection that can send messages and be closed.
+     */
     public interface Connection {
 
+        /**
+         * Sends a message over the WebSocket connection.
+         *
+         * @param message the message to send
+         */
         void send(String message);
 
+        /**
+         * Closes the WebSocket connection without blocking.
+         */
         void close();
 
+        /**
+         * Closes the WebSocket connection and blocks until it is fully closed.
+         *
+         * @throws InterruptedException if the thread is interrupted while waiting
+         */
         void closeBlocking() throws InterruptedException;
     }
 
+    /**
+     * Creates a WebSocket connection to the query API for a given instance.
+     */
     public interface Adapter {
+        /**
+         * Opens a WebSocket connection and returns it.
+         *
+         * @param  instanceProperties the instance properties containing the API URL
+         * @param  messageHandler     the listener that will receive messages from the API
+         * @return                    the open connection
+         * @throws InterruptedException if the thread is interrupted while connecting
+         */
         Connection connect(InstanceProperties instanceProperties, QueryWebSocketListener messageHandler) throws InterruptedException;
     }
 }

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketCommandLineClient.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketCommandLineClient.java
@@ -42,6 +42,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
 
+/**
+ * Allows a user to enter a query from the command line and submit it via the WebSocket API.
+ */
 public class QueryWebSocketCommandLineClient extends QueryCommandLineClient {
     private final String apiUrl;
     private final QueryWebSocketClient queryWebSocketClient;

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketConnection.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketConnection.java
@@ -34,6 +34,9 @@ import java.net.URI;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.QUERY_WEBSOCKET_API_URL;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.REGION;
 
+/**
+ * A WebSocket connection to the Sleeper query WebSocket API, authenticated with AWS IAM.
+ */
 class QueryWebSocketConnection extends WebSocketClient implements QueryWebSocketClient.Connection {
     public static final Logger LOGGER = LoggerFactory.getLogger(QueryWebSocketConnection.class);
 

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketFuture.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketFuture.java
@@ -22,10 +22,8 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * A future that completes with query results received via a WebSocket connection.
- *
- * @param <T> unused type parameter inherited from {@link CompletableFuture}
  */
-public class QueryWebSocketFuture<T> extends CompletableFuture<List<Row>> implements QueryWebSocketHandler {
+public class QueryWebSocketFuture extends CompletableFuture<List<Row>> implements QueryWebSocketHandler {
 
     @Override
     public void handleException(RuntimeException e) {

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketFuture.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketFuture.java
@@ -20,6 +20,11 @@ import sleeper.core.row.Row;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A future that completes with query results received via a WebSocket connection.
+ *
+ * @param <T> unused type parameter inherited from {@link CompletableFuture}
+ */
 public class QueryWebSocketFuture<T> extends CompletableFuture<List<Row>> implements QueryWebSocketHandler {
 
     @Override

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketHandler.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketHandler.java
@@ -19,9 +19,22 @@ import sleeper.core.row.Row;
 
 import java.util.List;
 
+/**
+ * Handles events from a WebSocket query session.
+ */
 public interface QueryWebSocketHandler {
 
+    /**
+     * Handles an exception that occurred during query processing.
+     *
+     * @param e the exception
+     */
     void handleException(RuntimeException e);
 
+    /**
+     * Handles the final results of a query.
+     *
+     * @param results the rows returned by the query
+     */
     void handleResults(List<Row> results);
 }

--- a/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketListener.java
+++ b/java/clients/src/main/java/sleeper/clients/query/QueryWebSocketListener.java
@@ -37,6 +37,9 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
+/**
+ * Handles WebSocket messages from the query API, assembling results across sub-queries.
+ */
 public class QueryWebSocketListener {
     public static final Logger LOGGER = LoggerFactory.getLogger(QueryWebSocketListener.class);
 
@@ -56,6 +59,11 @@ public class QueryWebSocketListener {
         this.handler = handler;
     }
 
+    /**
+     * Called when the WebSocket connection is opened. Sends the initial query.
+     *
+     * @param connection the newly opened connection
+     */
     public void onOpen(Connection connection) {
         this.connection = connection;
         LOGGER.info("Connected to WebSocket API");
@@ -65,6 +73,11 @@ public class QueryWebSocketListener {
         outstandingQueryIds.add(query.getQueryId());
     }
 
+    /**
+     * Called when a message is received from the WebSocket API.
+     *
+     * @param json the raw JSON message
+     */
     public void onMessage(String json) {
         QueryWebSocketMessage message;
         try {
@@ -94,11 +107,21 @@ public class QueryWebSocketListener {
         }
     }
 
+    /**
+     * Called when the WebSocket connection is closed. Notifies the handler of an unexpected closure.
+     *
+     * @param reason the reason the connection was closed
+     */
     public void onClose(String reason) {
         LOGGER.info("Disconnected from WebSocket API with reason: {}", reason);
         handler.handleException(new WebSocketClosedException(reason));
     }
 
+    /**
+     * Called when an error occurs on the WebSocket connection.
+     *
+     * @param error the exception that was raised
+     */
     public void onError(Exception error) {
         handler.handleException(new WebSocketErrorException(error));
         close();

--- a/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketClosedException.java
+++ b/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketClosedException.java
@@ -15,6 +15,9 @@
  */
 package sleeper.clients.query.exception;
 
+/**
+ * Thrown when the WebSocket connection is closed unexpectedly during a query.
+ */
 public class WebSocketClosedException extends WebSocketException {
 
     public WebSocketClosedException(String reason) {

--- a/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketErrorException.java
+++ b/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketErrorException.java
@@ -15,6 +15,9 @@
  */
 package sleeper.clients.query.exception;
 
+/**
+ * Thrown when an error response is received via the WebSocket API during a query.
+ */
 public class WebSocketErrorException extends WebSocketException {
     public WebSocketErrorException(String errorMessage) {
         super("Error while running queries: " + errorMessage);

--- a/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketException.java
+++ b/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketException.java
@@ -15,6 +15,9 @@
  */
 package sleeper.clients.query.exception;
 
+/**
+ * Thrown when an error occurs communicating via the WebSocket API.
+ */
 public class WebSocketException extends RuntimeException {
     public WebSocketException(String message) {
         this(message, null);

--- a/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketTimeoutException.java
+++ b/java/clients/src/main/java/sleeper/clients/query/exception/WebSocketTimeoutException.java
@@ -15,6 +15,9 @@
  */
 package sleeper.clients.query.exception;
 
+/**
+ * Thrown when a query times out waiting for results via the WebSocket API.
+ */
 public class WebSocketTimeoutException extends WebSocketException {
 
     public WebSocketTimeoutException(long timeoutMilliseconds, Exception cause) {

--- a/java/clients/src/test/java/sleeper/clients/query/FakeWebSocketConnection.java
+++ b/java/clients/src/test/java/sleeper/clients/query/FakeWebSocketConnection.java
@@ -20,6 +20,9 @@ import sleeper.core.properties.instance.InstanceProperties;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A fake WebSocket connection for use in tests, simulating the behaviour of a real WebSocket connection.
+ */
 public class FakeWebSocketConnection implements QueryWebSocketClient.Connection {
     private boolean connected = false;
     private boolean closed = false;
@@ -27,6 +30,11 @@ public class FakeWebSocketConnection implements QueryWebSocketClient.Connection 
     private List<String> sentMessages = new ArrayList<>();
     private List<WebSocketResponse> responses;
 
+    /**
+     * Returns an adapter backed by this fake connection.
+     *
+     * @return an adapter backed by this fake connection
+     */
     public QueryWebSocketClient.Adapter createAdapter() {
         return this::connect;
     }
@@ -72,21 +80,44 @@ public class FakeWebSocketConnection implements QueryWebSocketClient.Connection 
         return sentMessages;
     }
 
+    /**
+     * Delivers a message to the listener as if it arrived from the server.
+     *
+     * @param message the raw message to deliver
+     */
     public void onMessage(String message) {
         listener.onMessage(message);
     }
 
+    /**
+     * Simulates the server closing the connection.
+     *
+     * @param reason the close reason
+     */
     public void onClose(String reason) {
         listener.onClose(reason);
         connected = false;
         closed = true;
     }
 
+    /**
+     * Simulates an error on the connection.
+     *
+     * @param error the exception to deliver
+     */
     public void onError(Exception error) {
         listener.onError(error);
     }
 
+    /**
+     * A pre-defined response to be delivered to the listener when the connection is opened in tests.
+     */
     public interface WebSocketResponse {
+        /**
+         * Sends this response to the given fake connection.
+         *
+         * @param client the fake connection to send to
+         */
         void sendTo(FakeWebSocketConnection client);
     }
 }

--- a/java/clients/src/test/java/sleeper/clients/query/QueryClientTestConstants.java
+++ b/java/clients/src/test/java/sleeper/clients/query/QueryClientTestConstants.java
@@ -16,6 +16,9 @@
 
 package sleeper.clients.query;
 
+/**
+ * Constants used in tests for query command-line clients.
+ */
 public class QueryClientTestConstants {
     private QueryClientTestConstants() {
     }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/6290

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Checkstyle passing

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
