### PR TITLE
Issue 7191 - Document and test missing JSON row fields

### DIFF
--- a/java/core/src/main/java/sleeper/core/row/serialiser/RowJsonSerDe.java
+++ b/java/core/src/main/java/sleeper/core/row/serialiser/RowJsonSerDe.java
@@ -74,6 +74,10 @@ public class RowJsonSerDe {
 
     /**
      * Deserialises a JSON string to a row.
+     * <p>
+     * Missing fields and explicit JSON nulls are stored as null for nullable fields. For non-nullable fields,
+     * they are omitted from the row, including row keys and sort keys. This method does not validate that the row
+     * contains all fields required by the schema.
      *
      * @param  jsonSchema the JSON string
      * @return            a row

--- a/java/core/src/test/java/sleeper/core/row/serialiser/RowJsonSerDeNullabilityTest.java
+++ b/java/core/src/test/java/sleeper/core/row/serialiser/RowJsonSerDeNullabilityTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.row.serialiser;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import sleeper.core.row.Row;
+import sleeper.core.schema.Field;
+import sleeper.core.schema.Schema;
+import sleeper.core.schema.type.ByteArrayType;
+import sleeper.core.schema.type.IntType;
+import sleeper.core.schema.type.ListType;
+import sleeper.core.schema.type.LongType;
+import sleeper.core.schema.type.MapType;
+import sleeper.core.schema.type.StringType;
+import sleeper.core.schema.type.Type;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RowJsonSerDeNullabilityTest {
+
+    @ParameterizedTest
+    @MethodSource("valueTypes")
+    void shouldOmitMissingNonNullableValue(Type type) {
+        // Given
+        RowJsonSerDe serDe = serDe(type, false);
+
+        // When / Then
+        assertThat(serDe.fromJson("{\"key\":1}"))
+                .isEqualTo(new Row(Map.of("key", 1)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("valueTypes")
+    void shouldOmitExplicitNullForNonNullableValue(Type type) {
+        // Given
+        RowJsonSerDe serDe = serDe(type, false);
+
+        // When / Then
+        assertThat(serDe.fromJson("{\"key\":1,\"value\":null}"))
+                .isEqualTo(new Row(Map.of("key", 1)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("valueTypes")
+    void shouldStoreNullForMissingNullableValue(Type type) {
+        // Given
+        RowJsonSerDe serDe = serDe(type, true);
+        Row expected = new Row(Map.of("key", 1));
+        expected.put("value", null);
+
+        // When / Then
+        assertThat(serDe.fromJson("{\"key\":1}"))
+                .isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("valueTypes")
+    void shouldStoreExplicitNullForNullableValue(Type type) {
+        // Given
+        RowJsonSerDe serDe = serDe(type, true);
+        Row expected = new Row(Map.of("key", 1));
+        expected.put("value", null);
+
+        // When / Then
+        assertThat(serDe.fromJson("{\"key\":1,\"value\":null}"))
+                .isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{}", "{\"key\":null,\"sort\":null}"})
+    void shouldOmitMissingOrNullNonNullableKeys(String json) {
+        // Given
+        Schema schema = Schema.builder()
+                .rowKeyFields(new Field("key", new IntType()))
+                .sortKeyFields(new Field("sort", new StringType()))
+                .build();
+        RowJsonSerDe serDe = new RowJsonSerDe(schema);
+
+        // When / Then
+        assertThat(serDe.fromJson(json)).isEqualTo(new Row());
+    }
+
+    private RowJsonSerDe serDe(Type type, boolean nullable) {
+        return new RowJsonSerDe(Schema.builder()
+                .rowKeyFields(new Field("key", new IntType()))
+                .valueFields(new Field("value", type, nullable))
+                .build());
+    }
+
+    private static Stream<Type> valueTypes() {
+        return Stream.of(new IntType(), new LongType(), new StringType(), new ByteArrayType(),
+                new ListType(new StringType()), new MapType(new StringType(), new LongType()));
+    }
+}


### PR DESCRIPTION
### Issue
- [x] Resolves #7191.

Document the existing behaviour for missing fields and explicit JSON nulls. Nullable fields are stored with a null value; non-nullable fields, including row and sort keys, are omitted. Deserialisation does not validate row completeness. Runtime behaviour is unchanged.

### Tests
- [x] Add `RowJsonSerDeNullabilityTest`: 26 cases covering all six value types, nullable/non-nullable fields, and missing/null keys. Assertions distinguish an absent field from a field containing null.
- Core `mvn -B -pl core -PskipShade -Drust.skip -DskipITs verify` passed, including unit tests, Checkstyle, SpotBugs and dependency analysis.

### Documentation
- [x] Updated `fromJson` Javadoc to state the contract.
- [x] No dependencies changed; NOTICES unchanged.
