### PR TITLE
Issue 8091: Reject null bulk import job IDs

### DIFF
--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportExecutor.java
@@ -120,7 +120,15 @@ public class BulkImportExecutor {
             String errorMessage = "The bulk import job failed validation with the following checks failing: \n"
                     + String.join("\n", failedChecks);
             LOGGER.warn(errorMessage);
-            if (id != null) {
+            // In production, IngestJobMessageHandler assigns a missing ID before this executor is reached.
+            // Keep this defensive validation safe for direct executor use while matching the handler's tracking semantics.
+            if (id == null) {
+                ingestJobTracker.jobValidated(bulkImportJob.toIngestJob().toBuilder()
+                        .id(UUID.randomUUID().toString())
+                        .tableId(bulkImportJob.getTableId())
+                        .build()
+                        .createRejectedEvent(validationTimeSupplier.get(), failedChecks));
+            } else {
                 ingestJobTracker.jobValidated(bulkImportJob.toIngestJob()
                         .createRejectedEvent(validationTimeSupplier.get(), failedChecks));
             }

--- a/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportExecutor.java
+++ b/java/bulk-import/bulk-import-starter/src/main/java/sleeper/bulkimport/starter/executor/BulkImportExecutor.java
@@ -101,11 +101,15 @@ public class BulkImportExecutor {
     private boolean validateJob(BulkImportJob bulkImportJob) {
         List<String> failedChecks = new ArrayList<>();
         String id = bulkImportJob.getId();
-        if (!LOWER_ALPHANUMERICS_AND_DASHES.test(id)) {
-            failedChecks.add("Job Ids must only contain lowercase alphanumerics and dashes.");
-        }
-        if (id.length() > 63) {
-            failedChecks.add("Job IDs are only allowed to be up to 63 characters long.");
+        if (null == id) {
+            failedChecks.add("The job ID must be set to a non-null value.");
+        } else {
+            if (!LOWER_ALPHANUMERICS_AND_DASHES.test(id)) {
+                failedChecks.add("Job Ids must only contain lowercase alphanumerics and dashes.");
+            }
+            if (id.length() > 63) {
+                failedChecks.add("Job IDs are only allowed to be up to 63 characters long.");
+            }
         }
 
         if (null == bulkImportJob.getFiles() || bulkImportJob.getFiles().isEmpty()) {
@@ -116,8 +120,10 @@ public class BulkImportExecutor {
             String errorMessage = "The bulk import job failed validation with the following checks failing: \n"
                     + String.join("\n", failedChecks);
             LOGGER.warn(errorMessage);
-            ingestJobTracker.jobValidated(bulkImportJob.toIngestJob()
-                    .createRejectedEvent(validationTimeSupplier.get(), failedChecks));
+            if (id != null) {
+                ingestJobTracker.jobValidated(bulkImportJob.toIngestJob()
+                        .createRejectedEvent(validationTimeSupplier.get(), failedChecks));
+            }
             return false;
         } else {
             return true;

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportExecutorTest.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportExecutorTest.java
@@ -132,7 +132,12 @@ class BulkImportExecutorTest {
             // Then
             assertThat(objectKeyToJobFile).isEmpty();
             assertThat(runJobInvocations).isEmpty();
-            assertThat(tracker.getAllJobs(tableId)).isEmpty();
+            assertThat(tracker.getAllJobs(tableId)).singleElement().satisfies(status -> {
+                assertThat(status.getJobId()).isNotBlank();
+                assertThat(status.getRunsLatestFirst()).singleElement().satisfies(run -> {
+                    assertThat(run.getFailureReasons()).containsExactly("The job ID must be set to a non-null value.");
+                });
+            });
         }
 
         @Test

--- a/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportExecutorTest.java
+++ b/java/bulk-import/bulk-import-starter/src/test/java/sleeper/bulkimport/starter/executor/BulkImportExecutorTest.java
@@ -118,6 +118,24 @@ class BulkImportExecutorTest {
         }
 
         @Test
+        void shouldFailValidationIfJobIdIsNull() {
+            // Given
+            BulkImportJob importJob = jobForTable()
+                    .id(null)
+                    .files(List.of("file1.parquet"))
+                    .build();
+            Instant validationTime = Instant.parse("2023-06-02T15:41:00Z");
+
+            // When
+            executor(atTime(validationTime)).runJob(importJob);
+
+            // Then
+            assertThat(objectKeyToJobFile).isEmpty();
+            assertThat(runJobInvocations).isEmpty();
+            assertThat(tracker.getAllJobs(tableId)).isEmpty();
+        }
+
+        @Test
         void shouldFailValidationIfJobIdContainsMoreThan63Characters() {
             // Given
             String invalidId = UUID.randomUUID().toString() + UUID.randomUUID();


### PR DESCRIPTION
### Issue

- [x] My PR fully resolves the following issue:
    - Resolves https://github.com/gchq/sleeper/issues/8091

### Tests

- [x] Added `shouldFailValidationIfJobIdIsNull` to `BulkImportExecutorTest`.
- [x] Ran:
  `mvn -pl bulk-import/bulk-import-starter -am test`
  with Java 17.
- [x] Reactor build passed; `bulk-import-starter` ran 36 tests with 0 failures/errors. Checkstyle and SpotBugs passed.

### Implementation

`validateJob` now records a null job ID as a failed validation check before applying the format or length predicates, so it no longer throws from those checks.
A rejected job with no ID is not written to `IngestJobTracker`, because rejected tracker events require a non-null `jobId` and attempting to record one would simply move the NPE deeper into the rejection path. The validation failure is still logged and the job is neither written to the bulk-import bucket nor submitted to a platform.

### Documentation

- [x] No user-facing functionality or dependencies were added; no documentation/NOTICES update is required.