### PR TITLE
8097 spark integration two an ded multi region filters are unioned instead of intersected

### DIFF
--- a/java/analytics-integration/spark/src/main/java/sleeper/spark/CreateRegionsFromPushedFilters.java
+++ b/java/analytics-integration/spark/src/main/java/sleeper/spark/CreateRegionsFromPushedFilters.java
@@ -50,19 +50,23 @@ public class CreateRegionsFromPushedFilters {
         SplitPushedFiltersIntoSingleAndMultiRegionFilters split = new SplitPushedFiltersIntoSingleAndMultiRegionFilters();
         SingleAndMultiRegionFilters singleAndMultiRegionFilters = split.splitPushedFilters(pushedFilters);
         Region regionFromSingleRegionFilters = getRegionFromSingleRegionFilters(singleAndMultiRegionFilters.getSingleRegionFilters());
-        List<Region> regionsFromMultiRegionFilters = getRegionsFromMultiRegionFilters(singleAndMultiRegionFilters.getMultiRegionFilters());
-        if (!regionsFromMultiRegionFilters.isEmpty()) {
-            List<Region> regions = new ArrayList<>();
-            for (Region region : regionsFromMultiRegionFilters) {
-                Optional<Region> optionalIntersectedRegion = RegionIntersector.intersectRegions(region, regionFromSingleRegionFilters, rangeFactory, schema);
-                if (optionalIntersectedRegion.isPresent()) {
-                    regions.add(optionalIntersectedRegion.get());
+        // As the filters are combined with AND, each multi-region filter must be intersected with all the regions
+        // found so far, i.e. the result is the cross product of the regions of the individual filters.
+        List<Region> regions = List.of(regionFromSingleRegionFilters);
+        for (Filter filter : singleAndMultiRegionFilters.getMultiRegionFilters()) {
+            List<Region> regionsFromFilter = CreateRegionFromFilter.createRegionsFromFilter(filter, schema).get();
+            List<Region> intersectedRegions = new ArrayList<>();
+            for (Region regionSoFar : regions) {
+                for (Region regionFromFilter : regionsFromFilter) {
+                    Optional<Region> optionalIntersectedRegion = RegionIntersector.intersectRegions(regionSoFar, regionFromFilter, rangeFactory, schema);
+                    if (optionalIntersectedRegion.isPresent()) {
+                        intersectedRegions.add(optionalIntersectedRegion.get());
+                    }
                 }
             }
-            return regions;
-        } else {
-            return List.of(regionFromSingleRegionFilters);
+            regions = intersectedRegions;
         }
+        return regions;
     }
 
     private Region getRegionFromSingleRegionFilters(List<Filter> singleRegionFilters) {
@@ -75,13 +79,5 @@ public class CreateRegionsFromPushedFilters {
             intersectedRegion = RegionIntersector.intersectRegions(intersectedRegion, region, new RangeFactory(schema), schema).get();
         }
         return intersectedRegion;
-    }
-
-    private List<Region> getRegionsFromMultiRegionFilters(List<Filter> multiRegionFilters) {
-        List<Region> regions = new ArrayList<>();
-        for (Filter filter : multiRegionFilters) {
-            regions.addAll(CreateRegionFromFilter.createRegionsFromFilter(filter, schema).get());
-        }
-        return regions;
     }
 }

--- a/java/analytics-integration/spark/src/test/java/sleeper/spark/CreateRegionsFromPushedFiltersTest.java
+++ b/java/analytics-integration/spark/src/test/java/sleeper/spark/CreateRegionsFromPushedFiltersTest.java
@@ -152,6 +152,82 @@ public class CreateRegionsFromPushedFiltersTest {
     }
 
     @Test
+    void shouldReturnCorrectRegionsWhenInFiltersArePushedForTwoRowKeys() {
+        // Given
+        In inRowKey1 = new In(ROW_KEY_FIELD.getName(), new Object[]{"A", "B"});
+        In inRowKey2 = new In(ROW_KEY_FIELD2.getName(), new Object[]{"C", "D"});
+        Filter[] pushedFilters = new Filter[]{inRowKey1, inRowKey2};
+        CreateRegionsFromPushedFilters createRegionsFromPushedFilters = new CreateRegionsFromPushedFilters(SCHEMA2);
+
+        // When
+        List<Region> regions = createRegionsFromPushedFilters.getMinimumRegionCoveringPushedFilters(pushedFilters);
+
+        // Then
+        Region expectedRegionAC = RegionCanonicaliser.canonicaliseRegion(new Region(List.of(
+                RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD, "A"), RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD2, "C"))));
+        Region expectedRegionAD = RegionCanonicaliser.canonicaliseRegion(new Region(List.of(
+                RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD, "A"), RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD2, "D"))));
+        Region expectedRegionBC = RegionCanonicaliser.canonicaliseRegion(new Region(List.of(
+                RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD, "B"), RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD2, "C"))));
+        Region expectedRegionBD = RegionCanonicaliser.canonicaliseRegion(new Region(List.of(
+                RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD, "B"), RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD2, "D"))));
+        assertThat(regions.stream().map(RegionCanonicaliser::canonicaliseRegion))
+                .containsExactlyInAnyOrder(expectedRegionAC, expectedRegionAD, expectedRegionBC, expectedRegionBD);
+    }
+
+    @Test
+    void shouldReturnCorrectRegionsWhenInAndEqualToFiltersArePushedForTwoRowKeys() {
+        // Given
+        In inRowKey1 = new In(ROW_KEY_FIELD.getName(), new Object[]{"A", "B"});
+        EqualTo equalToRowKey2 = new EqualTo(ROW_KEY_FIELD2.getName(), "C");
+        Filter[] pushedFilters = new Filter[]{inRowKey1, equalToRowKey2};
+        CreateRegionsFromPushedFilters createRegionsFromPushedFilters = new CreateRegionsFromPushedFilters(SCHEMA2);
+
+        // When
+        List<Region> regions = createRegionsFromPushedFilters.getMinimumRegionCoveringPushedFilters(pushedFilters);
+
+        // Then
+        Region expectedRegionAC = RegionCanonicaliser.canonicaliseRegion(new Region(List.of(
+                RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD, "A"), RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD2, "C"))));
+        Region expectedRegionBC = RegionCanonicaliser.canonicaliseRegion(new Region(List.of(
+                RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD, "B"), RANGE_FACTORY2.createExactRange(ROW_KEY_FIELD2, "C"))));
+        assertThat(regions.stream().map(RegionCanonicaliser::canonicaliseRegion))
+                .containsExactlyInAnyOrder(expectedRegionAC, expectedRegionBC);
+    }
+
+    @Test
+    void shouldReturnOverlapOnlyWhenTwoInFiltersArePushedForSameRowKey() {
+        // Given
+        In in1 = new In(ROW_KEY_FIELD.getName(), new Object[]{"A", "B"});
+        In in2 = new In(ROW_KEY_FIELD.getName(), new Object[]{"B", "C"});
+        Filter[] pushedFilters = new Filter[]{in1, in2};
+        CreateRegionsFromPushedFilters createRegionsFromPushedFilters = new CreateRegionsFromPushedFilters(SCHEMA);
+
+        // When
+        List<Region> regions = createRegionsFromPushedFilters.getMinimumRegionCoveringPushedFilters(pushedFilters);
+
+        // Then
+        Region expectedRegionB = RegionCanonicaliser.canonicaliseRegion(new Region(RANGE_FACTORY.createExactRange(ROW_KEY_FIELD, "B")));
+        assertThat(regions.stream().map(RegionCanonicaliser::canonicaliseRegion))
+                .containsExactly(expectedRegionB);
+    }
+
+    @Test
+    void shouldReturnNoRegionsWhenPushedFiltersContradict() {
+        // Given
+        EqualTo equalTo = new EqualTo(ROW_KEY_FIELD.getName(), "E");
+        In in = new In(ROW_KEY_FIELD.getName(), new Object[]{"A", "B"});
+        Filter[] pushedFilters = new Filter[]{equalTo, in};
+        CreateRegionsFromPushedFilters createRegionsFromPushedFilters = new CreateRegionsFromPushedFilters(SCHEMA);
+
+        // When
+        List<Region> regions = createRegionsFromPushedFilters.getMinimumRegionCoveringPushedFilters(pushedFilters);
+
+        // Then
+        assertThat(regions).isEmpty();
+    }
+
+    @Test
     void shouldReturnCorrectRegionWhenEqualToFilterPushedWith2DKey() {
         // Given
         EqualTo equalTo = new EqualTo(ROW_KEY_FIELD.getName(), "E");


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [8097]
    - Resolves https://github.com/gchq/sleeper/issues/8097

### Tests

- [X] My PR adds the following tests based on [our test strategy](https://github.com/gchq/sleeper/blob/develop/docs/development/test-strategy.md) __OR__ does not need testing for this extremely good reason:
    - Added tests to CreateRegionsFromPushedFiltersTest

