### PR TITLE
Issue 8092: Fix snapshot deletion logger class

### DIFF
--- a/java/statestore-lambda/src/main/java/sleeper/statestore/lambda/snapshot/TransactionLogSnapshotDeletionTriggerLambda.java
+++ b/java/statestore-lambda/src/main/java/sleeper/statestore/lambda/snapshot/TransactionLogSnapshotDeletionTriggerLambda.java
@@ -47,7 +47,7 @@ import static sleeper.core.properties.table.TableProperty.STATESTORE_CLASSNAME;
  * snapshots.
  */
 public class TransactionLogSnapshotDeletionTriggerLambda implements RequestHandler<ScheduledEvent, Void> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionLogSnapshotCreationTriggerLambda.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TransactionLogSnapshotDeletionTriggerLambda.class);
 
     private final InstanceProperties instanceProperties;
     private final S3Client s3Client;


### PR DESCRIPTION
Fixes #8092.

Updates `TransactionLogSnapshotDeletionTriggerLambda` to initialise its logger with its own class instead of `TransactionLogSnapshotCreationTriggerLambda`.

Validation:
- `mvn -pl statestore-lambda -am -Pquick,skipShade -Drust.skip -DskipTests=false test` — 21 tests passed in the target module/reactor path
- `mvn verify -pl statestore-lambda -am -Pstyle,skipShade -Drust.skip -DskipTests` — Checkstyle, SpotBugs and dependency analysis passed
