### PR TITLE
7940 Upgrade Docker tools to Ubuntu 26.04

### DIFF
--- a/scripts/cli/builder/Dockerfile
+++ b/scripts/cli/builder/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && apt-get install -y \
     rsync \
     # Rust build time dependencies
     build-essential pkg-config libssl-dev \
-    # Clang installation dependencies
-    lsb-release wget software-properties-common gnupg \
+    clang-20 \
+    gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Trivy for vulnerability scanning
@@ -39,10 +39,6 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/trivy.gpg] https://aquasecurity.githu
     | tee /etc/apt/sources.list.d/trivy.list > /dev/null
 RUN apt-get update && apt-get install -y \
     trivy \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Clang 20
-RUN wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- 20 \
     && rm -rf /var/lib/apt/lists/*
 
 # VS Code Java extension requires Java 21, so we install that but set the preferred version to match AWS EMR.

--- a/scripts/cli/dependencies/Dockerfile
+++ b/scripts/cli/dependencies/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
Fixes #7940.

Upgrade the CLI Docker toolchain base to Ubuntu 26.04. Use Ubuntu's native Clang 20 package in the builder because the LLVM installer does not publish a Resolute repository.

Validation:
- dependencies image builds successfully
- builder image builds successfully
- environment image builds successfully
- Corretto 17, Maven, Clang 20, Rust/Cargo, Trivy, Node/npm, CDK, AWS CLI and Docker CLI execute successfully
- `git diff --check` passes