### PR TITLE
Issue 8088 - Remove unused retry override and test wait properties

### DIFF
--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -71,6 +71,7 @@ public class TransactionLogHead<T> {
     private final boolean updateLogBeforeAddTransaction;
     private final DoubleSupplier randomJitterFraction;
     private final ThreadSleep retryWaiter;
+    private final ExponentialBackoffWithJitter retryBackoff;
     private final Class<? extends StateStoreTransaction<T>> transactionType;
     private final TransactionLogSnapshotLoader snapshotLoader;
     private final Supplier<Instant> stateUpdateClock;
@@ -87,6 +88,7 @@ public class TransactionLogHead<T> {
         updateLogBeforeAddTransaction = builder.updateLogBeforeAddTransaction;
         randomJitterFraction = builder.randomJitterFraction;
         retryWaiter = builder.retryWaiter;
+        retryBackoff = builder.retryBackoff;
         transactionType = builder.transactionType;
         snapshotLoader = builder.snapshotLoader;
         stateUpdateClock = builder.stateUpdateClock;
@@ -332,6 +334,9 @@ public class TransactionLogHead<T> {
     }
 
     private ExponentialBackoffWithJitter readRetryBackoff() {
+        if (retryBackoff != null) {
+            return retryBackoff;
+        }
         WaitRange waitRange = WaitRange.firstAndMaxWaitCeilingSecs(
                 tableProperties.getLong(ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS) / 1000.0,
                 tableProperties.getLong(ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS) / 1000.0);
@@ -354,6 +359,7 @@ public class TransactionLogHead<T> {
         private Supplier<Instant> stateUpdateClock = Instant::now;
         private DoubleSupplier randomJitterFraction = Math::random;
         private ThreadSleep retryWaiter = Thread::sleep;
+        private ExponentialBackoffWithJitter retryBackoff;
         private T state;
         private long lastTransactionNumber = 0;
 
@@ -466,6 +472,18 @@ public class TransactionLogHead<T> {
          */
         public Builder<T> retryWaiter(ThreadSleep retryWaiter) {
             this.retryWaiter = retryWaiter;
+            return this;
+        }
+
+        /**
+         * Sets the configuration for exponential backoff during retries adding a transaction.
+         * Overrides the retry configuration in the table properties.
+         *
+         * @param  retryBackoff the backoff configuration
+         * @return              the builder
+         */
+        public Builder<T> retryBackoff(ExponentialBackoffWithJitter retryBackoff) {
+            this.retryBackoff = retryBackoff;
             return this;
         }
 

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogHead.java
@@ -71,7 +71,6 @@ public class TransactionLogHead<T> {
     private final boolean updateLogBeforeAddTransaction;
     private final DoubleSupplier randomJitterFraction;
     private final ThreadSleep retryWaiter;
-    private final ExponentialBackoffWithJitter retryBackoff;
     private final Class<? extends StateStoreTransaction<T>> transactionType;
     private final TransactionLogSnapshotLoader snapshotLoader;
     private final Supplier<Instant> stateUpdateClock;
@@ -88,7 +87,6 @@ public class TransactionLogHead<T> {
         updateLogBeforeAddTransaction = builder.updateLogBeforeAddTransaction;
         randomJitterFraction = builder.randomJitterFraction;
         retryWaiter = builder.retryWaiter;
-        retryBackoff = builder.retryBackoff;
         transactionType = builder.transactionType;
         snapshotLoader = builder.snapshotLoader;
         stateUpdateClock = builder.stateUpdateClock;
@@ -334,9 +332,6 @@ public class TransactionLogHead<T> {
     }
 
     private ExponentialBackoffWithJitter readRetryBackoff() {
-        if (retryBackoff != null) {
-            return retryBackoff;
-        }
         WaitRange waitRange = WaitRange.firstAndMaxWaitCeilingSecs(
                 tableProperties.getLong(ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS) / 1000.0,
                 tableProperties.getLong(ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS) / 1000.0);
@@ -359,7 +354,6 @@ public class TransactionLogHead<T> {
         private Supplier<Instant> stateUpdateClock = Instant::now;
         private DoubleSupplier randomJitterFraction = Math::random;
         private ThreadSleep retryWaiter = Thread::sleep;
-        private ExponentialBackoffWithJitter retryBackoff;
         private T state;
         private long lastTransactionNumber = 0;
 
@@ -472,18 +466,6 @@ public class TransactionLogHead<T> {
          */
         public Builder<T> retryWaiter(ThreadSleep retryWaiter) {
             this.retryWaiter = retryWaiter;
-            return this;
-        }
-
-        /**
-         * Sets the configuration for exponential backoff during retries adding a transaction.
-         * Overrides the retry configuration in the table properties.
-         *
-         * @param  retryBackoff the backoff configuration
-         * @return              the builder
-         */
-        public Builder<T> retryBackoff(ExponentialBackoffWithJitter retryBackoff) {
-            this.retryBackoff = retryBackoff;
             return this;
         }
 

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
@@ -25,7 +25,6 @@ import sleeper.core.statestore.transactionlog.snapshot.TransactionLogSnapshotLoa
 import sleeper.core.statestore.transactionlog.state.StateListenerBeforeApply;
 import sleeper.core.statestore.transactionlog.state.StateStoreFiles;
 import sleeper.core.statestore.transactionlog.state.StateStorePartitions;
-import sleeper.core.util.ExponentialBackoffWithJitter;
 import sleeper.core.util.ExponentialBackoffWithJitter.WaitRange;
 import sleeper.core.util.ThreadSleep;
 
@@ -55,8 +54,7 @@ public class TransactionLogStateStore extends DelegatingStateStore {
                 .transactionBodyStore(builder.transactionBodyStore)
                 .updateLogBeforeAddTransaction(builder.updateLogBeforeAddTransaction)
                 .randomJitterFraction(builder.randomJitterFraction)
-                .retryWaiter(builder.retryWaiter)
-                .retryBackoff(builder.retryBackoff));
+                .retryWaiter(builder.retryWaiter));
     }
 
     private TransactionLogStateStore(Builder builder, TransactionLogHead.Builder<?> headBuilder) {
@@ -134,7 +132,6 @@ public class TransactionLogStateStore extends DelegatingStateStore {
         private Supplier<Instant> partitionsStateUpdateClock = Instant::now;
         private DoubleSupplier randomJitterFraction = Math::random;
         private ThreadSleep retryWaiter = Thread::sleep;
-        private ExponentialBackoffWithJitter retryBackoff;
 
         private Builder() {
         }
@@ -200,17 +197,6 @@ public class TransactionLogStateStore extends DelegatingStateStore {
          */
         public Builder updateLogBeforeAddTransaction(boolean updateLogBeforeAddTransaction) {
             this.updateLogBeforeAddTransaction = updateLogBeforeAddTransaction;
-            return this;
-        }
-
-        /**
-         * Sets the configuration for exponential backoff during retries adding a transaction.
-         *
-         * @param  retryBackoff the backoff configuration
-         * @return              the builder
-         */
-        public Builder retryBackoff(ExponentialBackoffWithJitter retryBackoff) {
-            this.retryBackoff = retryBackoff;
             return this;
         }
 

--- a/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
+++ b/java/core/src/main/java/sleeper/core/statestore/transactionlog/TransactionLogStateStore.java
@@ -55,7 +55,8 @@ public class TransactionLogStateStore extends DelegatingStateStore {
                 .transactionBodyStore(builder.transactionBodyStore)
                 .updateLogBeforeAddTransaction(builder.updateLogBeforeAddTransaction)
                 .randomJitterFraction(builder.randomJitterFraction)
-                .retryWaiter(builder.retryWaiter));
+                .retryWaiter(builder.retryWaiter)
+                .retryBackoff(builder.retryBackoff));
     }
 
     private TransactionLogStateStore(Builder builder, TransactionLogHead.Builder<?> headBuilder) {
@@ -133,6 +134,7 @@ public class TransactionLogStateStore extends DelegatingStateStore {
         private Supplier<Instant> partitionsStateUpdateClock = Instant::now;
         private DoubleSupplier randomJitterFraction = Math::random;
         private ThreadSleep retryWaiter = Thread::sleep;
+        private ExponentialBackoffWithJitter retryBackoff;
 
         private Builder() {
         }
@@ -208,6 +210,7 @@ public class TransactionLogStateStore extends DelegatingStateStore {
          * @return              the builder
          */
         public Builder retryBackoff(ExponentialBackoffWithJitter retryBackoff) {
+            this.retryBackoff = retryBackoff;
             return this;
         }
 

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
@@ -42,11 +42,8 @@ import sleeper.core.statestore.transactionlog.transaction.TransactionType;
 import sleeper.core.statestore.transactionlog.transaction.impl.AddFilesTransaction;
 import sleeper.core.statestore.transactionlog.transaction.impl.ClearFilesTransaction;
 import sleeper.core.statestore.transactionlog.transaction.impl.InitialisePartitionsTransaction;
-import sleeper.core.util.ExponentialBackoffWithJitter;
-import sleeper.core.util.ExponentialBackoffWithJitter.WaitRange;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -55,7 +52,11 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static sleeper.core.properties.instance.TableDefaultProperty.DEFAULT_ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS;
+import static sleeper.core.properties.instance.TableDefaultProperty.DEFAULT_ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS;
+import static sleeper.core.properties.table.TableProperty.ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS;
 import static sleeper.core.properties.table.TableProperty.ADD_TRANSACTION_MAX_ATTEMPTS;
+import static sleeper.core.properties.table.TableProperty.ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS;
 import static sleeper.core.schema.SchemaTestHelper.createSchemaWithKey;
 import static sleeper.core.statestore.AssignJobIdRequest.assignJobOnPartitionToFiles;
 import static sleeper.core.statestore.FileReferenceTestData.DEFAULT_UPDATE_TIME;
@@ -117,27 +118,55 @@ public class TransactionLogStateStoreLogSpecificTest extends InMemoryTransaction
         }
 
         @Test
-        void shouldUseConfiguredRetryBackoff() {
+        void shouldUseTablePropertiesForRetryWaitRange() {
             // Given
-            List<Duration> configuredRetryWaits = new ArrayList<>();
-            ExponentialBackoffWithJitter retryBackoff = new ExponentialBackoffWithJitter(
-                    WaitRange.firstAndMaxWaitCeilingSecs(5, 5),
-                    () -> 1.0,
-                    waitMillis -> configuredRetryWaits.add(Duration.ofMillis(waitMillis)));
-            store = stateStore(stateStoreBuilder(schema).retryBackoff(retryBackoff));
-            FileReference file = fileFactory().rootFile("file.parquet", 100);
-            FileReference otherProcessFile = fileFactory().rootFile("other-file.parquet", 100);
-            filesLogStore.atStartOfNextAddTransaction(() -> {
-                update(otherProcess()).addFile(otherProcessFile);
-            });
+            tableProperties.setNumber(ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS, 250);
+            tableProperties.setNumber(ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS, 600);
+            store = stateStore(builder -> builder.randomJitterFraction(() -> 0.5));
 
             // When
-            update(store).addFile(file);
+            addFileWithConflicts(4);
 
             // Then
-            assertThat(configuredRetryWaits).containsExactly(Duration.ofSeconds(5));
-            assertThat(retryWaits).isEmpty();
+            assertThat(retryWaits).containsExactly(
+                    Duration.ofMillis(125), Duration.ofMillis(250),
+                    Duration.ofMillis(300), Duration.ofMillis(300));
         }
+
+        @Test
+        void shouldUseInstanceDefaultsForRetryWaitRange() {
+            // Given
+            instanceProperties.setNumber(DEFAULT_ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS, 120);
+            instanceProperties.setNumber(DEFAULT_ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS, 300);
+            store = stateStore(builder -> builder.randomJitterFraction(() -> 0.5));
+
+            // When
+            addFileWithConflicts(4);
+
+            // Then
+            assertThat(retryWaits).containsExactly(
+                    Duration.ofMillis(60), Duration.ofMillis(120),
+                    Duration.ofMillis(150), Duration.ofMillis(150));
+        }
+
+        @Test
+        void shouldPreferTableRetryWaitRangeOverInstanceDefaults() {
+            // Given
+            instanceProperties.setNumber(DEFAULT_ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS, 120);
+            instanceProperties.setNumber(DEFAULT_ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS, 300);
+            tableProperties.setNumber(ADD_TRANSACTION_FIRST_RETRY_WAIT_CEILING_MS, 250);
+            tableProperties.setNumber(ADD_TRANSACTION_MAX_RETRY_WAIT_CEILING_MS, 600);
+            store = stateStore(builder -> builder.randomJitterFraction(() -> 0.5));
+
+            // When
+            addFileWithConflicts(4);
+
+            // Then
+            assertThat(retryWaits).containsExactly(
+                    Duration.ofMillis(125), Duration.ofMillis(250),
+                    Duration.ofMillis(300), Duration.ofMillis(300));
+        }
+
 
         @Test
         void shouldRetryAddTransactionWhenConflictOccurredAddingTransaction() {
@@ -230,6 +259,18 @@ public class TransactionLogStateStoreLogSpecificTest extends InMemoryTransaction
                     .isEmpty();
             assertThat(retryWaits).isEmpty();
         }
+        private void addFileWithConflicts(int conflicts) {
+            List<FileReference> otherFiles = IntStream.range(0, conflicts)
+                    .mapToObj(index -> fileFactory().rootFile("other-file-" + index + ".parquet", 100))
+                    .collect(toUnmodifiableList());
+            filesLogStore.atStartOfNextAddTransactions(otherFiles.stream()
+                    .map(file -> (ThrowingRunnable) () -> update(otherProcess()).addFile(file))
+                    .collect(toUnmodifiableList()));
+            FileReference file = fileFactory().rootFile("file.parquet", 100);
+            update(store).addFile(file);
+            assertThat(store.getFileReferences()).containsAll(otherFiles).contains(file);
+        }
+
     }
 
     @Nested

--- a/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
+++ b/java/core/src/test/java/sleeper/core/statestore/transactionlog/TransactionLogStateStoreLogSpecificTest.java
@@ -42,8 +42,11 @@ import sleeper.core.statestore.transactionlog.transaction.TransactionType;
 import sleeper.core.statestore.transactionlog.transaction.impl.AddFilesTransaction;
 import sleeper.core.statestore.transactionlog.transaction.impl.ClearFilesTransaction;
 import sleeper.core.statestore.transactionlog.transaction.impl.InitialisePartitionsTransaction;
+import sleeper.core.util.ExponentialBackoffWithJitter;
+import sleeper.core.util.ExponentialBackoffWithJitter.WaitRange;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -111,6 +114,29 @@ public class TransactionLogStateStoreLogSpecificTest extends InMemoryTransaction
             assertThat(store.getFileReferences())
                     .containsExactly(file1, file2, file3);
             assertThat(retryWaits).hasSize(1);
+        }
+
+        @Test
+        void shouldUseConfiguredRetryBackoff() {
+            // Given
+            List<Duration> configuredRetryWaits = new ArrayList<>();
+            ExponentialBackoffWithJitter retryBackoff = new ExponentialBackoffWithJitter(
+                    WaitRange.firstAndMaxWaitCeilingSecs(5, 5),
+                    () -> 1.0,
+                    waitMillis -> configuredRetryWaits.add(Duration.ofMillis(waitMillis)));
+            store = stateStore(stateStoreBuilder(schema).retryBackoff(retryBackoff));
+            FileReference file = fileFactory().rootFile("file.parquet", 100);
+            FileReference otherProcessFile = fileFactory().rootFile("other-file.parquet", 100);
+            filesLogStore.atStartOfNextAddTransaction(() -> {
+                update(otherProcess()).addFile(otherProcessFile);
+            });
+
+            // When
+            update(store).addFile(file);
+
+            // Then
+            assertThat(configuredRetryWaits).containsExactly(Duration.ofSeconds(5));
+            assertThat(retryWaits).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
Fixes #8088, following the revised direction in review.

Remove the unused `TransactionLogStateStore.Builder.retryBackoff` method and the additional override plumbing introduced by the first revision. Use the existing jitter/waiter hooks to test the real retry-property path.

New tests cover table-level wait ranges, instance defaults, and table-over-instance precedence. They exercise repeated conflicts, exponential growth, the maximum cap, jitter and sub-second values without sleeping.

Validation from `java/`:
- `mvn -B -ntp verify -pl core -am -PskipShade -Drust.skip`: 1,376 unit tests and 43 integration tests passed; Checkstyle, SpotBugs and dependency analysis passed.
- The three new configuration tests fail when the first-delay setting is deliberately replaced with a constant. The mutation was removed and the complete core verification rerun successfully.
