### PR TITLE
Issue 8134 - Extend tear down timeout to one hour

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/teardown/WaitForStackToDelete.java
+++ b/java/clients/src/main/java/sleeper/clients/teardown/WaitForStackToDelete.java
@@ -33,7 +33,7 @@ import java.time.Duration;
 public class WaitForStackToDelete {
     private static final Logger LOGGER = LoggerFactory.getLogger(WaitForStackToDelete.class);
     private static final PollWithRetries DEFAULT_POLL = PollWithRetries
-            .intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofMinutes(45));
+            .intervalAndPollingTimeout(Duration.ofSeconds(30), Duration.ofHours(1));
 
     private final PollWithRetries poll;
     private final CloudFormationClient cloudFormationClient;
@@ -53,7 +53,11 @@ public class WaitForStackToDelete {
      * @return                      the monitor to wait for deletion
      */
     public static WaitForStackToDelete from(CloudFormationClient cloudFormationClient, String stackName) {
-        return from(DEFAULT_POLL, cloudFormationClient, stackName);
+        return from(defaultPoll(), cloudFormationClient, stackName);
+    }
+
+    static PollWithRetries defaultPoll() {
+        return DEFAULT_POLL;
     }
 
     /**

--- a/java/clients/src/test/java/sleeper/clients/teardown/TearDownInstanceTest.java
+++ b/java/clients/src/test/java/sleeper/clients/teardown/TearDownInstanceTest.java
@@ -18,6 +18,7 @@ package sleeper.clients.teardown;
 import org.junit.jupiter.api.Test;
 
 import sleeper.clients.util.console.ConsoleInput;
+import sleeper.core.util.PollWithRetries;
 import sleeper.core.util.cli.CommandArgumentReader;
 import sleeper.core.util.cli.CommandArgumentsException;
 
@@ -26,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Scanner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,6 +64,13 @@ class TearDownInstanceTest {
         assertThat(TearDownInstance.confirmTearDown(
                 consoleInput("\n", new ByteArrayOutputStream()), readArguments("/scripts", "test-instance")))
                 .isFalse();
+    }
+
+    @Test
+    void shouldWaitUpToOneHourForStackDeletion() {
+        assertThat(WaitForStackToDelete.defaultPoll())
+                .isEqualTo(PollWithRetries.intervalAndPollingTimeout(
+                        Duration.ofSeconds(30), Duration.ofHours(1)));
     }
 
     @Test


### PR DESCRIPTION
### Issue

- [x] Resolves https://github.com/gchq/sleeper/issues/8134

Extend the default CloudFormation stack-deletion wait from 45 minutes to one hour while keeping the existing 30-second polling interval.

### Tests

- [x] Added a regression check for the one-hour default timeout.
- [x] `TearDownInstanceTest`: 6 tests passed.
- [x] Maven reactor validation completed successfully with Checkstyle and SpotBugs.

### Documentation

- [x] No user-facing documentation change is required; this only extends an existing timeout.
- [x] No dependencies were added or removed.
