### PR TITLE
Issue 8095 - Relax assertion on EKS Spark driver pods

### DIFF
--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriver.java
@@ -55,6 +55,10 @@ import static sleeper.core.properties.table.TableProperty.TABLE_ID;
 public class AwsEksBulkImportDriver implements EksBulkImportDriver {
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsEksBulkImportDriver.class);
 
+    /** Label set by Spark's Kubernetes scheduler on the pods it creates, to distinguish drivers from executors. */
+    private static final String SPARK_ROLE_LABEL = "spark-role";
+    private static final String SPARK_ROLE_DRIVER = "driver";
+
     private final SystemTestInstanceContext instance;
     private final SentIngestJobsContext sentJobs;
     private final SfnClient sfnClient;
@@ -99,9 +103,10 @@ public class AwsEksBulkImportDriver implements EksBulkImportDriver {
         try (KubernetesClient client = k8sFactory.getClient(properties)) {
             list = client.pods()
                     .inNamespace(properties.get(BULK_IMPORT_EKS_NAMESPACE))
+                    .withLabel(SPARK_ROLE_LABEL, SPARK_ROLE_DRIVER)
                     .list();
         }
-        LOGGER.info("Found pods in Spark namespace: {}", list);
+        LOGGER.info("Found driver pods in Spark namespace: {}", list);
         return list.getItems().stream().map(Pod::toString).toList();
     }
 

--- a/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriver.java
+++ b/java/system-test/system-test-drivers/src/main/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriver.java
@@ -96,7 +96,7 @@ public class AwsEksBulkImportDriver implements EksBulkImportDriver {
     }
 
     @Override
-    public List<String> getPods() {
+    public List<String> getDriverPods() {
         InstanceProperties properties = instance.getInstanceProperties();
         logEndpointDiagnostics(properties);
         PodList list;

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriverK8sIT.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriverK8sIT.java
@@ -61,7 +61,7 @@ public class AwsEksBulkImportDriverK8sIT {
                 .always();
 
         // When / Then
-        assertThat(driver().getPods()).isEmpty();
+        assertThat(driver().getDriverPods()).isEmpty();
     }
 
     @Test
@@ -79,7 +79,7 @@ public class AwsEksBulkImportDriverK8sIT {
                 .always();
 
         // When / Then
-        assertThat(driver().getPods())
+        assertThat(driver().getDriverPods())
                 .singleElement()
                 .satisfies(pod -> assertThat(pod).contains("test-driver"));
     }

--- a/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriverK8sIT.java
+++ b/java/system-test/system-test-drivers/src/test/java/sleeper/systemtest/drivers/ingest/AwsEksBulkImportDriverK8sIT.java
@@ -29,12 +29,16 @@ import sleeper.systemtest.dsl.SystemTestContext;
 import sleeper.systemtest.dsl.testutil.InMemoryDslTest;
 import sleeper.systemtest.dsl.testutil.InMemoryTestInstance;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_NAMESPACE;
 
 @InMemoryDslTest
 @EnableKubernetesMockClient
 public class AwsEksBulkImportDriverK8sIT {
+
+    private static final String DRIVER_PODS_PATH = "/api/v1/namespaces/test-namespace/pods?labelSelector=spark-role%3Ddriver";
 
     InstanceProperties instanceProperties = InMemoryTestInstance.createDslInstanceProperties();
     SystemTestContext context;
@@ -49,10 +53,10 @@ public class AwsEksBulkImportDriverK8sIT {
     }
 
     @Test
-    void shouldGetNoPodsInNamespace() {
+    void shouldGetNoDriverPodsInNamespace() {
         // Given
         server.expect().get()
-                .withPath("/api/v1/namespaces/test-namespace/pods")
+                .withPath(DRIVER_PODS_PATH)
                 .andReturn(200, new PodListBuilder().build())
                 .always();
 
@@ -61,17 +65,23 @@ public class AwsEksBulkImportDriverK8sIT {
     }
 
     @Test
-    void shouldGetOnePodInNamespace() {
+    void shouldGetOneDriverPodInNamespace() {
         // Given
         server.expect().get()
-                .withPath("/api/v1/namespaces/test-namespace/pods")
+                .withPath(DRIVER_PODS_PATH)
                 .andReturn(200, new PodListBuilder()
                         .addNewItem()
+                        .withNewMetadata()
+                        .withName("test-driver")
+                        .withLabels(Map.of("spark-role", "driver"))
+                        .endMetadata()
                         .and().build())
                 .always();
 
         // When / Then
-        assertThat(driver().getPods()).hasSize(1);
+        assertThat(driver().getPods())
+                .singleElement()
+                .satisfies(pod -> assertThat(pod).contains("test-driver"));
     }
 
     @Test

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/EksBulkImportCheckDsl.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/EksBulkImportCheckDsl.java
@@ -57,8 +57,8 @@ public class EksBulkImportCheckDsl {
         }
     }
 
-    public List<String> getPods() {
-        return adminDriver.getPods();
+    public List<String> getDriverPods() {
+        return adminDriver.getDriverPods();
     }
 
     public List<String> getJobs() {

--- a/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/EksBulkImportDriver.java
+++ b/java/system-test/system-test-dsl/src/main/java/sleeper/systemtest/dsl/ingest/EksBulkImportDriver.java
@@ -31,11 +31,11 @@ public interface EksBulkImportDriver {
     List<String> getExecutionStatuses();
 
     /**
-     * Retrieves a list of Kubernetes pods in the Spark namespace.
+     * Retrieves a list of Spark driver Kubernetes pods.
      *
      * @return a list of descriptions of pods
      */
-    List<String> getPods();
+    List<String> getDriverPods();
 
     /**
      * Retrieves a list of Kubernetes jobs in the Spark namespace.

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksAutoBulkImportST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksAutoBulkImportST.java
@@ -83,7 +83,7 @@ public class EksAutoBulkImportST {
         assertThat(sleeper.eksBulkImportCheck().waitUntilExecutionsFinishedGetStatuses(
                 PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(10), Duration.ofMinutes(5))))
                 .containsOnly("SUCCEEDED");
-        assertThat(sleeper.eksBulkImportCheck().getPods())
+        assertThat(sleeper.eksBulkImportCheck().getDriverPods())
                 .isEmpty();
         assertThat(sleeper.eksBulkImportCheck().getJobs())
                 .isEmpty();

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksBulkImportPerformanceST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksBulkImportPerformanceST.java
@@ -79,7 +79,7 @@ public class EksBulkImportPerformanceST {
         assertThat(sleeper.eksBulkImportCheck().waitUntilExecutionsFinishedGetStatuses(
                 PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(10), Duration.ofMinutes(5))))
                 .containsOnly("SUCCEEDED");
-        assertThat(sleeper.eksBulkImportCheck().getPods())
+        assertThat(sleeper.eksBulkImportCheck().getDriverPods())
                 .isEmpty();
         assertThat(sleeper.eksBulkImportCheck().getJobs())
                 .isEmpty();

--- a/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksFargateBulkImportST.java
+++ b/java/system-test/system-test-suite/src/test/java/sleeper/systemtest/suite/EksFargateBulkImportST.java
@@ -83,7 +83,7 @@ public class EksFargateBulkImportST {
         assertThat(sleeper.eksBulkImportCheck().waitUntilExecutionsFinishedGetStatuses(
                 PollWithRetries.intervalAndPollingTimeout(Duration.ofSeconds(10), Duration.ofMinutes(5))))
                 .containsOnly("SUCCEEDED");
-        assertThat(sleeper.eksBulkImportCheck().getPods())
+        assertThat(sleeper.eksBulkImportCheck().getDriverPods())
                 .isEmpty();
         assertThat(sleeper.eksBulkImportCheck().getJobs())
                 .isEmpty();


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title, for example "Issue 1234 - My
      Feature". Note that before an issue is finished, you can still make a pull request by raising a separate issue
      for your progress.
    - Resolves https://github.com/gchq/sleeper/issues/8095

### Tests

- [x] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Updated AwsEksBulkImportDriverK8sIT

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it, or I have linked to a
  separate issue for that below.
- [x] If I have added new Java code, I have added Javadoc that explains it following [our conventions and style](https://github.com/gchq/sleeper/blob/develop/docs/development/conventions.md#javadoc).
- [x] If I have added or removed any dependencies from the project, I have updated the [NOTICES](/NOTICES) file.
