### PR TITLE
Issue 8090: Close split points file stream

### DIFF
--- a/java/core/src/main/java/sleeper/core/properties/local/ReadSplitPoints.java
+++ b/java/core/src/main/java/sleeper/core/properties/local/ReadSplitPoints.java
@@ -76,9 +76,11 @@ public class ReadSplitPoints {
      * @throws IOException          if the file could not be read
      */
     public static List<Object> readSplitPoints(TableProperties tableProperties, String splitPointsFile, boolean stringsBase64Encoded) throws IOException {
-        List<Object> splitPoints = fromLines(Files.lines(Paths.get(splitPointsFile)), tableProperties.getSchema(), stringsBase64Encoded);
-        LOGGER.info("Read {} split points from file: {}", splitPoints.size(), splitPointsFile);
-        return splitPoints;
+        try (Stream<String> lines = Files.lines(Paths.get(splitPointsFile))) {
+            List<Object> splitPoints = fromLines(lines, tableProperties.getSchema(), stringsBase64Encoded);
+            LOGGER.info("Read {} split points from file: {}", splitPoints.size(), splitPointsFile);
+            return splitPoints;
+        }
     }
 
     /**


### PR DESCRIPTION
### Issue

- [x] My PR fully resolves the following issue:
    - Resolves https://github.com/gchq/sleeper/issues/8090

### Tests

- [x] Existing `ReadSplitPointsIT` covers both plain and Base64-encoded split-point file reads through the affected method.
- [x] Ran:
  `mvn -pl core -am -Dit.test=ReadSplitPointsIT -Dfailsafe.failIfNoSpecifiedTests=false verify`
  with Java 17.
- [x] Core verification passed: 1,373 unit tests and 2 `ReadSplitPointsIT` tests, with Checkstyle, SpotBugs and dependency analysis clean.

### Implementation

`readSplitPoints(TableProperties, String, boolean)` now owns the `Files.lines` stream in a try-with-resources block, so the underlying file is always closed after collection or if parsing fails.
### Documentation

- [x] No user-facing functionality or dependencies were added; no documentation/NOTICES update is required.