### PR TITLE
Issue 7941 - Upgrade environment build EC2 to Ubuntu 26.04

### DIFF
--- a/java/deployment/cdk-environment/src/main/java/sleeper/environment/cdk/config/AppParameters.java
+++ b/java/deployment/cdk-environment/src/main/java/sleeper/environment/cdk/config/AppParameters.java
@@ -29,7 +29,7 @@ public class AppParameters {
     public static final StringParameter BUILD_FORK = StringParameter.keyAndDefault("fork", "gchq");
     public static final StringParameter BUILD_BRANCH = StringParameter.keyAndDefault("branch", "develop");
 
-    public static final StringParameter BUILD_IMAGE_NAME = StringParameter.keyAndDefault("buildImageName", "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*");
+    public static final StringParameter BUILD_IMAGE_NAME = StringParameter.keyAndDefault("buildImageName", "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-*");
     public static final StringParameter BUILD_IMAGE_OWNER = StringParameter.keyAndDefault("buildImageOwner", "099720109477");
     public static final StringParameter BUILD_IMAGE_LOGIN_USER = StringParameter.keyAndDefault("buildImageLoginUser", "ubuntu");
     public static final StringParameter BUILD_IMAGE_ROOT_DEVICE_NAME = StringParameter.keyAndDefault("buildImageRootDeviceName", "/dev/sda1");

--- a/java/deployment/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/BuildEC2ImageTest.java
+++ b/java/deployment/cdk-environment/src/test/java/sleeper/environment/cdk/buildec2/BuildEC2ImageTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.environment.cdk.buildec2;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.environment.cdk.config.AppContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static sleeper.environment.cdk.buildec2.BuildEC2Image.NAME;
+
+public class BuildEC2ImageTest {
+
+    @Test
+    void shouldUseUbuntu2604ImageByDefault() {
+        assertThat(AppContext.empty().get(NAME))
+                .isEqualTo("ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-*");
+    }
+}


### PR DESCRIPTION
### Issue

- [x] Resolves #7941

Update the default nightly environment-build EC2 AMI pattern from Ubuntu 24.04 Noble to Ubuntu 26.04 Resolute. The Canonical owner, login user, root device and volume settings are unchanged.

### Tests

- [x] Added a regression test for the Ubuntu 26.04 default image pattern.
- [x] `cdk-environment` reactor: 44 tests passed with Java 17; Checkstyle and SpotBugs passed.

### Documentation

- [x] No user-facing documentation change is required; the existing `buildImageName` override remains available.
- [x] No dependencies changed.
