### PR TITLE
Issue 7951 - Alphabetise command options and help sections

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployExistingInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployExistingInstance.java
@@ -69,27 +69,30 @@ public class DeployExistingInstance {
         return new Builder();
     }
 
+    public static final CommandLineUsage USAGE = CommandLineUsage.builder()
+            .positionalArguments(List.of("scripts directory", "instance ID"))
+            .systemArguments(List.of("scripts directory"))
+            .options(List.of(
+                    CommandOption.longOption("force-cdk-app"),
+                    CommandOption.longFlag("paused")))
+            .helpSummary("" +
+                    "Redeploys an existing Sleeper instance. This can only be used with an instance that was deployed " +
+                    "with the standard scripts or CDK app from the main Sleeper GitHub.\n" +
+                    "\n" +
+                    "--force-cdk-app <app>\n" +
+                    "This can be used to force use of a specific CDK app to deploy the instance. Usually the CDK app " +
+                    "will be automatically detected. This should only be used if the detection fails, for example if " +
+                    "you are upgrading from a version that did not have this auto-detection. Do not use this if the " +
+                    "instance was deployed with a CDK app that is not listed.\n" +
+                    "Available apps from Sleeper GitHub: " + SleeperInternalCdkApp.describeCdkAppsDeployingSleeperInstance() + "\n" +
+                    "\n" +
+                    "--paused\n" +
+                    "If set, the instance will be deployed paused. Periodic background processes will not run until " +
+                    "the instance is manually resumed.")
+            .build();
+
     public static void main(String[] rawArgs) throws IOException, InterruptedException {
-        CommandLineUsage usage = CommandLineUsage.builder()
-                .positionalArguments(List.of("scripts directory", "instance ID"))
-                .systemArguments(List.of("scripts directory"))
-                .options(List.of(CommandOption.longFlag("paused"), CommandOption.longOption("force-cdk-app")))
-                .helpSummary("" +
-                        "Redeploys an existing Sleeper instance. This can only be used with an instance that was deployed " +
-                        "with the standard scripts or CDK app from the main Sleeper GitHub.\n" +
-                        "\n" +
-                        "--paused\n" +
-                        "If set, the instance will be deployed paused. Periodic background processes will not run until " +
-                        "the instance is manually resumed.\n" +
-                        "\n" +
-                        "--force-cdk-app <app>\n" +
-                        "This can be used to force use of a specific CDK app to deploy the instance. Usually the CDK app " +
-                        "will be automatically detected. This should only be used if the detection fails, for example if " +
-                        "you are upgrading from a version that did not have this auto-detection. Do not use this if the " +
-                        "instance was deployed with a CDK app that is not listed.\n" +
-                        "Available apps from Sleeper GitHub: " + SleeperInternalCdkApp.describeCdkAppsDeployingSleeperInstance())
-                .build();
-        Arguments args = CommandArguments.parseAndValidateOrExit(usage, rawArgs, arguments -> new Arguments(
+        Arguments args = CommandArguments.parseAndValidateOrExit(USAGE, rawArgs, arguments -> new Arguments(
                 Path.of(arguments.getString("scripts directory")),
                 arguments.getString("instance ID"),
                 arguments.isFlagSet("paused"),

--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployNewInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployNewInstance.java
@@ -77,9 +77,9 @@ public class DeployNewInstance {
             .systemArguments(List.of("scriptsDirectory"))
             .positionalArguments(List.of("scriptsDirectory", "instanceId", "vpcId", "subnetIds"))
             .options(List.of(
-                    CommandOption.longOption("properties-file"),
                     CommandOption.longOption("config-dir"),
-                    CommandOption.longFlag("paused")))
+                    CommandOption.longFlag("paused"),
+                    CommandOption.longOption("properties-file")))
             .helpSummary("" +
                     "Deploys a new instance of Sleeper.\n" +
                     "\n" +

--- a/java/clients/src/main/java/sleeper/clients/deploy/UploadArtefacts.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/UploadArtefacts.java
@@ -63,13 +63,13 @@ public class UploadArtefacts {
     public static final CommandLineUsage USAGE = CommandLineUsage.builder()
             .systemArguments(List.of("scripts directory"))
             .options(List.of(
-                    CommandOption.shortOption('p', "properties"),
-                    CommandOption.shortOption('i', "id"),
-                    CommandOption.longFlag("create-builder"),
                     CommandOption.longOption("base-image-registry"),
+                    CommandOption.longOption("cdk-app"),
+                    CommandOption.longFlag("create-builder"),
                     CommandOption.longFlag("create-deployment"),
-                    CommandOption.shortOption('u', "upload"),
-                    CommandOption.longOption("cdk-app")))
+                    CommandOption.shortOption('i', "id"),
+                    CommandOption.shortOption('p', "properties"),
+                    CommandOption.shortOption('u', "upload")))
             .helpSummary("Uploads jars and Docker images to AWS. You must set either an instance properties file " +
                     "or an artefacts deployment ID to upload to.\n" +
                     "\n" +
@@ -79,13 +79,17 @@ public class UploadArtefacts {
                     "CDK app directly, you can then use this tool to upload the needed artefacts to that " +
                     "deployment.\n" +
                     "\n" +
-                    "--properties, -p\n" +
-                    "An instance properties file to read configuration from. If you do not also set the " +
-                    "artefacts deployment ID, it will be read from this file, defaulting to the instance ID. " +
-                    "Docker images that are not required to deploy this instance will not be uploaded.\n" +
+                    "--base-image-registry <registry-prefix>\n" +
+                    "By default, if you're uploading from a local build, a local Docker registry will be created " +
+                    "to hold base images for further builds. This will not be used when retrieving images from a " +
+                    "remote repository. If you set up a suitable registry yourself, you can use " +
+                    "--base-image-registry <registry-prefix> to use that instead.\n" +
                     "\n" +
-                    "--id, -i\n" +
-                    "An artefacts deployment ID to upload to. All Docker images will be uploaded.\n" +
+                    "--cdk-app\n" +
+                    "By default we include images required for a normal Sleeper instance deployment. Other " +
+                    "deployment types may need different Docker images, in which case you can set this to a CDK " +
+                    "app that requires extra images.\n" +
+                    "Valid values: " + SleeperInternalCdkApp.describeCdkAppsDeployingSleeperInstance() + "\n" +
                     "\n" +
                     "--create-builder\n" +
                     "By default, if you're uploading from a local build, a Docker builder will be created " +
@@ -93,25 +97,21 @@ public class UploadArtefacts {
                     "remote repository. If you set up a suitable builder yourself instead, you can use " +
                     "--create-builder=false to turn off this behaviour.\n" +
                     "\n" +
-                    "--base-image-registry <registry-prefix>\n" +
-                    "By default, if you're uploading from a local build, a local Docker registry will be created " +
-                    "to hold base images for further builds. This will not be used when retrieving images from a " +
-                    "remote repository. If you set up a suitable registry yourself, you can use " +
-                    "--base-image-registry <registry-prefix> to use that instead.\n" +
-                    "\n" +
                     "--create-deployment\n" +
                     "By default, we assume you have deployed an artefacts deployment separately. If you set this " +
                     "flag, this tool will deploy a new artefacts CDK deployment for you.\n" +
                     "\n" +
+                    "--id, -i\n" +
+                    "An artefacts deployment ID to upload to. All Docker images will be uploaded.\n" +
+                    "\n" +
+                    "--properties, -p\n" +
+                    "An instance properties file to read configuration from. If you do not also set the " +
+                    "artefacts deployment ID, it will be read from this file, defaulting to the instance ID. " +
+                    "Docker images that are not required to deploy this instance will not be uploaded.\n" +
+                    "\n" +
                     "--upload, -u\n" +
                     "By default, all artefacts are uploaded. You can use \"--upload jars\" to only upload the " +
-                    "jars, or \"--upload images\" to only upload the container images.\n" +
-                    "\n" +
-                    "--cdk-app\n" +
-                    "By default we include images required for a normal Sleeper instance deployment. Other " +
-                    "deployment types may need different Docker images, in which case you can set this to a CDK " +
-                    "app that requires extra images.\n" +
-                    "Valid values: " + SleeperInternalCdkApp.describeCdkAppsDeployingSleeperInstance())
+                    "jars, or \"--upload images\" to only upload the container images.")
             .build();
 
     public static Arguments readArguments(CommandArguments arguments, Function<Path, InstanceProperties> loadInstanceProperties) {

--- a/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/container/BuildDockerImage.java
@@ -49,17 +49,19 @@ public class BuildDockerImage {
             .positionalArguments(List.of("scripts directory", "image name", "tag"))
             .systemArguments(List.of("scripts directory"))
             .options(List.of(
-                    CommandOption.longFlag("multiplatform"),
-                    CommandOption.longOption("default-base-image")))
+                    CommandOption.longOption("default-base-image"),
+                    CommandOption.longFlag("multiplatform")))
             .helpSummary("Available Docker deployment image names: " +
                     DockerDeployment.all().stream().map(DockerDeployment::getDeploymentName).collect(joining(", ")) + "\n\n" +
                     "Available lambda image names: " +
                     LambdaJar.all().stream().map(LambdaJar::getImageName).collect(joining(", ")) + "\n\n" +
-                    "The --multiplatform flag specifies to build a multiplatform image if it's configured to be " +
-                    "built that way. By default an image is only built for the default platform. If you pass " +
-                    "--default-base-image <image>, it will be set in the BASE_IMAGE build argument, but only if " +
-                    "the image uses the default base image. Other arguments will be passed through to Docker as " +
-                    "options when specified at the end.")
+                    "Other arguments will be passed through to Docker as options when specified at the end.\n\n" +
+                    "--default-base-image <image>\n" +
+                    "Sets the BASE_IMAGE build argument, but only if the image uses the default base image.\n" +
+                    "\n" +
+                    "--multiplatform\n" +
+                    "Builds a multiplatform image if it's configured to be built that way. " +
+                    "By default an image is only built for the default platform.")
             .passThroughExtraArguments(true)
             .build();
 

--- a/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
+++ b/java/clients/src/main/java/sleeper/clients/report/FilesStatusReport.java
@@ -98,8 +98,8 @@ public class FilesStatusReport {
             .positionalArguments(List.of("instance-id", "table-name"))
             .options(List.of(
                     CommandOption.longOption("max-no-ref-files"),
-                    CommandOption.longFlag("verbose"),
-                    CommandOption.longOption("report-type")))
+                    CommandOption.longOption("report-type"),
+                    CommandOption.longFlag("verbose")))
             .helpSummary("" +
                     "Creates a report on the status of files in a Sleeper table.\n" +
                     "\n" +

--- a/java/clients/src/main/java/sleeper/clients/table/AddTableClient.java
+++ b/java/clients/src/main/java/sleeper/clients/table/AddTableClient.java
@@ -69,10 +69,10 @@ public class AddTableClient {
     public static final CommandLineUsage USAGE = CommandLineUsage.builder()
             .positionalArguments(List.of("instance-id"))
             .options(List.of(
-                    CommandOption.longOption("table-name"),
+                    CommandOption.longOption("config-dir"),
                     CommandOption.longOption("schema"),
-                    CommandOption.longOption("table-properties"),
-                    CommandOption.longOption("config-dir")))
+                    CommandOption.longOption("table-name"),
+                    CommandOption.longOption("table-properties")))
             .helpSummary("" +
                     "Adds a new table to an existing Sleeper instance.\n" +
                     "\n" +

--- a/java/clients/src/test/java/sleeper/clients/util/CommandHelpTest.java
+++ b/java/clients/src/test/java/sleeper/clients/util/CommandHelpTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import sleeper.clients.deploy.DeployExistingInstance;
+import sleeper.clients.deploy.DeployNewInstance;
+import sleeper.clients.deploy.UploadArtefacts;
+import sleeper.clients.deploy.container.BuildDockerImage;
+import sleeper.clients.report.FilesStatusReport;
+import sleeper.clients.table.AddTableClient;
+import sleeper.core.util.cli.CommandLineUsage;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommandHelpTest {
+
+    @ParameterizedTest(name = "{0} lists options alphabetically")
+    @MethodSource("commands")
+    void shouldListOptionsInAlphabeticalOrder(String command, CommandLineUsage usage, List<String> options) {
+        assertThat(usage.createUsageMessage())
+                .as(command)
+                .endsWith("Available options: --help, " + options.stream().map(name -> "--" + name).collect(joining(", ")));
+    }
+
+    @ParameterizedTest(name = "{0} describes every option alphabetically")
+    @MethodSource("commands")
+    void shouldDescribeOptionsInAlphabeticalOrder(String command, CommandLineUsage usage, List<String> options) {
+        List<String> headings = Pattern.compile("^--([a-z-]+)(?=[ ,\\n])", Pattern.MULTILINE)
+                .matcher(usage.createHelpText())
+                .results()
+                .map(match -> match.group(1))
+                .toList();
+        assertThat(headings).as(command).containsExactlyElementsOf(options);
+    }
+
+    private static Stream<Arguments> commands() {
+        return Stream.of(
+                Arguments.of("addTable", AddTableClient.USAGE,
+                        List.of("config-dir", "schema", "table-name", "table-properties")),
+                Arguments.of("filesStatusReport", FilesStatusReport.USAGE,
+                        List.of("max-no-ref-files", "report-type", "verbose")),
+                Arguments.of("deployExisting", DeployExistingInstance.USAGE,
+                        List.of("force-cdk-app", "paused")),
+                Arguments.of("deployNew", DeployNewInstance.USAGE,
+                        List.of("config-dir", "paused", "properties-file")),
+                Arguments.of("uploadArtefacts", UploadArtefacts.USAGE,
+                        List.of("base-image-registry", "cdk-app", "create-builder", "create-deployment", "id", "properties", "upload")),
+                Arguments.of("buildDockerImage", BuildDockerImage.USAGE,
+                        List.of("default-base-image", "multiplatform")));
+    }
+}


### PR DESCRIPTION
### Issue

- [x] Resolves #7951.

Alphabetise option lists and help sections for the six listed commands, including the newer `--base-image-registry` option. Give the Docker build options their own help sections and expose the existing deployment usage definition like the other commands. Keep positional arguments, aliases, defaults and the built-in `--help` position unchanged.

### Tests

- [x] Twelve parameterised help-output checks cover option order and complete, matching descriptions. Nine fail with the original ordering.
- [x] All 743 clients unit tests pass. Checkstyle, SpotBugs and dependency analysis pass with Java 17.
- [x] Invoked all six command entry points with `--help` and checked the printed option lists and sections. Their existing exit status of 1 is unchanged.

Validation: `cd java && mvn -pl clients verify -DskipITs -DskipRust`. AWS integration and Rust tests were not run.

### Documentation

- [x] Updated the command-line help itself.
- [x] No dependencies changed; no NOTICES change required.
