### PR TITLE
Issue 8102: Improve bulk import job ID handling

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/api/SleeperClient.java
+++ b/java/clients/src/main/java/sleeper/clients/api/SleeperClient.java
@@ -46,6 +46,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -58,6 +60,8 @@ import java.util.stream.Stream;
  * data in ways that are not thread safe, so this client should be owned by a single thread.
  */
 public class SleeperClient implements AutoCloseable {
+
+    private static final Predicate<String> LOWER_ALPHANUMERICS_AND_DASHES = Pattern.compile("^[a-z0-9-]+$").asPredicate();
 
     private final InstanceProperties instanceProperties;
     private final TableIndex tableIndex;
@@ -283,11 +287,25 @@ public class SleeperClient implements AutoCloseable {
      * It is vital that the Sleeper table is pre-split first. Bulk import jobs will be refused unless there are a
      * minimum number of partitions defined, set in the table property `sleeper.table.bulk.import.min.leaf.partitions`.
      *
-     * @param platform the platform the import should run on
-     * @param job      the job listing files in S3 to ingest
+     * @param  platform the platform the import should run on
+     * @param  job      the job listing files in S3 to ingest
+     * @return          the ID of the job for tracking
      */
-    public void bulkImportFromFiles(BulkImportPlatform platform, BulkImportJob job) {
+    public String bulkImportFromFiles(BulkImportPlatform platform, BulkImportJob job) {
+        Objects.requireNonNull(job, "job must not be null");
+        String jobId = job.getId();
+        if (jobId == null) {
+            jobId = UUID.randomUUID().toString();
+            job = job.toBuilder().id(jobId).build();
+        }
+        if (!LOWER_ALPHANUMERICS_AND_DASHES.test(jobId)) {
+            throw new IllegalArgumentException("Job Ids must only contain lowercase alphanumerics and dashes.");
+        }
+        if (jobId.length() > 63) {
+            throw new IllegalArgumentException("Job IDs are only allowed to be up to 63 characters long.");
+        }
         bulkImportJobSender.sendFilesToBulkImport(platform, job);
+        return jobId;
     }
 
     /**

--- a/java/clients/src/test/java/sleeper/clients/api/SleeperClientTest.java
+++ b/java/clients/src/test/java/sleeper/clients/api/SleeperClientTest.java
@@ -315,7 +315,7 @@ class SleeperClientTest {
         // When / Then
         assertThatThrownBy(() -> sleeperClient.bulkImportFromFiles(platform, job))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("lowercase alphanumerics and dashes");
+                .hasMessage("Job Ids must only contain lowercase alphanumerics and dashes.");
         assertThat(instance.bulkImportQueues()).isEmpty();
     }
 
@@ -332,7 +332,7 @@ class SleeperClientTest {
         // When / Then
         assertThatThrownBy(() -> sleeperClient.bulkImportFromFiles(platform, job))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("up to 63 characters");
+                .hasMessage("Job IDs are only allowed to be up to 63 characters long.");
         assertThat(instance.bulkImportQueues()).isEmpty();
     }
 

--- a/java/clients/src/test/java/sleeper/clients/api/SleeperClientTest.java
+++ b/java/clients/src/test/java/sleeper/clients/api/SleeperClientTest.java
@@ -267,6 +267,76 @@ class SleeperClientTest {
     }
 
     @Test
+    void shouldGenerateIdForBulkImportJobWhenIdIsNull() {
+        // Given
+        BulkImportPlatform platform = BulkImportPlatform.NonPersistentEMR;
+        BulkImportJob job = BulkImportJob.builder()
+                .tableName("import-table")
+                .files(List.of("filename.parquet"))
+                .build();
+
+        // When
+        String jobId = sleeperClient.bulkImportFromFiles(platform, job);
+
+        // Then
+        assertThat(jobId).isNotBlank();
+        assertThat(instance.bulkImportQueues()).isEqualTo(
+                Map.of(platform, List.of(job.toBuilder().id(jobId).build())));
+    }
+
+    @Test
+    void shouldReturnExistingIdForBulkImportJob() {
+        // Given
+        BulkImportPlatform platform = BulkImportPlatform.NonPersistentEMR;
+        BulkImportJob job = BulkImportJob.builder()
+                .id("my-job")
+                .tableName("import-table")
+                .files(List.of("filename.parquet"))
+                .build();
+
+        // When
+        String jobId = sleeperClient.bulkImportFromFiles(platform, job);
+
+        // Then
+        assertThat(jobId).isEqualTo("my-job");
+        assertThat(instance.bulkImportQueues()).isEqualTo(Map.of(platform, List.of(job)));
+    }
+
+    @Test
+    void shouldRejectInvalidBulkImportJobIdBeforeSending() {
+        // Given
+        BulkImportPlatform platform = BulkImportPlatform.NonPersistentEMR;
+        BulkImportJob job = BulkImportJob.builder()
+                .id("Invalid_Job")
+                .tableName("import-table")
+                .files(List.of("filename.parquet"))
+                .build();
+
+        // When / Then
+        assertThatThrownBy(() -> sleeperClient.bulkImportFromFiles(platform, job))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("lowercase alphanumerics and dashes");
+        assertThat(instance.bulkImportQueues()).isEmpty();
+    }
+
+    @Test
+    void shouldRejectBulkImportJobIdLongerThan63CharactersBeforeSending() {
+        // Given
+        BulkImportPlatform platform = BulkImportPlatform.NonPersistentEMR;
+        BulkImportJob job = BulkImportJob.builder()
+                .id("a".repeat(64))
+                .tableName("import-table")
+                .files(List.of("filename.parquet"))
+                .build();
+
+        // When / Then
+        assertThatThrownBy(() -> sleeperClient.bulkImportFromFiles(platform, job))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("up to 63 characters");
+        assertThat(instance.bulkImportQueues()).isEmpty();
+    }
+
+    @Test
     void shouldSendParquetFilesToIngestBatcher() {
         String tableName = "ingest-table";
         List<String> fileList = List.of("filename1.parquet", "filename2.parquet");


### PR DESCRIPTION
## Description

Fixes #8102.

Makes the `BulkImportJob` overload consistent with the table-name overload:
- assigns a UUID when the supplied job has no ID;
- returns the ID used for submission;
- fails fast on invalid IDs before sending to the bulk-import queue.

## Testing

- `SleeperClientTest`: 16/16 passed
- full `clients` unit suite: 728 tests passed
- Checkstyle: 0 violations
- SpotBugs: 0 findings
- `git diff --check`

No documentation or dependency changes.
