### PR TITLE
Issue 7996 - Set jdk.httpclient.keepalive.timeout in nightly tests

### DIFF
--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -37,6 +37,13 @@ RESULTS_BUCKET=$4
 MAIN_SUITE_NAME=$5
 SUITE_PARAMS=("-Dsleeper.system.test.cluster.enabled=true" "-Drust.skip" "-Dsleeper.system.test.create.multi.platform.builder=false")
 
+# The nightly tests run in a private subnet behind a NAT gateway, which silently drops
+# idle connections at 350s.
+# This configuration stops Java's built-in HttpClient from reusing connections that are
+# that old. At time of writing the system tests only use this in AwsSleeperTablesDriver.
+# This may be removed in https://github.com/gchq/sleeper/issues/7840.
+SUITE_PARAMS=(... "-DsystemTest.extraJvmArgs=-Djdk.httpclient.keepalive.timeout=300")
+
 shift 4
 if [ "$MAIN_SUITE_NAME" == "performance" ] || [ "$MAIN_SUITE_NAME" == "functional" ]; then
   shift

--- a/scripts/test/nightly/runTests.sh
+++ b/scripts/test/nightly/runTests.sh
@@ -42,7 +42,7 @@ SUITE_PARAMS=("-Dsleeper.system.test.cluster.enabled=true" "-Drust.skip" "-Dslee
 # This configuration stops Java's built-in HttpClient from reusing connections that are
 # that old. At time of writing the system tests only use this in AwsSleeperTablesDriver.
 # This may be removed in https://github.com/gchq/sleeper/issues/7840.
-SUITE_PARAMS=(... "-DsystemTest.extraJvmArgs=-Djdk.httpclient.keepalive.timeout=300")
+export JDK_JAVA_OPTIONS="-Djdk.httpclient.keepalive.timeout=300"
 
 shift 4
 if [ "$MAIN_SUITE_NAME" == "performance" ] || [ "$MAIN_SUITE_NAME" == "functional" ]; then


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/7996

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Manually tested that JDK_JAVA_OPTIONS is applied to set ConnectionPool.KEEP_ALIVE through Maven/Failsafe/JUnit

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
