### PR TITLE
Issue 7408 - Document logging level defaults

### DIFF
--- a/docs/usage/properties/instance/user/logging.md
+++ b/docs/usage/properties/instance/user/logging.md
@@ -2,12 +2,12 @@
 
 The following instance properties relate to logging.
 
-| Property Name                 | Description                                                                                                          | Default Value | Run CDK Deploy When Changed |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------|-----------------------------|
-| sleeper.logging.level         | The logging level for logging Sleeper classes. This does not apply to the MetricsLogger which is always set to INFO. |               | true                        |
-| sleeper.logging.apache.level  | The logging level for Apache logs that are not Parquet.                                                              |               | true                        |
-| sleeper.logging.parquet.level | The logging level for Parquet logs.                                                                                  |               | true                        |
-| sleeper.logging.aws.level     | The logging level for AWS logs.                                                                                      |               | true                        |
-| sleeper.logging.root.level    | The logging level for everything else.                                                                               |               | true                        |
-| sleeper.logging.backtrace     | Configuration for Rust backtrace generation, set in the environment variable RUST_BACKTRACE.                         |               | true                        |
-| sleeper.logging.rust          | Configuration for Rust logging, set in the environment variable RUST_LOG.                                            |               | true                        |
+| Property Name                 | Description                                                                                                                           | Default Value | Run CDK Deploy When Changed |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------------|-----------------------------|
+| sleeper.logging.level         | The logging level for Sleeper classes. This overrides the corresponding Log4j setting, except for MetricsLogger which is always INFO. | INFO          | true                        |
+| sleeper.logging.apache.level  | The logging level for Apache libraries other than Parquet. This overrides the corresponding Log4j setting.                            | INFO          | true                        |
+| sleeper.logging.parquet.level | The logging level for Apache Parquet. This overrides the corresponding Log4j setting.                                                 | WARN          | true                        |
+| sleeper.logging.aws.level     | The logging level for AWS SDK libraries. This overrides the corresponding Log4j setting.                                              | INFO          | true                        |
+| sleeper.logging.root.level    | The root logging level for messages not covered by a more specific category. This overrides the corresponding Log4j setting.          | INFO          | true                        |
+| sleeper.logging.backtrace     | Configuration for Rust backtrace generation, set in the environment variable RUST_BACKTRACE.                                          |               | true                        |
+| sleeper.logging.rust          | Configuration for Rust logging, set in the environment variable RUST_LOG.                                                             |               | true                        |

--- a/example/basic/instance.properties
+++ b/example/basic/instance.properties
@@ -51,7 +51,7 @@
 
 ## The following instance properties relate to logging.
 
-# The logging level for logging Sleeper classes. This does not apply to the MetricsLogger which is
-# always set to INFO.
-# (uncomment to set a value)
-# sleeper.logging.level=
+# The logging level for Sleeper classes. This overrides the corresponding Log4j setting, except for
+# MetricsLogger which is always INFO.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.level=INFO

--- a/example/full/instance.properties
+++ b/example/full/instance.properties
@@ -1921,26 +1921,28 @@
 
 ## The following instance properties relate to logging.
 
-# The logging level for logging Sleeper classes. This does not apply to the MetricsLogger which is
-# always set to INFO.
-# (uncomment to set a value)
-# sleeper.logging.level=
+# The logging level for Sleeper classes. This overrides the corresponding Log4j setting, except for
+# MetricsLogger which is always INFO.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.level=INFO
 
-# The logging level for Apache logs that are not Parquet.
-# (uncomment to set a value)
-# sleeper.logging.apache.level=
+# The logging level for Apache libraries other than Parquet. This overrides the corresponding Log4j
+# setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.apache.level=INFO
 
-# The logging level for Parquet logs.
-# (uncomment to set a value)
-# sleeper.logging.parquet.level=
+# The logging level for Apache Parquet. This overrides the corresponding Log4j setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.parquet.level=WARN
 
-# The logging level for AWS logs.
-# (uncomment to set a value)
-# sleeper.logging.aws.level=
+# The logging level for AWS SDK libraries. This overrides the corresponding Log4j setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.aws.level=INFO
 
-# The logging level for everything else.
-# (uncomment to set a value)
-# sleeper.logging.root.level=
+# The root logging level for messages not covered by a more specific category. This overrides the
+# corresponding Log4j setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.root.level=INFO
 
 # Configuration for Rust backtrace generation, set in the environment variable RUST_BACKTRACE.
 # (uncomment to set a value)

--- a/java/core/src/main/java/sleeper/core/properties/instance/LoggingLevelsProperty.java
+++ b/java/core/src/main/java/sleeper/core/properties/instance/LoggingLevelsProperty.java
@@ -25,24 +25,29 @@ import java.util.List;
  */
 public interface LoggingLevelsProperty {
     UserDefinedInstanceProperty LOGGING_LEVEL = Index.propertyBuilder("sleeper.logging.level")
-            .description("The logging level for logging Sleeper classes. This does not apply to the MetricsLogger which is always set to INFO.")
+            .description("The logging level for Sleeper classes. This overrides the corresponding Log4j setting, except for MetricsLogger which is always INFO.")
+            .defaultValue("INFO")
             .propertyGroup(InstancePropertyGroup.LOGGING)
             .includedInBasicTemplate(true)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty APACHE_LOGGING_LEVEL = Index.propertyBuilder("sleeper.logging.apache.level")
-            .description("The logging level for Apache logs that are not Parquet.")
+            .description("The logging level for Apache libraries other than Parquet. This overrides the corresponding Log4j setting.")
+            .defaultValue("INFO")
             .propertyGroup(InstancePropertyGroup.LOGGING)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty PARQUET_LOGGING_LEVEL = Index.propertyBuilder("sleeper.logging.parquet.level")
-            .description("The logging level for Parquet logs.")
+            .description("The logging level for Apache Parquet. This overrides the corresponding Log4j setting.")
+            .defaultValue("WARN")
             .propertyGroup(InstancePropertyGroup.LOGGING)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty AWS_LOGGING_LEVEL = Index.propertyBuilder("sleeper.logging.aws.level")
-            .description("The logging level for AWS logs.")
+            .description("The logging level for AWS SDK libraries. This overrides the corresponding Log4j setting.")
+            .defaultValue("INFO")
             .propertyGroup(InstancePropertyGroup.LOGGING)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty ROOT_LOGGING_LEVEL = Index.propertyBuilder("sleeper.logging.root.level")
-            .description("The logging level for everything else.")
+            .description("The root logging level for messages not covered by a more specific category. This overrides the corresponding Log4j setting.")
+            .defaultValue("INFO")
             .propertyGroup(InstancePropertyGroup.LOGGING)
             .runCdkDeployWhenChanged(true).build();
     UserDefinedInstanceProperty RUST_BACKTRACE = Index.propertyBuilder("sleeper.logging.backtrace")

--- a/java/core/src/test/java/sleeper/core/properties/SleeperPropertiesPrettyPrinterTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/SleeperPropertiesPrettyPrinterTest.java
@@ -138,7 +138,7 @@ class SleeperPropertiesPrettyPrinterTest {
             // When / Then
             assertThat(printEmptyInstanceProperties())
                     .contains("# (no value set, uncomment to set a value)\n" +
-                            "# sleeper.logging.root.level=\n");
+                            "# sleeper.logging.rust=\n");
         }
 
         @Test
@@ -152,8 +152,8 @@ class SleeperPropertiesPrettyPrinterTest {
         @Test
         void shouldPrintPropertyValueSetToEmptyString() {
             // When / Then
-            assertThat(printInstanceProperties("sleeper.logging.root.level="))
-                    .contains("\n# sleeper.logging.root.level=\n");
+            assertThat(printInstanceProperties("sleeper.logging.rust="))
+                    .contains("\n# sleeper.logging.rust=\n");
         }
 
         @Test
@@ -163,13 +163,14 @@ class SleeperPropertiesPrettyPrinterTest {
                     "sleeper.logging.parquet.level=INFO\n" +
                     "sleeper.logging.aws.level=INFO\n" +
                     "sleeper.logging.root.level=INFO"))
-                    .contains("# The logging level for Parquet logs.\n" +
+                    .contains("# The logging level for Apache Parquet. This overrides the corresponding Log4j setting.\n" +
                             "sleeper.logging.parquet.level=INFO\n" +
                             "\n" +
-                            "# The logging level for AWS logs.\n" +
+                            "# The logging level for AWS SDK libraries. This overrides the corresponding Log4j setting.\n" +
                             "sleeper.logging.aws.level=INFO\n" +
                             "\n" +
-                            "# The logging level for everything else.\n" +
+                            "# The root logging level for messages not covered by a more specific category. This overrides the\n" +
+                            "# corresponding Log4j setting.\n" +
                             "sleeper.logging.root.level=INFO");
         }
 

--- a/java/core/src/test/java/sleeper/core/properties/instance/LoggingLevelsPropertyTest.java
+++ b/java/core/src/test/java/sleeper/core/properties/instance/LoggingLevelsPropertyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.core.properties.instance;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.core.properties.instance.LoggingLevelsProperty.APACHE_LOGGING_LEVEL;
+import static sleeper.core.properties.instance.LoggingLevelsProperty.AWS_LOGGING_LEVEL;
+import static sleeper.core.properties.instance.LoggingLevelsProperty.LOGGING_LEVEL;
+import static sleeper.core.properties.instance.LoggingLevelsProperty.PARQUET_LOGGING_LEVEL;
+import static sleeper.core.properties.instance.LoggingLevelsProperty.ROOT_LOGGING_LEVEL;
+
+class LoggingLevelsPropertyTest {
+
+    @Test
+    void shouldMatchLoggingPropertyDefaultsToMainLog4jConfiguration() throws IOException, URISyntaxException {
+        Properties log4jProperties = loadMainLog4jProperties();
+
+        assertThat(List.of(
+                LOGGING_LEVEL,
+                ROOT_LOGGING_LEVEL,
+                APACHE_LOGGING_LEVEL,
+                PARQUET_LOGGING_LEVEL,
+                AWS_LOGGING_LEVEL))
+                .allSatisfy(property -> assertThat(property.getDefaultValue())
+                        .as(property.getPropertyName())
+                        .isEqualTo(log4jProperties.getProperty(property.getPropertyName())));
+    }
+
+    private static Properties loadMainLog4jProperties() throws IOException, URISyntaxException {
+        Path mainClasses = Path.of(LoggingLevelsProperty.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        Properties properties = new Properties();
+        try (InputStream input = Files.newInputStream(mainClasses.resolve("log4j.properties"))) {
+            properties.load(input);
+        }
+        return properties;
+    }
+}

--- a/scripts/templates/instanceproperties.template
+++ b/scripts/templates/instanceproperties.template
@@ -1925,26 +1925,28 @@
 
 ## The following instance properties relate to logging.
 
-# The logging level for logging Sleeper classes. This does not apply to the MetricsLogger which is
-# always set to INFO.
-# (uncomment to set a value)
-# sleeper.logging.level=
+# The logging level for Sleeper classes. This overrides the corresponding Log4j setting, except for
+# MetricsLogger which is always INFO.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.level=INFO
 
-# The logging level for Apache logs that are not Parquet.
-# (uncomment to set a value)
-# sleeper.logging.apache.level=
+# The logging level for Apache libraries other than Parquet. This overrides the corresponding Log4j
+# setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.apache.level=INFO
 
-# The logging level for Parquet logs.
-# (uncomment to set a value)
-# sleeper.logging.parquet.level=
+# The logging level for Apache Parquet. This overrides the corresponding Log4j setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.parquet.level=WARN
 
-# The logging level for AWS logs.
-# (uncomment to set a value)
-# sleeper.logging.aws.level=
+# The logging level for AWS SDK libraries. This overrides the corresponding Log4j setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.aws.level=INFO
 
-# The logging level for everything else.
-# (uncomment to set a value)
-# sleeper.logging.root.level=
+# The root logging level for messages not covered by a more specific category. This overrides the
+# corresponding Log4j setting.
+# (default value shown below, uncomment to set a value)
+# sleeper.logging.root.level=INFO
 
 # Configuration for Rust backtrace generation, set in the environment variable RUST_BACKTRACE.
 # (uncomment to set a value)


### PR DESCRIPTION
### Issue

- [x] Resolves https://github.com/gchq/sleeper/issues/7408

Define the documented logging defaults alongside the instance properties and keep them aligned with the main Log4j configuration through a regression test. The descriptions now clarify the scope of each logging category and that the instance property overrides the corresponding Log4j setting.

The generated property documentation and examples now show the effective defaults: INFO for Sleeper, root, Apache and AWS logging, and WARN for Parquet.

### Tests

- [x] `LoggingLevelsPropertyTest` verifies all five property defaults match the production `log4j.properties` values.
- [x] Focused test passed.
- [x] Maven reactor verification passed with Checkstyle and SpotBugs.

### Documentation

- [x] Regenerated logging property documentation and instance-property examples/templates.
- [x] No dependencies changed.