### PR TITLE
Issue 8062: Paginate persistent EMR cluster lookup

### DIFF
--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/persistent/PersistentEmrPlatformExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/persistent/PersistentEmrPlatformExecutor.java
@@ -23,7 +23,6 @@ import software.amazon.awssdk.services.emr.model.AddJobFlowStepsRequest;
 import software.amazon.awssdk.services.emr.model.ClusterState;
 import software.amazon.awssdk.services.emr.model.ClusterSummary;
 import software.amazon.awssdk.services.emr.model.EmrException;
-import software.amazon.awssdk.services.emr.model.ListClustersResponse;
 import software.amazon.awssdk.services.emr.model.StepConfig;
 
 import sleeper.bulkimport.starter.executor.BulkImportArguments;
@@ -86,10 +85,10 @@ public class PersistentEmrPlatformExecutor implements PlatformExecutor {
 
     private static String getClusterIdFromName(EmrClient emrClient, String clusterName) {
         LOGGER.debug("Searching for id of cluster with name {}", clusterName);
-        ListClustersResponse response = emrClient.listClusters(request -> request
-                .clusterStates(ClusterState.BOOTSTRAPPING, ClusterState.RUNNING, ClusterState.STARTING, ClusterState.WAITING));
         String clusterId = null;
-        for (ClusterSummary cs : response.clusters()) {
+        for (ClusterSummary cs : emrClient.listClustersPaginator(request -> request
+                .clusterStates(ClusterState.BOOTSTRAPPING, ClusterState.RUNNING, ClusterState.STARTING, ClusterState.WAITING))
+                .clusters()) {
             LOGGER.debug("Found cluster with name {}", cs.name());
             if (cs.name().equals(clusterName)) {
                 clusterId = cs.id();

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/PersistentEmrPlatformExecutorWiremockIT.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/PersistentEmrPlatformExecutorWiremockIT.java
@@ -115,6 +115,46 @@ class PersistentEmrPlatformExecutorWiremockIT {
     }
 
     @Test
+    void shouldFindClusterOnSecondPage(WireMockRuntimeInfo runtimeInfo) {
+        // Given
+        BulkImportJob job = jobForTable()
+                .id("test-job")
+                .files(List.of("file.parquet"))
+                .build();
+        stubFor(post("/")
+                .withHeader("X-Amz-Target", equalTo("ElasticMapReduce.ListClusters"))
+                .inScenario("pagination")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("second-page")
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("{\"Clusters\":[{\"Id\":\"other-cluster-id\",\"Name\":\"other-cluster\"}],\"Marker\":\"next-page\"}")));
+        stubFor(post("/")
+                .withHeader("X-Amz-Target", equalTo("ElasticMapReduce.ListClusters"))
+                .inScenario("pagination")
+                .whenScenarioStateIs("second-page")
+                .willReturn(aResponse().withStatus(200)
+                        .withBody(exampleString("example/persistent-emr/listclusters-response.json"))));
+        stubFor(post("/")
+                .withHeader("X-Amz-Target", equalTo("ElasticMapReduce.AddJobFlowSteps"))
+                .willReturn(aResponse().withStatus(200)));
+
+        // When
+        createExecutor(runtimeInfo).runJob(job, "test-run");
+
+        // Then
+        assertThat(findAll(postRequestedFor(urlEqualTo("/"))
+                .withHeader("X-Amz-Target", equalTo("ElasticMapReduce.ListClusters"))))
+                .hasSize(2)
+                .anySatisfy(request -> assertThatJson(request.getBodyAsString())
+                        .isEqualTo("{\"ClusterStates\":[\"BOOTSTRAPPING\",\"RUNNING\",\"STARTING\",\"WAITING\"]}"))
+                .anySatisfy(request -> assertThatJson(request.getBodyAsString())
+                        .isEqualTo("{\"ClusterStates\":[\"BOOTSTRAPPING\",\"RUNNING\",\"STARTING\",\"WAITING\"],\"Marker\":\"next-page\"}"));
+        assertThat(findAll(postRequestedFor(urlEqualTo("/"))
+                .withHeader("X-Amz-Target", equalTo("ElasticMapReduce.AddJobFlowSteps"))))
+                .hasSize(1);
+    }
+
+    @Test
     void shouldRetryWhenRateLimitedOnListClusters(WireMockRuntimeInfo runtimeInfo) {
         // Given
         BulkImportJob job = jobForTable()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My Feature".
    - Resolves https://github.com/gchq/sleeper/issues/8062

### Tests

- [x] My PR adds the following tests based on our test strategy:
    - `PersistentEmrPlatformExecutorWiremockIT.shouldFindClusterOnSecondPage`

The new WireMock integration test proves the EMR client follows the pagination marker and finds a persistent cluster on the second page. It failed before the change with `Found no cluster with name test-cluster` and passes after switching to the AWS SDK paginator.

Validation completed locally with Java 21:
- 1,483 relevant unit tests passed across the Maven reactor.
- 5/5 `PersistentEmrPlatformExecutorWiremockIT` tests passed.
- Checkstyle passed with zero violations.
- SpotBugs passed with zero findings.
- Maven dependency analysis passed.

### Documentation

- [x] No documentation change is needed; this fixes an internal cluster lookup bug without changing user-facing behaviour or configuration.
- [x] No new public Java API was added, so no additional Javadoc is required.
- [x] No dependencies were added or removed, so `NOTICES` does not need updating.
