### PR TITLE
Issue 7674 - Update Docker image test scripts

### DIFF
--- a/docs/development/dev-scripts.md
+++ b/docs/development/dev-scripts.md
@@ -5,15 +5,20 @@ In the `/scripts/dev` folder are some scripts that can assist you while working 
 #### `buildDockerImage.sh`
 
 This will build a single Docker image, and can be used to prepare for execution of the local Docker image tests, e.g.
-`QueryLambdaDockerImageST`. You can run it like this:
+`QueryLambdaDockerImageST`. Build the Sleeper project first so the generated scripts and JARs required by the image are
+available, then run the image build:
 
 ```bash
+./scripts/build/build.sh
 ./scripts/dev/buildDockerImage.sh query-lambda test
 ```
 
 The first parameter is the name of the image, as listed in the documentation
 of [Docker images](../deployment/docker-images.md). The second parameter is the tag, usually "test" for an automated
 Docker image test.
+
+For the compaction image, `scripts/test/docker/buildTestCompactionDockerImage.sh` performs the required project build,
+builds the image, and runs `CompactionTaskDockerImageST` in one command.
 
 #### `checkNotices.sh`
 

--- a/scripts/test/docker/testCompactionDockerImage.sh
+++ b/scripts/test/docker/testCompactionDockerImage.sh
@@ -26,5 +26,5 @@ docker build -t "compaction-job-execution:test" "$COMPACTION_DOCKER_DIR"
 
 pushd "$PROJECT_ROOT/java"
 echo "Running..."
-mvn verify -PsystemTest -Drust.skip=true -pl clients "-DrunIT=*DockerImageST"
+mvn verify -PsystemTest -Drust.skip=true -pl clients "-DrunIT=CompactionTaskDockerImageST"
 popd


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Issue

- [x] My PR fully resolves the following issues. I've referenced an issue in the PR title.
    - Resolves https://github.com/gchq/sleeper/issues/7674

### Tests

- [x] This corrects which existing Docker image system test the local compaction script selects, so no new Java test is needed.
    - `bash -n scripts/test/docker/testCompactionDockerImage.sh`
    - `bash -n scripts/test/docker/buildTestCompactionDockerImage.sh`
    - `mvn -pl clients -am -DskipTests -Drust.skip=true test-compile` completed successfully, including compilation of `CompactionTaskDockerImageST`
    - `shellcheck` passed for both Docker test scripts
    - `git diff --check` passed
    - The Docker-backed system test was not run locally because the Docker daemon is unavailable on this machine

### Documentation

- [x] Updated `docs/development/dev-scripts.md` to state the required project build and point to `buildTestCompactionDockerImage.sh` for the complete compaction-image workflow.
- [x] No Java code was added, so no Javadoc change is required.
- [x] No dependencies were added or removed, so `NOTICES` is unchanged.
