### PR TITLE
Issue 8043 - Remove Jetty servers from production dependencies

### DIFF
--- a/code-style/.trivyignore.yaml
+++ b/code-style/.trivyignore.yaml
@@ -1,9 +1,4 @@
 
-vulnerabilities:
+vulnerabilities: []
   # You can suppress known vulnerabilities here like this:
   # - id: CVE-2000-12345
-
-  #  org.eclipse.jetty:jetty-security
-  - id: CVE-2026-10050
-  #  org.eclipse.jetty:jetty-server
-  - id: CVE-2026-6790

--- a/java/bulk-import/bulk-import-runner/pom.xml
+++ b/java/bulk-import/bulk-import-runner/pom.xml
@@ -172,7 +172,7 @@
             <!-- Override the parent pom's hadoop-client managed dependency to also exclude reload4j -->
             <!-- and slf4j-reload4j. Hadoop 3.4 bundles them in several of its sub-modules (hadoop-common, -->
             <!-- hadoop-yarn-common, ...), so excluding them at hadoop-client level cascades across the subtree. -->
-            <!-- The log4j and netty-all exclusions are inherited from the parent pom but must be repeated -->
+            <!-- The log4j, netty-all and Jetty webapp exclusions from the parent pom must be repeated -->
             <!-- here, since a child dependencyManagement entry replaces the parent's rather than merging. -->
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
@@ -194,6 +194,16 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
+                    </exclusion>
+                    <!-- Hadoop daemon web applications are not used by Sleeper's filesystem clients.
+                    Exclude them at source so they cannot pull Jetty servers into production artifacts. -->
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-servlet</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-webapp</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/java/clients/src/main/java/sleeper/clients/deploy/localstack/DeployDockerInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/localstack/DeployDockerInstance.java
@@ -16,7 +16,6 @@
 
 package sleeper.clients.deploy.localstack;
 
-import org.eclipse.jetty.io.RuntimeIOException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sqs.SqsClient;
@@ -39,6 +38,7 @@ import sleeper.core.schema.type.StringType;
 import sleeper.statestore.StateStoreFactory;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -124,7 +124,7 @@ public class DeployDockerInstance {
                         StateStoreFactory.createProvider(instanceProperties, s3Client, dynamoClient))
                         .run();
             } catch (IOException e) {
-                throw new RuntimeIOException(e);
+                throw new UncheckedIOException(e);
             }
         }
     }

--- a/java/common/localstack-test/pom.xml
+++ b/java/common/localstack-test/pom.xml
@@ -86,4 +86,23 @@
             </exclusions>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <rules>
+                        <bannedDependencies>
+                            <!-- This test-support module runs WireMock. Its consumers must use test scope. -->
+                            <includes combine.children="append">
+                                <include>org.eclipse.jetty:jetty-server</include>
+                                <include>org.eclipse.jetty:jetty-security</include>
+                            </includes>
+                        </bannedDependencies>
+                    </rules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -638,6 +638,16 @@
                         <groupId>io.netty</groupId>
                         <artifactId>netty-all</artifactId>
                     </exclusion>
+                    <!-- Hadoop daemon web applications are not used by Sleeper's filesystem clients.
+                    Exclude them at source so they cannot pull Jetty servers into production artifacts. -->
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-servlet</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-webapp</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -1884,11 +1894,17 @@
                             <excludes>
                                 <exclude>*log4j*:*log4j*</exclude>
                                 <exclude>org.slf4j:slf4j-log4j12</exclude>
+                                <!-- Sleeper uses Hadoop as a filesystem client, not an embedded HTTP server.
+                                Keep Jetty's server and authentication implementation out of runtime artifacts. -->
+                                <exclude>org.eclipse.jetty:jetty-server:*:*:compile</exclude>
+                                <exclude>org.eclipse.jetty:jetty-server:*:*:runtime</exclude>
+                                <exclude>org.eclipse.jetty:jetty-security:*:*:compile</exclude>
+                                <exclude>org.eclipse.jetty:jetty-security:*:*:runtime</exclude>
                             </excludes>
                             <includes>
                                 <include>org.apache.logging.log4j:*</include>
                             </includes>
-                            <message>Log4j conflicts with reload4j, add an exclusion</message>
+                            <message>Remove conflicting Log4j or production Jetty server dependencies. Jetty servers are only needed by test utilities.</message>
                         </bannedDependencies>
                         <dependencyConvergence />
                         <banDuplicatePomDependencyVersions />


### PR DESCRIPTION
## Issue

Resolves #8043.

The Jetty findings correspond to real production dependencies. `hadoop-client` brings in `jetty-servlet` and `jetty-webapp`; Maven then resolves overlapping Jetty dependencies at compile scope even where the displayed path runs through the test-only WireMock dependency. The existing per-module `jetty-http` scope overrides do not cover these server artifacts.

In a baseline build at `ab344198e83b44566c7346afee63aa4a758ad4db`, the ingest utility jar contains 355 Jetty server classes and 62 Jetty security classes. Both reported advisories are detected when scanning that jar.

## Changes

- Exclude Hadoop's unused servlet/webapp dependencies at their source, including the bulk-import runner's dependency-management override.
- Replace the incidental Jetty `RuntimeIOException` import with Java's `UncheckedIOException`.
- Make Maven Enforcer reject `jetty-server` and `jetty-security` in compile/runtime scope. The only exception is `localstack-test`, which implements the WireMock test support itself. Test-scoped dependencies remain allowed.
- Remove the two Trivy suppressions for CVE-2026-10050 and CVE-2026-6790.

Trino's legitimate Jetty HTTP client dependencies are preserved. This change does not claim to remove every Jetty artifact or every dependency vulnerability.

## Tests

All commands below were run with Java 17 from `java/` unless noted otherwise.

```sh
mvn -B -ntp validate -Drust.skip
mvn -B -ntp verify -pl clients -am -PskipShade -Drust.skip \
  -Dit.test=ParquetRowReaderIT,ParquetRowWriterFactoryIT,ParquetReaderIteratorIT,AwsScheduleRulesIT,PersistentEmrStepCountIT,CleanUpLogGroupsIT,WaitForStackToDeleteIT \
  -Dfailsafe.failIfNoSpecifiedTests=false
mvn -B -ntp package -pl clients -am -Pquick -Drust.skip
```

Results:

- Dependency validation passes across all 78 reactor modules.
- The clients dependency reactor passes 2,638 unit tests and 43 selected integration tests, with no failures or skips in those tests. Checkstyle and SpotBugs pass.
- The new Enforcer guard fails against the original Hadoop dependency declarations, then passes after the exclusions. Six additional isolated Maven probes confirm that both server/security artifacts are rejected at compile/runtime scope and accepted at test scope.
- Rebuilt ingest and client utility jars contain no Jetty server/security classes or corresponding Maven metadata.
- A separate Java process, using only the rebuilt ingest utility jar as its application classpath, writes and reads a Parquet file successfully while confirming that `Server` and `SecurityHandler` are absent. This avoids accidentally relying on WireMock's test classpath.
- Grype scans of the baseline and rebuilt ingest jars detect the two corresponding GHSA findings before the fix and zero server/security findings after it. Other scanner findings are outside this change.

The packaging command runs separately from the test command; its `quick` profile is not being used as evidence that tests ran. AWS system tests and complete container-image scans were not run.

## Documentation and notices

The dependency exclusions and narrowly scoped test-support exception are documented in the POMs. No new public Java API or user-facing configuration is introduced. The existing Jetty NOTICES entry is retained because the project still uses Jetty for its HTTP client and tests; `scripts/dev/checkNotices.sh` passes.

## Checklist

- [x] The change addresses the linked issue and removes the unnecessary suppressed production dependencies.
- [x] Build-time regression coverage fails on the original dependency declarations and passes with the fix.
- [x] Existing functional tests and static analysis pass as detailed above.
- [x] Dependency notices checked.
- [x] No tests or security checks were disabled to hide a failure.
