### PR TITLE
Issue 7140 - Remove upload artefacts overwrite flag

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/deploy/UploadArtefacts.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/UploadArtefacts.java
@@ -67,7 +67,6 @@ public class UploadArtefacts {
                         CommandOption.shortOption('i', "id"),
                         CommandOption.longFlag("create-builder"),
                         CommandOption.longFlag("create-deployment"),
-                        CommandOption.longFlag("overwrite-existing"),
                         CommandOption.shortOption('u', "upload"),
                         CommandOption.longOption("cdk-app")))
                 .helpSummary("Uploads jars and Docker images to AWS. You must set either an instance properties file " +
@@ -96,10 +95,6 @@ public class UploadArtefacts {
                         "By default, we assume you have deployed an artefacts deployment separately. If you set this " +
                         "flag, this tool will deploy a new artefacts CDK deployment for you.\n" +
                         "\n" +
-                        "--overwrite-existing\n" +
-                        "By default, images are only uploaded if they do not already exist for this version of " +
-                        "Sleeper. This flag disables that check.\n" +
-                        "\n" +
                         "--upload, -u\n" +
                         "By default, all artefacts are uploaded. You can use \"--upload jars\" to only upload the " +
                         "jars, or \"--upload images\" to only upload the container images.\n" +
@@ -126,7 +121,6 @@ public class UploadArtefacts {
                         .orElse(SleeperInternalCdkApp.STANDARD),
                 arguments.isFlagSetWithDefault("create-builder", true),
                 arguments.isFlagSetWithDefault("create-deployment", false),
-                arguments.isFlagSetWithDefault("overwrite-existing", false),
                 arguments.getOptionalString("upload").map(ToUpload::fromString).orElse(ToUpload.ALL)));
 
         String deploymentId;
@@ -179,7 +173,6 @@ public class UploadArtefacts {
                 uploadImages.upload(UploadDockerImagesToEcrRequest.builder()
                         .ecrPrefix(ecrPrefix)
                         .images(images)
-                        .overwriteExistingTag(args.overwriteExisting())
                         .build());
             }
         }
@@ -192,7 +185,6 @@ public class UploadArtefacts {
             SleeperInternalCdkApp cdkApp,
             boolean createMultiplatformBuilder,
             boolean createDeployment,
-            boolean overwriteExisting,
             ToUpload toUpload) {
 
         public Arguments {

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrRequest.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/UploadDockerImagesToEcrRequest.java
@@ -28,12 +28,10 @@ import static sleeper.core.properties.instance.CommonProperty.ECR_REPOSITORY_PRE
 public class UploadDockerImagesToEcrRequest {
     private final String ecrPrefix;
     private final List<StackDockerImage> images;
-    private final boolean overwriteExistingTag;
 
     private UploadDockerImagesToEcrRequest(Builder builder) {
         ecrPrefix = requireNonNull(builder.ecrPrefix, "ecrPrefix must not be null");
         images = requireNonNull(builder.images, "images must not be null");
-        overwriteExistingTag = builder.overwriteExistingTag;
     }
 
     public static Builder builder() {
@@ -50,10 +48,6 @@ public class UploadDockerImagesToEcrRequest {
 
     public List<StackDockerImage> getImages() {
         return images;
-    }
-
-    public boolean isOverwriteExistingTag() {
-        return overwriteExistingTag;
     }
 
     @Override
@@ -81,7 +75,6 @@ public class UploadDockerImagesToEcrRequest {
     public static final class Builder {
         private String ecrPrefix;
         private List<StackDockerImage> images;
-        private boolean overwriteExistingTag;
 
         private Builder() {
         }
@@ -97,11 +90,6 @@ public class UploadDockerImagesToEcrRequest {
 
         public Builder images(List<StackDockerImage> images) {
             this.images = images;
-            return this;
-        }
-
-        public Builder overwriteExistingTag(boolean overwriteExistingTag) {
-            this.overwriteExistingTag = overwriteExistingTag;
             return this;
         }
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My Feature".
    - Resolves https://github.com/gchq/sleeper/issues/7140

### What changed

- Removed the unused `--overwrite-existing` option from `UploadArtefacts` and its help text.
- Removed the unused `overwriteExistingTag` property from `UploadDockerImagesToEcrRequest`.

The request property was not read by the upload implementation, so the command-line option had no effect. Removing both avoids presenting an unsupported behaviour to users.

### Tests

- [x] This removal does not need a new test because it removes an inert command option and an unused request property. Existing compilation and upload tests verify that callers and upload behaviour remain valid.
    - `mvn -pl clients -am -DskipRust -Dtest=UploadDockerImagesToEcrTest -Dsurefire.failIfNoSpecifiedTests=false test` (28 tests passed)
    - `mvn -pl clients -am -DskipRust -DskipTests test` (compilation, Checkstyle and SpotBugs passed)

### Documentation

- [x] This PR adds no new functionality, so no usage documentation is required.
- [x] This PR adds no new Java code, so no new Javadoc is required.
- [x] This PR does not add or remove dependencies, so no NOTICES update is required.
