### PR TITLE
Issue 8064: Run PTY command once

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/util/command/CommandUtils.java
+++ b/java/clients/src/main/java/sleeper/clients/util/command/CommandUtils.java
@@ -59,7 +59,7 @@ public class CommandUtils {
     public static void runCommandLogOutputWithPty(Command command) throws IOException, InterruptedException {
         LOGGER.info("Running command: {}", command);
         PtyProcess process = command.toPtyProcessBuilder().start();
-        CompletableFuture<Void> logOutput = logOutput(command.toPtyProcessBuilder().start());
+        CompletableFuture<Void> logOutput = logOutput(process);
         int exitCode = process.waitFor();
         logOutput.join();
         LOGGER.info("Exit code: {}", exitCode);

--- a/java/clients/src/test/java/sleeper/clients/util/command/CommandUtilsTest.java
+++ b/java/clients/src/test/java/sleeper/clients/util/command/CommandUtilsTest.java
@@ -31,6 +31,19 @@ public class CommandUtilsTest {
     private Path tempDir;
 
     @Test
+    void shouldRunCommandWithPtyOnce() throws IOException, InterruptedException {
+        // Given
+        Path output = tempDir.resolve("output.txt");
+        Command command = command("sh", "-c", "echo run >> \"$1\"", "sh", output.toString());
+
+        // When
+        CommandUtils.runCommandLogOutputWithPty(command);
+
+        // Then
+        assertThat(Files.readAllLines(output)).containsExactly("run");
+    }
+
+    @Test
     void shouldPassAFileToACommandWithoutQuotes() throws IOException, InterruptedException {
         // Given
         Path path = Files.createFile(tempDir.resolve("test1.jar"));


### PR DESCRIPTION
### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/8064

`runCommandLogOutputWithPty` started one PTY process to wait for and then started a second copy of the same command to log its output. This changes the logging path to consume output from the process that was already started, so one invocation runs the command exactly once.

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - `CommandUtilsTest.shouldRunCommandWithPtyOnce`

The regression test failed before the fix because one invocation appended two lines to a temporary file, and passes after the fix with exactly one line.

Validation:
- `CommandUtilsTest`: 9 tests passed
- complete `clients` unit suite: 725 tests passed
- Checkstyle: 0 violations
- SpotBugs: 0 findings

### Documentation

- [x] No documentation change is needed because this fixes internal command execution without changing the user-facing interface.
- [x] No new Java class or method was added, so no additional Javadoc is required.
- [x] No dependencies were added or removed, so `NOTICES` is unchanged.
