### PR TITLE
Issue 8089: Close SleeperProperties output streams

### DIFF
--- a/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
+++ b/java/core/src/main/java/sleeper/core/properties/SleeperProperties.java
@@ -344,8 +344,7 @@ public abstract class SleeperProperties<T extends SleeperProperty> implements Sl
      * @param file the file to save to
      */
     public void save(File file) {
-        try {
-            OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file));
+        try (OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(file))) {
             save(outputStream);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -359,8 +358,7 @@ public abstract class SleeperProperties<T extends SleeperProperty> implements Sl
      * @param file the path to save to
      */
     public void save(Path file) {
-        try {
-            OutputStream outputStream = new BufferedOutputStream(Files.newOutputStream(file));
+        try (OutputStream outputStream = new BufferedOutputStream(Files.newOutputStream(file))) {
             save(outputStream);
         } catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
### Description

Closes the output streams opened by `SleeperProperties.save(File)` and `save(Path)` using try-with-resources.

Fixes #8089.

### Testing

- `mvn -pl core -am test -Pquick -Drust.skip -DskipTests=false` — 1,373 tests passed
- `mvn verify -Pstyle,skipShade -Drust.skip -pl core -am -DskipTests` with JDK 17 — Checkstyle clean, SpotBugs clean
