### PR TITLE
Issue 7268 - Manage artefact cleanup log retention

### DIFF
--- a/docs/deployment/deploy-with-cdk.md
+++ b/docs/deployment/deploy-with-cdk.md
@@ -186,3 +186,17 @@ These other context variables will be defaulted or read from the configuration i
 For `SleeperArtefactsCdkApp`, `-c id=<id>` will set the artefacts deployment ID. You can also
 set `-c deploy=<all/jars/images>` to choose which repositories you want to create. This defaults to `all`,
 and should be left as the default when deploying a Sleeper instance against the artefacts.
+
+### Artefact cleanup logs
+
+The artefacts stack manages the log group for the function that empties the jars bucket
+on stack deletion. Log events do not expire and the group is retained by default. Pass `-c retainLogsAfterDestroy=false`
+to `SleeperArtefactsCdkApp` to delete this group with the stack. This setting does not
+change deletion of the jars or the bucket.
+
+Scripted instance deployments pass `sleeper.retain.logs.after.destroy` to the artefacts
+stack when they create or update it. A separately managed artefacts deployment must set
+its own CDK context value. Image-only artefacts deployments have no jars cleanup group.
+
+On upgrade, the function uses a new, CloudFormation-managed log group. Older log groups
+created automatically by Lambda remain unmanaged and are not deleted by this setting.

--- a/java/clients/src/main/java/sleeper/clients/deploy/DeployInstance.java
+++ b/java/clients/src/main/java/sleeper/clients/deploy/DeployInstance.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 
 import static sleeper.core.properties.instance.CommonProperty.ARTEFACTS_DEPLOYMENT_ID;
 import static sleeper.core.properties.instance.CommonProperty.ID;
+import static sleeper.core.properties.instance.CommonProperty.RETAIN_LOGS_AFTER_DESTROY;
 import static sleeper.core.properties.instance.CommonProperty.SUBNETS;
 import static sleeper.core.properties.instance.CommonProperty.VPC_ID;
 import static sleeper.core.properties.model.SleeperInternalCdkApp.ARTEFACTS;
@@ -76,7 +77,7 @@ public class DeployInstance implements InstanceDeployer {
         LOGGER.info("vpcId: {}", instanceProperties.get(VPC_ID));
         LOGGER.info("subnetIds: {}", instanceProperties.get(SUBNETS));
         if (!instanceProperties.isSet(ARTEFACTS_DEPLOYMENT_ID)) {
-            invokeCdk.invoke(ARTEFACTS, CdkCommand.deployArtefacts(instanceProperties.get(ID)));
+            invokeCdk.invoke(ARTEFACTS, CdkCommand.deployArtefacts(instanceProperties.get(ID), instanceProperties.getBoolean(RETAIN_LOGS_AFTER_DESTROY)));
         }
         syncJars.sync(SyncJarsRequest.from(instanceProperties));
         dockerImageUploader.upload(

--- a/java/clients/src/main/java/sleeper/clients/util/cdk/CdkCommand.java
+++ b/java/clients/src/main/java/sleeper/clients/util/cdk/CdkCommand.java
@@ -31,6 +31,19 @@ public record CdkCommand(List<String> command, List<String> arguments) {
                 .build();
     }
 
+    /**
+     * Creates an artefacts deployment command with a cleanup log retention policy.
+     *
+     * @param  deploymentId           the artefacts deployment ID
+     * @param  retainLogsAfterDestroy whether cleanup logs should remain after stack deletion
+     * @return                        the deployment command
+     */
+    public static CdkCommand deployArtefacts(String deploymentId, boolean retainLogsAfterDestroy) {
+        return deployArtefacts(deploymentId).toBuilder()
+                .context("retainLogsAfterDestroy", retainLogsAfterDestroy)
+                .build();
+    }
+
     public static CdkCommand deployPropertiesChange(Path configurationDirectory) {
         return builder().deploy().configurationDirectory(configurationDirectory).build();
     }

--- a/java/clients/src/test/java/sleeper/clients/util/cdk/CdkCommandTest.java
+++ b/java/clients/src/test/java/sleeper/clients/util/cdk/CdkCommandTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sleeper.clients.util.cdk;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CdkCommandTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void shouldPassArtefactCleanupLogPolicy(boolean retain) {
+        CdkCommand command = CdkCommand.deployArtefacts("test-deployment", retain);
+        assertThat(command.command()).containsExactly("deploy", "--require-approval", "never");
+        assertThat(command.arguments()).containsExactly(
+                "-c", "id=test-deployment", "-c", "retainLogsAfterDestroy=" + retain);
+    }
+
+    @Test
+    void shouldKeepExistingArtefactsCommandUnchanged() {
+        assertThat(CdkCommand.deployArtefacts("test-deployment").arguments())
+                .containsExactly("-c", "id=test-deployment");
+    }
+}

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/SleeperArtefactsCdkApp.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/SleeperArtefactsCdkApp.java
@@ -51,6 +51,7 @@ public class SleeperArtefactsCdkApp {
                 .build());
         SleeperArtefactRepositories.Builder.create(stack, deploymentId)
                 .deploy(ToDeploy.fromString(context.tryGetContext("deploy")))
+                .retainLogsAfterDestroy(context.getBooleanOrDefault("retainLogsAfterDestroy", true))
                 .build();
         app.synth();
     }

--- a/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/SleeperArtefactRepositories.java
+++ b/java/deployment/cdk/src/main/java/sleeper/cdk/artefacts/SleeperArtefactRepositories.java
@@ -16,7 +16,10 @@
 package sleeper.cdk.artefacts;
 
 import org.apache.commons.lang3.EnumUtils;
+import software.amazon.awscdk.CfnDeletionPolicy;
+import software.amazon.awscdk.CfnResource;
 import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.ICfnResourceOptions;
 import software.amazon.awscdk.RemovalPolicy;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.services.ecr.IRepository;
@@ -26,6 +29,8 @@ import software.amazon.awscdk.services.ecr.TagStatus;
 import software.amazon.awscdk.services.iam.Effect;
 import software.amazon.awscdk.services.iam.PolicyStatement;
 import software.amazon.awscdk.services.iam.ServicePrincipal;
+import software.amazon.awscdk.services.logs.LogGroup;
+import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.s3.BlockPublicAccess;
 import software.amazon.awscdk.services.s3.Bucket;
 import software.amazon.awscdk.services.s3.BucketAccessControl;
@@ -62,14 +67,27 @@ public class SleeperArtefactRepositories {
         deploymentId = Objects.requireNonNull(builder.deploymentId, "deploymentId must not be null");
         String accountName = Objects.requireNonNull(builder.accountName, "accountName must not be null");
         deploy = Optional.ofNullable(builder.deploy).orElse(ToDeploy.ALL);
-        jarsBucket = deploy.isDeployJars() ? createJarsBucket(scope, accountName, deploymentId) : null;
+        jarsBucket = deploy.isDeployJars() ? createJarsBucket(scope, accountName, deploymentId, builder.retainLogsAfterDestroy) : null;
         if (deploy.isDeployImages()) {
             deployImages();
         }
     }
 
     public static IBucket createJarsBucket(Construct scope, String accountName, String deploymentId) {
-        return Bucket.Builder.create(scope, "JarsBucket")
+        return createJarsBucket(scope, accountName, deploymentId, true);
+    }
+
+    /**
+     * Creates a versioned jars bucket with managed logs for its cleanup function.
+     *
+     * @param  scope                  the scope for the bucket
+     * @param  accountName            the AWS account
+     * @param  deploymentId           the artefacts deployment ID
+     * @param  retainLogsAfterDestroy whether to retain cleanup logs after stack deletion
+     * @return                        the jars bucket
+     */
+    public static IBucket createJarsBucket(Construct scope, String accountName, String deploymentId, boolean retainLogsAfterDestroy) {
+        IBucket bucket = Bucket.Builder.create(scope, "JarsBucket")
                 .bucketName(SleeperArtefactsLocation.getDefaultJarsBucketName(accountName, deploymentId))
                 .encryption(BucketEncryption.S3_MANAGED)
                 .accessControl(BucketAccessControl.PRIVATE)
@@ -83,6 +101,36 @@ public class SleeperArtefactRepositories {
                 // https://docs.aws.amazon.com/cdk/api/v1/java/software/amazon/awscdk/services/lambda/Version.html
                 .versioned(true)
                 .build();
+        configureCleanupLogs(scope, retainLogsAfterDestroy);
+        return bucket;
+    }
+
+    private static void configureCleanupLogs(Construct scope, boolean retainLogsAfterDestroy) {
+        // Keep the existing provider and custom resource so upgrading does not replace the bucket cleanup resource.
+        Construct provider = (Construct) Stack.of(scope).getNode().findChild("Custom::S3AutoDeleteObjectsCustomResourceProvider");
+        CfnResource handler = (CfnResource) provider.getNode().findChild("Handler");
+        CfnDeletionPolicy deletionPolicy = retainLogsAfterDestroy ? CfnDeletionPolicy.RETAIN : CfnDeletionPolicy.DELETE;
+        LogGroup logGroup = (LogGroup) provider.getNode().tryFindChild("LogGroup");
+        if (logGroup == null) {
+            logGroup = LogGroup.Builder.create(provider, "LogGroup")
+                    .retention(RetentionDays.INFINITE)
+                    .removalPolicy(retainLogsAfterDestroy ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY)
+                    .build();
+            // Referencing the group keeps it alive until the cleanup function has been deleted.
+            handler.addPropertyOverride("LoggingConfig.LogGroup", logGroup.getLogGroupName());
+        } else {
+            CfnResource logResource = (CfnResource) logGroup.getNode().getDefaultChild();
+            if (logResource == null) {
+                throw new IllegalStateException("Cleanup log group has no CloudFormation resource");
+            }
+            ICfnResourceOptions options = logResource.getCfnOptions();
+            if (options == null) {
+                throw new IllegalStateException("Cleanup log group has no CloudFormation options");
+            }
+            if (!Objects.equals(deletionPolicy, options.getDeletionPolicy())) {
+                throw new IllegalArgumentException("Buckets sharing a cleanup provider must use the same log retention policy");
+            }
+        }
     }
 
     public String getDeploymentId() {
@@ -147,6 +195,7 @@ public class SleeperArtefactRepositories {
         private final String deploymentId;
         private String accountName;
         private ToDeploy deploy;
+        private boolean retainLogsAfterDestroy = true;
 
         private Builder(Construct scope, String deploymentId) {
             this.scope = scope;
@@ -167,6 +216,17 @@ public class SleeperArtefactRepositories {
 
         public Builder deploy(ToDeploy deploy) {
             this.deploy = deploy;
+            return this;
+        }
+
+        /**
+         * Sets whether cleanup logs are retained when the artefacts stack is destroyed. Defaults to true.
+         *
+         * @param  retainLogsAfterDestroy whether to retain the logs
+         * @return                        this builder
+         */
+        public Builder retainLogsAfterDestroy(boolean retainLogsAfterDestroy) {
+            this.retainLogsAfterDestroy = retainLogsAfterDestroy;
             return this;
         }
 

--- a/java/deployment/cdk/src/test/java/sleeper/cdk/artefacts/SleeperArtefactRepositoriesIT.java
+++ b/java/deployment/cdk/src/test/java/sleeper/cdk/artefacts/SleeperArtefactRepositoriesIT.java
@@ -23,8 +23,16 @@ import software.amazon.awscdk.AppProps;
 import software.amazon.awscdk.Environment;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.assertions.Match;
+import software.amazon.awscdk.assertions.Template;
+import software.constructs.Construct;
 
 import sleeper.cdk.testutil.StackPrinter;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SleeperArtefactRepositoriesIT {
 
@@ -41,6 +49,95 @@ public class SleeperArtefactRepositoriesIT {
         // Then
         Approvals.verify(printer.toJson(stack), new Options()
                 .forFile().withName("repositories", ".json"));
+    }
+
+    @Test
+    void shouldManageCleanupLogGroup() {
+        // Given
+        Stack stack = createRootStack("test-deployment");
+
+        // When
+        SleeperArtefactRepositories.Builder.create(stack, "test-deployment").build();
+
+        // Then
+        Template.fromStack(stack).resourceCountIs("AWS::Logs::LogGroup", 1);
+    }
+
+    @Test
+    void shouldRetainCleanupLogsWhenConfigured() {
+        assertCleanupLogRemovalPolicy(true);
+    }
+
+    @Test
+    void shouldDeleteCleanupLogsWhenConfigured() {
+        assertCleanupLogRemovalPolicy(false);
+    }
+
+    private void assertCleanupLogRemovalPolicy(boolean retain) {
+        // Given
+        Stack stack = createRootStack("test-deployment");
+
+        // When
+        SleeperArtefactRepositories.Builder.create(stack, "test-deployment")
+                .retainLogsAfterDestroy(retain)
+                .build();
+
+        // Then
+        Template template = Template.fromStack(stack);
+        Map<String, Map<String, Object>> groups = template.findResources("AWS::Logs::LogGroup");
+        assertThat(groups).hasSize(1);
+        String logGroupId = groups.keySet().iterator().next();
+        template.hasResourceProperties("AWS::Logs::LogGroup", Map.of("RetentionInDays", Match.absent()));
+        template.hasResource("AWS::Logs::LogGroup", Map.of(
+                "DeletionPolicy", retain ? "Retain" : "Delete",
+                "UpdateReplacePolicy", retain ? "Retain" : "Delete"));
+        template.hasResourceProperties("AWS::Lambda::Function", Map.of(
+                "LoggingConfig", Map.of("LogGroup", Map.of("Ref", logGroupId))));
+        template.resourceCountIs("AWS::Lambda::Function", 1);
+        template.resourceCountIs("Custom::S3AutoDeleteObjects", 1);
+    }
+
+    @Test
+    void shouldNotCreateCleanupLogsForImagesOnly() {
+        // Given
+        Stack stack = createRootStack("test-deployment");
+
+        // When
+        SleeperArtefactRepositories.Builder.create(stack, "test-deployment")
+                .deploy(SleeperArtefactRepositories.ToDeploy.IMAGES)
+                .retainLogsAfterDestroy(false)
+                .build();
+
+        // Then
+        Template.fromStack(stack).resourceCountIs("AWS::Logs::LogGroup", 0);
+        Template.fromStack(stack).resourceCountIs("AWS::Lambda::Function", 0);
+    }
+
+    @Test
+    void shouldShareCleanupLogsAcrossBucketsInOneStack() {
+        // Given
+        Stack stack = createRootStack("test-deployment");
+
+        // When
+        SleeperArtefactRepositories.createJarsBucket(new Construct(stack, "First"), "test-account", "first", false);
+        SleeperArtefactRepositories.createJarsBucket(new Construct(stack, "Second"), "test-account", "second", false);
+
+        // Then
+        Template.fromStack(stack).resourceCountIs("AWS::Logs::LogGroup", 1);
+        Template.fromStack(stack).resourceCountIs("Custom::S3AutoDeleteObjects", 2);
+    }
+
+    @Test
+    void shouldRejectConflictingCleanupLogPolicies() {
+        // Given
+        Stack stack = createRootStack("test-deployment");
+        SleeperArtefactRepositories.createJarsBucket(new Construct(stack, "First"), "test-account", "first", true);
+
+        // When / Then
+        assertThatThrownBy(() -> SleeperArtefactRepositories.createJarsBucket(
+                new Construct(stack, "Second"), "test-account", "second", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Buckets sharing a cleanup provider must use the same log retention policy");
     }
 
     private Stack createRootStack(String deploymentId) {

--- a/java/deployment/cdk/src/test/java/sleeper/cdk/artefacts/repositories.approved.json
+++ b/java/deployment/cdk/src/test/java/sleeper/cdk/artefacts/repositories.approved.json
@@ -156,11 +156,21 @@
                   " S3 bucket."
                 ]
               ]
+            },
+            "LoggingConfig": {
+              "LogGroup": {
+                "Ref": "CustomS3AutoDeleteObjectsCustomResourceProviderLogGroup99DE39BE"
+              }
             }
           },
           "DependsOn": [
             "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092"
           ]
+        },
+        "CustomS3AutoDeleteObjectsCustomResourceProviderLogGroup99DE39BE": {
+          "Type": "AWS::Logs::LogGroup",
+          "UpdateReplacePolicy": "Retain",
+          "DeletionPolicy": "Retain"
         },
         "Repositoryathenalambda37B1EEB6": {
           "Type": "AWS::ECR::Repository",


### PR DESCRIPTION
### Issue
- [x] Resolves #7268.

Manage the jars-cleanup Lambda log group in CloudFormation. `retainLogsAfterDestroy` defaults to true; scripted instance deployments pass through `sleeper.retain.logs.after.destroy`. Log events retain their existing unlimited lifetime.

Keep the existing bucket, cleanup function and custom-resource identities on upgrade. Only the function's log destination changes. Existing unmanaged log groups are left untouched. Image-only deployments create no cleanup logs, and buckets sharing the provider must agree on the removal policy.

### Tests
- [x] `CdkCommandTest` covers both flag values and the unchanged legacy command.
- [x] `SleeperArtefactRepositoriesIT` covers retention, deletion, provider sharing, conflicts and image-only deployments. The approval change contains only the managed group and its Lambda reference.
- 757 unit tests and 7 CDK synthesis integration tests passed; Checkstyle, SpotBugs and dependency analysis passed. No live AWS deployment or teardown was run.

### Documentation
- [x] Documented the context flag, scripted inheritance and treatment of pre-existing log groups.
- [x] Added Javadoc for the new public methods.
- [x] No dependencies changed; NOTICES unchanged.
