### PR TITLE
Issue 7652 - Use custom artefacts for EKS bulk import images

### DIFF
--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -25,6 +25,19 @@ our [publishing tools](../development/publishing.md) to prepare the artefacts.
 It's important to upload artefacts from within AWS to avoid lengthy uploads into AWS. Usually this is done from an EC2
 instance.
 
+#### Custom container images
+
+A custom `SleeperArtefacts` implementation can supply `SleeperContainerImages` through
+`SleeperInstanceArtefacts`. Implement `SleeperContainerImages.getDockerImageName(DockerDeployment)`
+to return the full image reference for a deployment, including its registry and tag or digest.
+`SleeperContainerImagesFromProperties` retains the standard repository and version-based naming.
+
+For EKS bulk import, the selected image is used for the Spark submission pod and recorded in the
+CDK-defined property `sleeper.bulk.import.eks.image`. The Spark driver and executor pods read the
+same image from that property. Instances deployed before this property was introduced continue
+using the standard repository and version-based name until they are redeployed. Custom image
+registries must be reachable and readable from the EKS cluster.
+
 #### `uploadArtefacts.sh`
 
 This script can upload artefacts to an existing CDK deployment. You can either pass in the deployment ID that you used

--- a/docs/usage/properties/instance/cdk/bulk_import.md
+++ b/docs/usage/properties/instance/cdk/bulk_import.md
@@ -2,28 +2,29 @@
 
 The following instance properties relate to bulk import, i.e. ingesting data using Spark jobs running on EMR or EKS.
 
-| Property Name                                     | Description                                                                            |
-|---------------------------------------------------|----------------------------------------------------------------------------------------|
-| sleeper.bulk.import.bucket                        | The S3 Bucket name of the bulk import bucket.                                          |
-| sleeper.bulk.import.emr.ec2.role.name             | The name of the job flow role for bulk import using EMR.                               |
-| sleeper.bulk.import.emr.role.name                 | The name of the role assumed by the bulk import clusters using EMR.                    |
-| sleeper.bulk.import.emr.security.conf.name        | The name of the security configuration used by bulk import using EMR.                  |
-| sleeper.bulk.import.emr.job.queue.url             | The URL of the queue for bulk import jobs using EMR.                                   |
-| sleeper.bulk.import.emr.job.queue.arn             | The ARN of the queue for bulk import jobs using EMR.                                   |
-| sleeper.bulk.import.emr.serverless.cluster.name   | The name of the cluster used for EMR Serverless bulk import jobs.                      |
-| sleeper.bulk.import.emr.serverless.application.id | The id of the application used for EMR Serverless bulk import jobs.                    |
-| sleeper.bulk.import.emr.serverless.role.arn       | The ARN of the role assumed by the bulk import clusters using EMR Serverless.          |
-| sleeper.bulk.import.emr.serverless.job.queue.url  | The URL of the queue for bulk import jobs using EMR Serverless.                        |
-| sleeper.bulk.import.emr.serverless.job.queue.arn  | The ARN of the queue for bulk import jobs using EMR Serverless.                        |
-| sleeper.bulk.import.emr.serverless.studio.url     | The url for EMR Studio used to access EMR Serverless.                                  |
-| sleeper.bulk.import.persistent.emr.job.queue.url  | The URL of the queue for bulk import jobs using persistent EMR.                        |
-| sleeper.bulk.import.persistent.emr.job.queue.arn  | The ARN of the queue for bulk import jobs using persistent EMR.                        |
-| sleeper.bulk.import.persistent.emr.cluster.name   | The name of the cluster used for persistent EMR bulk import jobs.                      |
-| sleeper.bulk.import.persistent.emr.master         | The public DNS name of the cluster's master node for bulk import using persistent EMR. |
-| sleeper.bulk.import.eks.job.queue.url             | The URL of the queue for bulk import jobs using EKS.                                   |
-| sleeper.bulk.import.eks.job.queue.arn             | The ARN of the queue for bulk import jobs using EKS.                                   |
-| sleeper.bulk.import.eks.statemachine.arn          | The ARN of the state machine for bulk import jobs using EKS.                           |
-| sleeper.bulk.import.eks.k8s.namespace             | The ID of the Kubernetes namespace where Spark jobs will run for bulk import.          |
-| sleeper.bulk.import.eks.k8s.cluster.name          | The name of the EKS cluster for bulk import.                                           |
-| sleeper.bulk.import.eks.k8s.endpoint              | The endpoint of the EKS cluster for bulk import.                                       |
-| sleeper.bulk.import.eks.k8s.ca.data               | The certificate authority data of the EKS cluster for bulk import.                     |
+| Property Name                                     | Description                                                                              |
+|---------------------------------------------------|------------------------------------------------------------------------------------------|
+| sleeper.bulk.import.bucket                        | The S3 Bucket name of the bulk import bucket.                                            |
+| sleeper.bulk.import.emr.ec2.role.name             | The name of the job flow role for bulk import using EMR.                                 |
+| sleeper.bulk.import.emr.role.name                 | The name of the role assumed by the bulk import clusters using EMR.                      |
+| sleeper.bulk.import.emr.security.conf.name        | The name of the security configuration used by bulk import using EMR.                    |
+| sleeper.bulk.import.emr.job.queue.url             | The URL of the queue for bulk import jobs using EMR.                                     |
+| sleeper.bulk.import.emr.job.queue.arn             | The ARN of the queue for bulk import jobs using EMR.                                     |
+| sleeper.bulk.import.emr.serverless.cluster.name   | The name of the cluster used for EMR Serverless bulk import jobs.                        |
+| sleeper.bulk.import.emr.serverless.application.id | The id of the application used for EMR Serverless bulk import jobs.                      |
+| sleeper.bulk.import.emr.serverless.role.arn       | The ARN of the role assumed by the bulk import clusters using EMR Serverless.            |
+| sleeper.bulk.import.emr.serverless.job.queue.url  | The URL of the queue for bulk import jobs using EMR Serverless.                          |
+| sleeper.bulk.import.emr.serverless.job.queue.arn  | The ARN of the queue for bulk import jobs using EMR Serverless.                          |
+| sleeper.bulk.import.emr.serverless.studio.url     | The url for EMR Studio used to access EMR Serverless.                                    |
+| sleeper.bulk.import.persistent.emr.job.queue.url  | The URL of the queue for bulk import jobs using persistent EMR.                          |
+| sleeper.bulk.import.persistent.emr.job.queue.arn  | The ARN of the queue for bulk import jobs using persistent EMR.                          |
+| sleeper.bulk.import.persistent.emr.cluster.name   | The name of the cluster used for persistent EMR bulk import jobs.                        |
+| sleeper.bulk.import.persistent.emr.master         | The public DNS name of the cluster's master node for bulk import using persistent EMR.   |
+| sleeper.bulk.import.eks.job.queue.url             | The URL of the queue for bulk import jobs using EKS.                                     |
+| sleeper.bulk.import.eks.job.queue.arn             | The ARN of the queue for bulk import jobs using EKS.                                     |
+| sleeper.bulk.import.eks.statemachine.arn          | The ARN of the state machine for bulk import jobs using EKS.                             |
+| sleeper.bulk.import.eks.image                     | The full container image name for EKS bulk import, including registry and tag or digest. |
+| sleeper.bulk.import.eks.k8s.namespace             | The ID of the Kubernetes namespace where Spark jobs will run for bulk import.            |
+| sleeper.bulk.import.eks.k8s.cluster.name          | The name of the EKS cluster for bulk import.                                             |
+| sleeper.bulk.import.eks.k8s.endpoint              | The endpoint of the EKS cluster for bulk import.                                         |
+| sleeper.bulk.import.eks.k8s.ca.data               | The certificate authority data of the EKS cluster for bulk import.                       |

--- a/java/bulk-import/bulk-import-core/src/main/java/sleeper/bulkimport/core/configuration/SparkConfigurationUtils.java
+++ b/java/bulk-import/bulk-import-core/src/main/java/sleeper/bulkimport/core/configuration/SparkConfigurationUtils.java
@@ -27,6 +27,7 @@ import static sleeper.core.properties.instance.BulkImportProperty.BULK_IMPORT_SP
 import static sleeper.core.properties.instance.BulkImportProperty.BULK_IMPORT_SPARK_SPECULATION;
 import static sleeper.core.properties.instance.BulkImportProperty.BULK_IMPORT_SPARK_SPECULATION_QUANTILE;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_CLUSTER_ENDPOINT;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_IMAGE;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_NAMESPACE;
 import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.REGION;
 import static sleeper.core.properties.instance.CommonProperty.MAXIMUM_CONNECTIONS_TO_S3;
@@ -210,7 +211,9 @@ public class SparkConfigurationUtils {
 
         // spark.kubernetes properties
         sparkConf.put("spark.master", "k8s://" + instanceProperties.get(BULK_IMPORT_EKS_CLUSTER_ENDPOINT));
-        sparkConf.put("spark.kubernetes.container.image", DockerDeployment.EKS_BULK_IMPORT.getDockerImageName(instanceProperties));
+        sparkConf.put("spark.kubernetes.container.image", instanceProperties.isSet(BULK_IMPORT_EKS_IMAGE)
+                ? instanceProperties.get(BULK_IMPORT_EKS_IMAGE)
+                : DockerDeployment.EKS_BULK_IMPORT.getDockerImageName(instanceProperties));
         sparkConf.put("spark.kubernetes.namespace", instanceProperties.get(BULK_IMPORT_EKS_NAMESPACE));
         sparkConf.put("spark.kubernetes.authenticate.driver.serviceAccountName", "spark");
         sparkConf.put("spark.kubernetes.executor.podTemplateFile", "/tmp/executor-template.yaml");

--- a/java/bulk-import/bulk-import-core/src/test/java/sleeper/bulkimport/core/configuration/SparkConfigurationUtilsTest.java
+++ b/java/bulk-import/bulk-import-core/src/test/java/sleeper/bulkimport/core/configuration/SparkConfigurationUtilsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.bulkimport.core.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.core.properties.instance.InstanceProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.ACCOUNT;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_IMAGE;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.DNS_SUFFIX;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.REGION;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.VERSION;
+import static sleeper.core.properties.instance.CommonProperty.ECR_REPOSITORY_PREFIX;
+
+class SparkConfigurationUtilsTest {
+
+    @Test
+    void shouldUseDeployedImageForSparkPods() {
+        // Given
+        InstanceProperties properties = instanceProperties();
+        String customImage = "registry.example.com/custom/spark@sha256:" + "a".repeat(64);
+        properties.set(BULK_IMPORT_EKS_IMAGE, customImage);
+
+        // When / Then
+        assertThat(SparkConfigurationUtils.getSparkConfigurationForEKSFromInstanceProperties(properties))
+                .containsEntry("spark.kubernetes.container.image", customImage);
+    }
+
+    @Test
+    void shouldRetainImageNameForOlderDeployments() {
+        // Given
+        InstanceProperties properties = instanceProperties();
+
+        // When / Then
+        assertThat(SparkConfigurationUtils.getSparkConfigurationForEKSFromInstanceProperties(properties))
+                .containsEntry("spark.kubernetes.container.image",
+                        "test-account.dkr.ecr.test-region.amazonaws.com/test-instance/bulk-import-runner:1.2.3");
+    }
+    private InstanceProperties instanceProperties() {
+        InstanceProperties properties = new InstanceProperties();
+        properties.set(ACCOUNT, "test-account");
+        properties.set(REGION, "test-region");
+        properties.set(DNS_SUFFIX, "amazonaws.com");
+        properties.set(VERSION, "1.2.3");
+        properties.set(ECR_REPOSITORY_PREFIX, "test-instance");
+        return properties;
+    }
+
+}

--- a/java/core/src/main/java/sleeper/core/properties/instance/CdkDefinedInstanceProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/CdkDefinedInstanceProperty.java
@@ -785,6 +785,11 @@ public interface CdkDefinedInstanceProperty extends InstanceProperty {
             .description("The ARN of the state machine for bulk import jobs using EKS.")
             .propertyGroup(InstancePropertyGroup.BULK_IMPORT)
             .build();
+    CdkDefinedInstanceProperty BULK_IMPORT_EKS_IMAGE = Index
+            .propertyBuilder("sleeper.bulk.import.eks.image")
+            .description("The full container image name for EKS bulk import, including registry and tag or digest.")
+            .propertyGroup(InstancePropertyGroup.BULK_IMPORT)
+            .build();
     CdkDefinedInstanceProperty BULK_IMPORT_EKS_NAMESPACE = Index
             .propertyBuilder("sleeper.bulk.import.eks.k8s.namespace")
             .description("The ID of the Kubernetes namespace where Spark jobs will run for bulk import.")

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/SleeperInstanceArtefacts.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/SleeperInstanceArtefacts.java
@@ -21,6 +21,7 @@ import sleeper.cdk.artefacts.containers.SleeperContainerImages;
 import sleeper.cdk.artefacts.containers.SleeperEcsImages;
 import sleeper.cdk.artefacts.jars.SleeperJars;
 import sleeper.cdk.lambda.SleeperLambdaCode;
+import sleeper.core.deploy.DockerDeployment;
 import sleeper.core.properties.instance.InstanceProperties;
 import sleeper.core.properties.model.LambdaDeployType;
 
@@ -63,6 +64,16 @@ public class SleeperInstanceArtefacts {
      */
     public SleeperEcsImages ecsImagesAtScope(Construct scope) {
         return containerImages.ecsImagesAtScope(scope);
+    }
+
+    /**
+     * Retrieves the full image name for a container deployment.
+     *
+     * @param  deployment the container deployment
+     * @return            the image name, including registry and tag or digest
+     */
+    public String getDockerImageName(DockerDeployment deployment) {
+        return containerImages.getDockerImageName(deployment);
     }
 
 }

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/containers/SleeperContainerImages.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/containers/SleeperContainerImages.java
@@ -17,6 +17,8 @@ package sleeper.cdk.artefacts.containers;
 
 import software.constructs.Construct;
 
+import sleeper.core.deploy.DockerDeployment;
+
 /**
  * Code to refer to container images during deployment.
  */
@@ -37,5 +39,13 @@ public interface SleeperContainerImages {
      * @return       the helper
      */
     SleeperLambdaImages lambdaImagesAtScope(Construct scope);
+
+    /**
+     * Retrieves the full image name for a container deployment.
+     *
+     * @param  deployment the container deployment
+     * @return            the image name, including registry and tag or digest
+     */
+    String getDockerImageName(DockerDeployment deployment);
 
 }

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/containers/SleeperContainerImagesFromProperties.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/containers/SleeperContainerImagesFromProperties.java
@@ -20,6 +20,7 @@ import software.amazon.awscdk.services.lambda.DockerImageCode;
 import software.amazon.awscdk.services.lambda.EcrImageCodeProps;
 import software.constructs.Construct;
 
+import sleeper.core.deploy.DockerDeployment;
 import sleeper.core.properties.instance.InstanceProperties;
 
 import java.util.List;
@@ -53,6 +54,11 @@ public class SleeperContainerImagesFromProperties implements SleeperContainerIma
                         .tagOrDigest(digestProvider.getDigestToDeploy(handler.getJar().getImageName(),
                                 handler.getJar().getEcrRepositoryName(instanceProperties)))
                         .build());
+    }
+
+    @Override
+    public String getDockerImageName(DockerDeployment deployment) {
+        return deployment.getDockerImageName(instanceProperties);
     }
 
 }

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/stack/bulkimport/EksBulkImportStack.java
@@ -194,7 +194,7 @@ public final class EksBulkImportStack extends NestedStack {
         coreStacks.grantIngest(sparkServiceAccount.getRole());
         coreStacks.grantReadWritePartitions(sparkServiceAccount.getRole());
 
-        StateMachine stateMachine = createStateMachine(bulkImportCluster, instanceProperties, coreStacks);
+        StateMachine stateMachine = createStateMachine(bulkImportCluster, instanceProperties, artefacts, coreStacks);
         instanceProperties.set(CdkDefinedInstanceProperty.BULK_IMPORT_EKS_STATE_MACHINE_ARN, stateMachine.getStateMachineArn());
 
         // Replace AmazonEKSEditPolicy with .groups(List.of("step-function")) when available:
@@ -299,8 +299,10 @@ public final class EksBulkImportStack extends NestedStack {
                 .build());
     }
 
-    private StateMachine createStateMachine(Cluster cluster, InstanceProperties instanceProperties, SleeperCoreStacks coreStacks) {
-        String imageName = DockerDeployment.EKS_BULK_IMPORT.getDockerImageName(instanceProperties);
+    private StateMachine createStateMachine(Cluster cluster, InstanceProperties instanceProperties,
+            SleeperInstanceArtefacts artefacts, SleeperCoreStacks coreStacks) {
+        String imageName = artefacts.getDockerImageName(DockerDeployment.EKS_BULK_IMPORT);
+        instanceProperties.set(CdkDefinedInstanceProperty.BULK_IMPORT_EKS_IMAGE, imageName);
         Optional<String> jobLookupTableName = coreStacks.getIngestJobLookupTableName(instanceProperties.get(ID));
 
         Map<String, Object> runJobState = parseEksStepDefinition(

--- a/java/deployment/cdk/src/test/java/sleeper/cdk/artefacts/containers/SleeperContainerImagesFromPropertiesTest.java
+++ b/java/deployment/cdk/src/test/java/sleeper/cdk/artefacts/containers/SleeperContainerImagesFromPropertiesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.cdk.artefacts.containers;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.core.deploy.DockerDeployment;
+import sleeper.core.properties.instance.InstanceProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.ACCOUNT;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.DNS_SUFFIX;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.REGION;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.VERSION;
+import static sleeper.core.properties.instance.CommonProperty.ECR_REPOSITORY_PREFIX;
+import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstancePropertiesWithId;
+
+class SleeperContainerImagesFromPropertiesTest {
+
+    @Test
+    void shouldUseInstanceImageNameAndVersion() {
+        // Given
+        InstanceProperties properties = createTestInstancePropertiesWithId("test-instance");
+        SleeperContainerImages images = images(properties);
+
+        // When / Then
+        assertThat(images.getDockerImageName(DockerDeployment.EKS_BULK_IMPORT))
+                .isEqualTo("test-account.dkr.ecr.test-region.amazonaws.com/test-instance/bulk-import-runner:1.2.3");
+    }
+
+    @Test
+    void shouldUseCustomRegistryProperties() {
+        // Given
+        InstanceProperties properties = createTestInstancePropertiesWithId("test-instance");
+        properties.set(ACCOUNT, "123456789012");
+        properties.set(REGION, "cn-north-1");
+        properties.set(DNS_SUFFIX, "amazonaws.com.cn");
+        properties.set(ECR_REPOSITORY_PREFIX, "custom/artefacts");
+        properties.set(VERSION, "custom-version");
+        SleeperContainerImages images = images(properties);
+
+        // When / Then
+        assertThat(images.getDockerImageName(DockerDeployment.EKS_BULK_IMPORT))
+                .isEqualTo("123456789012.dkr.ecr.cn-north-1.amazonaws.com.cn/custom/artefacts/bulk-import-runner:custom-version");
+    }
+
+    private SleeperContainerImages images(InstanceProperties properties) {
+        return new SleeperContainerImagesFromProperties(properties,
+                new SleeperContainerImageDigestProvider((image, repository) -> {
+                    throw new AssertionError("Image name lookup should not access ECR");
+                }));
+    }
+}

--- a/java/deployment/cdk/src/test/java/sleeper/cdk/stack/bulkimport/EksBulkImportStackIT.java
+++ b/java/deployment/cdk/src/test/java/sleeper/cdk/stack/bulkimport/EksBulkImportStackIT.java
@@ -19,10 +19,19 @@ import org.approvaltests.Approvals;
 import org.approvaltests.core.Options;
 import org.junit.jupiter.api.Test;
 
+import sleeper.bulkimport.core.configuration.SparkConfigurationUtils;
+import sleeper.cdk.artefacts.SleeperInstanceArtefacts;
+import sleeper.cdk.artefacts.containers.SleeperContainerImageDigestProvider;
+import sleeper.cdk.artefacts.containers.SleeperContainerImagesFromProperties;
+import sleeper.cdk.artefacts.jars.SleeperJarVersionIdProvider;
+import sleeper.cdk.artefacts.jars.SleeperJarsFromProperties;
 import sleeper.cdk.stack.SleeperCoreStacks;
 import sleeper.cdk.testutil.SleeperStackTestBase;
+import sleeper.core.deploy.DockerDeployment;
 import sleeper.core.properties.model.EksClusterType;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.core.properties.instance.CdkDefinedInstanceProperty.BULK_IMPORT_EKS_IMAGE;
 import static sleeper.core.properties.instance.EKSProperty.BULK_IMPORT_EKS_AUTOMODE_CONFIGURE_NODEPOOL;
 import static sleeper.core.properties.instance.EKSProperty.BULK_IMPORT_EKS_AUTOMODE_FLUENT_BIT_LOGGING_ENABLED;
 import static sleeper.core.properties.instance.EKSProperty.BULK_IMPORT_EKS_AWSCLI_LAYER_ARN;
@@ -129,6 +138,48 @@ public class EksBulkImportStackIT extends SleeperStackTestBase {
         // Then
         Approvals.verify(printer.toJson(stack), new Options()
                 .forFile().withName("eks-bulk-import-awscli-layer", ".json"));
+    }
+
+    @Test
+    void shouldUseCustomImageForFargateCluster() {
+        assertUsesCustomImage(EksClusterType.FARGATE);
+    }
+
+    @Test
+    void shouldUseCustomImageForAutoModeCluster() {
+        assertUsesCustomImage(EksClusterType.AUTOMODE);
+    }
+
+    private void assertUsesCustomImage(EksClusterType clusterType) {
+        // Given
+        String customImage = "registry.example.com/custom/spark@sha256:" + "a".repeat(64);
+        instanceProperties.setEnum(BULK_IMPORT_EKS_CLUSTER_TYPE, clusterType);
+        SleeperCoreStacks core = SleeperCoreStacks.create(rootStack, instanceProps());
+        BulkImportBucketStack bucket = new BulkImportBucketStack(rootStack, "BulkImportBucket", instanceProperties, core);
+        SleeperContainerImagesFromProperties images = new SleeperContainerImagesFromProperties(instanceProperties,
+                new SleeperContainerImageDigestProvider((image, repository) -> "test-digest")) {
+            @Override
+            public String getDockerImageName(DockerDeployment deployment) {
+                assertThat(deployment).isSameAs(DockerDeployment.EKS_BULK_IMPORT);
+                return customImage;
+            }
+        };
+        SleeperInstanceArtefacts customArtefacts = new SleeperInstanceArtefacts(instanceProperties,
+                new SleeperJarsFromProperties(instanceProperties,
+                        new SleeperJarVersionIdProvider(jar -> jar.getArtifactId() + "-test-version")),
+                images);
+
+        // When
+        EksBulkImportStack stack = new EksBulkImportStack(
+                rootStack, "EksBulkImport", instanceProperties, customArtefacts, bucket, core);
+
+        // Then
+        assertThat(printer.toJson(stack))
+                .contains(customImage)
+                .doesNotContain(DockerDeployment.EKS_BULK_IMPORT.getDockerImageName(instanceProperties));
+        assertThat(instanceProperties.get(BULK_IMPORT_EKS_IMAGE)).isEqualTo(customImage);
+        assertThat(SparkConfigurationUtils.getSparkConfigurationForEKSFromInstanceProperties(instanceProperties))
+                .containsEntry("spark.kubernetes.container.image", customImage);
     }
 
 }


### PR DESCRIPTION
### Issue

- [x] Resolves #7652.

Use `SleeperInstanceArtefacts` to select the EKS bulk-import image. Publish the selected reference in `sleeper.bulk.import.eks.image` so the submission, driver and executor pods use the same image. Retain the existing image naming for older deployments.

Custom `SleeperContainerImages` implementations must now implement `getDockerImageName(DockerDeployment)`.

### Tests

- [x] Added image-provider and Spark configuration tests, plus custom-image synthesis regressions for Fargate and Auto Mode.
- [x] Affected unit suites: 2,178 passed. EKS synthesis suite: 8 passed, including six unchanged template approvals.
- [x] Checkstyle, SpotBugs and dependency analysis passed.

The custom-image synthesis tests and Spark image-selection regression fail without the corresponding fixes. Tested with Java 17. No live AWS deployment was run; the separate custom CDK repository was not modified.

### Documentation

- [x] Documented custom image selection and regenerated the CDK property reference.
- [x] Added Javadoc for the new public methods.
- [x] No dependencies changed; no NOTICES update is required.
