### PR TITLE
7916 Python API websocket queries fail when resultsPublisherConfig is empty

### DIFF
--- a/java/query/query-lambda/src/main/java/sleeper/query/lambda/WebSocketQueryProcessorLambda.java
+++ b/java/query/query-lambda/src/main/java/sleeper/query/lambda/WebSocketQueryProcessorLambda.java
@@ -110,9 +110,14 @@ public class WebSocketQueryProcessorLambda implements RequestHandler<APIGatewayV
                 // Default to sending results back to client via WebSocket connection
                 if (query.getResultsPublisherConfig().get(ResultsOutput.DESTINATION) == null ||
                         query.getResultsPublisherConfig().get(ResultsOutput.DESTINATION).equals(WebSocketOutput.DESTINATION_NAME)) {
-                    query.getResultsPublisherConfig().put(ResultsOutput.DESTINATION, WebSocketOutput.DESTINATION_NAME);
-                    query.getResultsPublisherConfig().put(WebSocketOutput.ENDPOINT, endpoint);
-                    query.getResultsPublisherConfig().put(WebSocketOutput.CONNECTION_ID, event.getRequestContext().getConnectionId());
+
+                    LOGGER.info("Updating resultsPublisherConfig for websocket output");
+                    Map<String, String> resultsPublisherConfig = new HashMap<>(query.getResultsPublisherConfig());
+                    resultsPublisherConfig.put(ResultsOutput.DESTINATION, WebSocketOutput.DESTINATION_NAME);
+                    resultsPublisherConfig.put(WebSocketOutput.ENDPOINT, endpoint);
+                    resultsPublisherConfig.put(WebSocketOutput.CONNECTION_ID, event.getRequestContext().getConnectionId());
+
+                    query = query.withResultsPublisherConfig(resultsPublisherConfig);
                 }
 
                 LOGGER.info("Query to be processed: {}", query);

--- a/python/src/sleeper/logging.py
+++ b/python/src/sleeper/logging.py
@@ -15,11 +15,13 @@
 import logging
 
 
-def enable_logging(level: int = logging.INFO) -> None:
+def enable_logging(level: int = logging.INFO):
     logger = logging.getLogger("sleeper")
 
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(filename)s/%(funcName)s %(message)s"))
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+        logger.addHandler(handler)
 
-    logger.addHandler(handler)
     logger.setLevel(level)
+    logger.propagate = False

--- a/python/test/exact_query_via_web_socket.py
+++ b/python/test/exact_query_via_web_socket.py
@@ -19,7 +19,7 @@ import json
 import logging
 
 from pq import ParquetSerialiser
-from sleeper import SleeperClient
+from sleeper import SleeperClient, enable_logging
 
 
 async def run():
@@ -28,7 +28,6 @@ async def run():
 
     logger.debug("Sending query via web socket")
     rows = await sleeper_client.web_socket_exact_key_query(table_name=args.table, keys=args.keys, query_id=args.queryid, strings_base64_encoded=args.base64_encoded)
-
     file_path = args.outdir + "/" + args.queryid + ".parquet"
     logger.debug(f"Saving resulst to disk at {file_path}")
     with open(file_path, "wb") as file:
@@ -57,10 +56,12 @@ if __name__ == "__main__":
 
     sleeper_client_logger = logging.getLogger("sleeper.client")
     if args.debug:
-        sleeper_client_logger.setLevel(logging.DEBUG)
+        # Enable Sleeper Client logging level
+        enable_logging(logging.DEBUG)
         logger.setLevel(logging.DEBUG)
     else:
-        sleeper_client_logger.setLevel(logging.INFO)
+        # Enable Sleeper Client logging level
+        enable_logging(logging.INFO)
         logger.setLevel(logging.INFO)
 
     asyncio.run(run())


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [ ] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7916

### Tests

- [ ] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - MyUnitTest

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [ ] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [ ] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
