### PR TITLE
Issue 6768 - Exclude invalid tables from instance property deployment

### DIFF
--- a/java/clients/src/main/java/sleeper/clients/admin/properties/AdminClientPropertiesStore.java
+++ b/java/clients/src/main/java/sleeper/clients/admin/properties/AdminClientPropertiesStore.java
@@ -98,6 +98,17 @@ public class AdminClientPropertiesStore {
         return client.createTablePropertiesStore(instanceProperties).streamAllTables();
     }
 
+    private Stream<TableProperties> streamValidTableProperties(InstanceProperties instanceProperties) {
+        return streamTableProperties(instanceProperties)
+                .filter(table -> {
+                    if (table.isValid()) {
+                        return true;
+                    }
+                    LOGGER.warn("Excluding invalid table {} from local configuration", table.get(TABLE_NAME));
+                    return false;
+                });
+    }
+
     public void saveInstanceProperties(InstanceProperties properties) {
         saveInstanceProperties(properties, () -> {
             LOGGER.info("Saving to AWS");
@@ -116,14 +127,14 @@ public class AdminClientPropertiesStore {
     private void saveInstanceProperties(InstanceProperties properties, SaveInstanceProperties saveProperties) {
         try {
             LOGGER.info("Saving to local configuration");
-            client.saveLocalProperties(properties, streamTableProperties(properties));
+            client.saveLocalProperties(properties, streamValidTableProperties(properties));
             saveProperties.save();
         } catch (IOException | RuntimeException | InterruptedException e) {
             String instanceId = properties.get(ID);
             CouldNotSaveInstanceProperties wrapped = new CouldNotSaveInstanceProperties(instanceId, e);
             try {
                 LOGGER.info("Reverting local configuration");
-                client.saveLocalProperties(loadInstanceProperties(instanceId), streamTableProperties(properties));
+                client.saveLocalProperties(loadInstanceProperties(instanceId), streamValidTableProperties(properties));
             } catch (Exception e2) {
                 wrapped.addSuppressed(e2);
             }

--- a/java/clients/src/test/java/sleeper/clients/admin/properties/AdminClientPropertiesStoreIT.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/properties/AdminClientPropertiesStoreIT.java
@@ -111,6 +111,20 @@ public class AdminClientPropertiesStoreIT extends AdminClientITBase {
         }
 
         @Test
+        void shouldUpdateInstancePropertyWhenTableHasInvalidConfiguration() {
+            // Given
+            createTableInS3WithEmptySchema("invalid-table");
+
+            // When
+            updateInstanceProperty(instanceId, FARGATE_VERSION, "1.2.3");
+
+            // Then
+            assertThat(store().loadInstanceProperties(instanceId).get(FARGATE_VERSION))
+                    .isEqualTo("1.2.3");
+            assertThat(loadTablesFromDirectory(instanceProperties, tempDir)).isEmpty();
+        }
+
+        @Test
         void shouldRemoveDeletedTableFromLocalDirectoryWhenInstancePropertyIsUpdated() {
             // Given
             createTableInS3("old-test-table");
@@ -232,6 +246,21 @@ public class AdminClientPropertiesStoreIT extends AdminClientITBase {
             assertThat(localTablesWhenCdkDeployed)
                     .extracting(table -> table.get(TABLE_NAME))
                     .containsExactly("test-table");
+        }
+
+        @Test
+        void shouldExcludeInvalidTableWhenDeployingInstancePropertyChange() throws Exception {
+            // Given
+            createTableInS3WithEmptySchema("invalid-table");
+            List<TableProperties> localTablesWhenCdkDeployed = new ArrayList<>();
+            rememberLocalPropertiesWhenCdkDeployed(new AtomicReference<>(), localTablesWhenCdkDeployed);
+
+            // When
+            updateInstancePropertyViaCdk(instanceId, TASK_RUNNER_LAMBDA_MEMORY_IN_MB, "123");
+
+            // Then
+            verifyAnyAppDeployedWithCdk();
+            assertThat(localTablesWhenCdkDeployed).isEmpty();
         }
 
         @Test

--- a/java/clients/src/test/java/sleeper/clients/admin/properties/AdminClientPropertiesStoreTest.java
+++ b/java/clients/src/test/java/sleeper/clients/admin/properties/AdminClientPropertiesStoreTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Crown Copyright
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sleeper.clients.admin.properties;
+
+import org.junit.jupiter.api.Test;
+
+import sleeper.clients.deploy.container.DockerImageConfiguration;
+import sleeper.clients.deploy.container.UploadDockerImagesToEcr;
+import sleeper.clients.util.cdk.InvokeCdk;
+import sleeper.core.properties.instance.InstanceProperties;
+import sleeper.core.properties.table.TableProperties;
+import sleeper.core.properties.table.TablePropertiesStore;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static sleeper.core.properties.table.TableProperty.SCHEMA;
+import static sleeper.core.properties.table.TableProperty.TABLE_NAME;
+import static sleeper.core.properties.testutils.InstancePropertiesTestHelper.createTestInstanceProperties;
+import static sleeper.core.properties.testutils.TablePropertiesTestHelper.createTestTableProperties;
+import static sleeper.core.schema.SchemaTestHelper.createSchemaWithKey;
+
+class AdminClientPropertiesStoreTest {
+
+    @Test
+    void shouldExcludeInvalidTableWhenSavingInstanceProperties() throws Exception {
+        // Given
+        InstanceProperties instanceProperties = createTestInstanceProperties();
+        TableProperties validTable = createTestTableProperties(instanceProperties, createSchemaWithKey("key"));
+        validTable.set(TABLE_NAME, "valid-table");
+        TableProperties invalidTable = new TableProperties(instanceProperties);
+        invalidTable.set(TABLE_NAME, "invalid-table");
+        invalidTable.set(SCHEMA, "{}");
+
+        AdminClientPropertiesStore.Client client = mock(AdminClientPropertiesStore.Client.class);
+        TablePropertiesStore tableStore = mock(TablePropertiesStore.class);
+        when(client.createTablePropertiesStore(instanceProperties)).thenReturn(tableStore);
+        when(tableStore.streamAllTables()).thenReturn(Stream.of(validTable, invalidTable));
+        AtomicReference<List<TableProperties>> localTables = new AtomicReference<>();
+        doAnswer(invocation -> {
+            Stream<TableProperties> tables = invocation.getArgument(1);
+            localTables.set(tables.toList());
+            return null;
+        }).when(client).saveLocalProperties(eq(instanceProperties), any());
+
+        AdminClientPropertiesStore store = new AdminClientPropertiesStore(
+                client, mock(InvokeCdk.class), Path.of("generated"),
+                mock(UploadDockerImagesToEcr.class), DockerImageConfiguration.getDefault());
+
+        // When
+        store.saveInstanceProperties(instanceProperties);
+
+        // Then
+        assertThat(localTables.get())
+                .extracting(table -> table.get(TABLE_NAME))
+                .containsExactly("valid-table");
+    }
+}


### PR DESCRIPTION
### Issue

- [x] Resolves https://github.com/gchq/sleeper/issues/6768

### Tests

- [x] Adds `AdminClientPropertiesStoreTest.shouldExcludeInvalidTableWhenSavingInstanceProperties`.
- [x] Adds integration coverage for saving and CDK deployment when an invalid table exists.

### Documentation

- [x] No user-facing documentation change is needed; this restores the expected admin-client behaviour.
- [x] No new Java API or dependency is introduced.

Invalid table configuration is now excluded from the generated local/CDK configuration when instance properties are saved, so it cannot block an unrelated instance-property update. Table-property updates still use the unfiltered stream, allowing an invalid table to be repaired through the admin client.

Local unit regression passes. The LocalStack integration class requires Docker, which is not available in the local environment.
