### PR TITLE
Issue 8063: Fix split points Base64 argument

### DIFF
--- a/java/statestore/src/main/java/sleeper/statestore/InitialiseStateStoreFromSplitPoints.java
+++ b/java/statestore/src/main/java/sleeper/statestore/InitialiseStateStoreFromSplitPoints.java
@@ -66,6 +66,16 @@ public class InitialiseStateStoreFromSplitPoints {
     }
 
     /**
+     * Reads whether string split points are Base64 encoded from the command line arguments.
+     *
+     * @param  args the command line arguments
+     * @return      true if the fourth argument specifies Base64 encoded strings
+     */
+    static boolean stringsBase64Encoded(String[] args) {
+        return 4 == args.length && Boolean.parseBoolean(args[3]);
+    }
+
+    /**
      * Initialises a state store from the command line.
      *
      * @param  args        the command line arguments
@@ -89,7 +99,7 @@ public class InitialiseStateStoreFromSplitPoints {
             List<Object> splitPoints = null;
             if (args.length > 2) {
                 String splitPointsFile = args[2];
-                boolean stringsBase64Encoded = 4 == args.length && Boolean.parseBoolean(args[2]);
+                boolean stringsBase64Encoded = stringsBase64Encoded(args);
                 splitPoints = readSplitPoints(tableProperties, splitPointsFile, stringsBase64Encoded);
             }
 

--- a/java/statestore/src/test/java/sleeper/statestore/InitialiseStateStoreFromSplitPointsTest.java
+++ b/java/statestore/src/test/java/sleeper/statestore/InitialiseStateStoreFromSplitPointsTest.java
@@ -33,12 +33,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
 import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
 import static sleeper.core.schema.SchemaTestHelper.createSchemaWithKey;
+import static sleeper.statestore.InitialiseStateStoreFromSplitPoints.stringsBase64Encoded;
 
 public class InitialiseStateStoreFromSplitPointsTest {
     private final InstanceProperties instanceProperties = createTestInstanceProperties();
     private final Schema schema = createSchemaWithKey("key");
     private final TableProperties tableProperties = createTestTableProperties(instanceProperties, schema);
     private final StateStoreProvider stateStoreProvider = InMemoryTransactionLogStateStore.createProvider(instanceProperties, new InMemoryTransactionLogsPerTable());
+
+    @Test
+    void shouldReadStringsBase64EncodedFromFourthArgument() {
+        assertThat(stringsBase64Encoded(new String[]{"instance", "table", "split-points.txt", "true"}))
+                .isTrue();
+    }
 
     @Test
     void shouldInitialiseStateStoreFromSplitPoints() throws Exception {


### PR DESCRIPTION
### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My Feature".
    - Resolves https://github.com/gchq/sleeper/issues/8063

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md):
    - `InitialiseStateStoreFromSplitPointsTest.shouldReadStringsBase64EncodedFromFourthArgument`

The regression test failed before the fix because the split-points filename (the third argument) was parsed as the Base64 flag. It passes after reading the fourth argument instead.

Validation:
- Targeted regression: 3 tests passed.
- Relevant reactor excluding the two existing Arrow format test classes: 1,411 tests passed.
- Checkstyle passed for all reactor modules.
- SpotBugs passed for all reactor modules.
- `git diff --check` passed.

The two existing Arrow format test classes cannot run on this local Homebrew OpenJDK 21 because Apache Arrow 12 cannot access its unsafe direct-buffer implementation. They fail independently of this change.

### Documentation

- [x] This is a bug fix with no new user-facing functionality, so no documentation changes are required.
- [x] The new helper method has Javadoc following the project conventions.
- [x] No dependencies were added or removed, so `NOTICES` is unchanged.
