### PR TITLE
Issue 7938 - Upgrade base image to Ubuntu 26.04

### DIFF
--- a/java/common/docker-base/docker/Dockerfile
+++ b/java/common/docker-base/docker/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     ca-certificates \


### PR DESCRIPTION
Fixes #7938.

Upgrade the deployed container base image from Ubuntu 24.04 to Ubuntu 26.04.

Validation:
- base Docker image builds successfully
- image reports Ubuntu 26.04.1 LTS (resolute)
- Corretto Java/Javac 17 and curl run successfully inside the image