### PR TITLE
Add byte array values to BulkImportJobDriverIT

### DIFF
--- a/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/BulkImportJobDriverIT.java
+++ b/java/bulk-import/bulk-import-runner/src/test/java/sleeper/bulkimport/runner/BulkImportJobDriverIT.java
@@ -488,7 +488,8 @@ class BulkImportJobDriverIT {
                 .valueFields(
                         new Field("value1", new StringType()),
                         new Field("value2", new ListType(new IntType())),
-                        new Field("value3", new MapType(new StringType(), new LongType())))
+                        new Field("value3", new MapType(new StringType(), new LongType())),
+                        new Field("value4", new ByteArrayType()))
                 .build();
     }
 
@@ -526,6 +527,7 @@ class BulkImportJobDriverIT {
             Map<String, Long> map = new HashMap<>();
             map.put("A", 1L);
             row.put("value3", map);
+            row.put("value4", ("" + i).getBytes(StandardCharsets.UTF_8));
             rows.add(row);
             // Add row again but with the sort field set to a different value
             Row row2 = new Row(row);
@@ -547,6 +549,7 @@ class BulkImportJobDriverIT {
             Map<String, Long> map = new HashMap<>();
             map.put("A", 1L);
             row.put("value3", map);
+            row.put("value4", ("" + i).getBytes(StandardCharsets.UTF_8));
             rows.add(row);
         }
         Collections.shuffle(rows);
@@ -564,6 +567,7 @@ class BulkImportJobDriverIT {
             Map<String, Long> map = new HashMap<>();
             map.put("A", 1L);
             row.put("value3", map);
+            row.put("value4", ("" + i).getBytes(StandardCharsets.UTF_8));
             rows.add(row);
             // Add row again but with the sort field set to a different value
             Row row2 = new Row(row);


### PR DESCRIPTION
## Description

Add a byte array value field to `BulkImportJobDriverIT` and populate it in the test rows. This extends the bulk import integration test coverage to verify byte array values are handled correctly.

Closes #7198.

## Testing

```shell
SPARK_LOCAL_IP=127.0.0.1 mvn -pl bulk-import/bulk-import-runner \
  -PskipShade -DskipRust \
  -Dit.test=BulkImportJobDriverIT verify
```

30 integration test cases passed with no failures or errors.